### PR TITLE
fix(discord): fail closed when the voice bridge changes

### DIFF
--- a/talk_cli.py
+++ b/talk_cli.py
@@ -491,17 +491,29 @@ async def run_talk_session(audio: object | None = None) -> int:
                 )
 
                 sender = asyncio.create_task(send_microphone())
+                receiver = asyncio.create_task(receive_events())
                 pump = asyncio.create_task(pump_announcements(announce_queue, relay, ws))
                 try:
-                    await receive_events()
+                    # Sender and receiver are one failure domain. In particular,
+                    # an audio bridge exception must not disappear inside a
+                    # detached task while receive_events waits forever on a
+                    # socket that can no longer receive useful input.
+                    done, _pending = await asyncio.wait(
+                        {sender, receiver}, return_when=asyncio.FIRST_COMPLETED
+                    )
+                    for finished in done:
+                        finished.result()
                 finally:
                     talk_steer.set_landed_notifier(None)
                     talk_lifecycle.detach_session()
                     sender.cancel()
+                    receiver.cancel()
                     pump.cancel()
                     for watcher in watchers:
                         watcher.cancel()
-                    await asyncio.gather(sender, pump, *watchers, return_exceptions=True)
+                    await asyncio.gather(
+                        sender, receiver, pump, *watchers, return_exceptions=True
+                    )
     except asyncio.CancelledError:
         raise
     except Exception as exc:  # noqa: BLE001 — one line at the operator, not a traceback

--- a/talk_discord.py
+++ b/talk_discord.py
@@ -81,6 +81,10 @@ _UNSET = object()
 #: comfortably under it.
 KEEPALIVE_INTERVAL_S = 20.0
 
+#: Allow a brief discord.py reconnect transition, but never synthesize
+#: healthy-looking silence forever on a client that is no longer connected.
+BRIDGE_DISCONNECT_GRACE_S = 1.0
+
 
 def _running_loop():
     """The loop to marshal host calls onto, or ``None`` off-loop."""
@@ -333,6 +337,8 @@ class DiscordAudio:
         self._restore_voice_mode: Any = _UNSET
         self._restore_play: Any = _UNSET
         self._final_played = 0
+        self._bridge_failure: str | None = None
+        self._disconnected_since: float | None = None
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -356,6 +362,8 @@ class DiscordAudio:
             )
 
         self._bridge = bridge
+        self._bridge_failure = None
+        self._disconnected_since = None
         self._source = _new_source(self._outbound)
         self._audio_clock = time.monotonic()
         self._loop = _running_loop()
@@ -468,6 +476,7 @@ class DiscordAudio:
     def stop(self) -> None:
         """Hand the connection back. Safe twice, and after a failed start."""
 
+        bridge_is_current = self._bridge_identity_is_current()
         bridge, self._bridge = self._bridge, None
         # Teardown is best-effort at every step: a half-torn-down bridge
         # must still hand the connection back to the host, in the reverse
@@ -480,7 +489,7 @@ class DiscordAudio:
                 # Only re-register for a receiver that is still alive. If the
                 # host already tore it down, re-adding an inert callback keeps
                 # its reader thread awake for the life of the connection.
-                if getattr(receiver, "_running", False):
+                if bridge_is_current and getattr(receiver, "_running", False):
                     connection.add_socket_listener(self._original_on_packet)
             with suppress(Exception):
                 receiver._on_packet = self._original_on_packet
@@ -514,6 +523,12 @@ class DiscordAudio:
         so we take the buffers continuously and leave the host's own gate
         to its own bookkeeping.
         """
+
+        if not self._bridge_identity_is_current(receiver):
+            self._mark_bridge_failure(
+                "the Discord voice connection changed while I was listening"
+            )
+            return
 
         try:
             buffers = getattr(receiver, "_buffers", None)
@@ -553,6 +568,83 @@ class DiscordAudio:
                         pass
         except Exception:  # noqa: BLE001 — this runs on the HOST's thread
             _log.debug("discord capture drain failed", exc_info=True)
+
+    def _bridge_identity_is_current(self, receiver: Any | None = None) -> bool:
+        """Whether the adapter still publishes the exact bridge we borrowed."""
+
+        bridge = self._bridge
+        if bridge is None:
+            return True
+        try:
+            adapter = bridge["adapter"]
+            guild_id = bridge["guild_id"]
+            clients = getattr(adapter, "_voice_clients", None)
+            receivers = getattr(adapter, "_voice_receivers", None)
+            if not isinstance(clients, dict) or not isinstance(receivers, dict):
+                return False
+            return (
+                clients.get(guild_id) is bridge["voice_client"]
+                and receivers.get(guild_id) is bridge["receiver"]
+                and (receiver is None or receiver is bridge["receiver"])
+            )
+        except Exception:  # noqa: BLE001 — host internals are an untrusted boundary
+            return False
+
+    def _mark_bridge_failure(self, message: str) -> None:
+        if self._bridge_failure is None:
+            self._bridge_failure = message
+            _log.error("discord voice bridge lost: %s", message)
+
+    def _bridge_credentials_are_current(self) -> bool:
+        """Whether the receiver decrypts with the live connection generation."""
+
+        bridge = self._bridge
+        if bridge is None:
+            return True
+        try:
+            receiver = bridge["receiver"]
+            voice_client = bridge["voice_client"]
+            connection = voice_client._connection
+            return (
+                receiver._vc is voice_client
+                and bytes(receiver._secret_key) == bytes(connection.secret_key)
+                and receiver._dave_session is connection.dave_session
+            )
+        except Exception:  # noqa: BLE001 — unverifiable credentials are not healthy
+            return False
+
+    def _fail_if_bridge_lost(self) -> None:
+        if not self._bridge_identity_is_current():
+            self._mark_bridge_failure(
+                "the Discord voice connection changed while I was listening"
+            )
+        elif not self._bridge_credentials_are_current():
+            self._mark_bridge_failure(
+                "the Discord voice credentials changed while I was listening"
+            )
+        bridge = self._bridge
+        if bridge is not None and self._bridge_failure is None:
+            try:
+                connected = bool(bridge["voice_client"].is_connected())
+            except Exception:  # noqa: BLE001 — host liveness is an untrusted boundary
+                self._mark_bridge_failure(
+                    "the Discord voice connection liveness could not be verified"
+                )
+            else:
+                now = time.monotonic()
+                if connected:
+                    self._disconnected_since = None
+                elif self._disconnected_since is None:
+                    self._disconnected_since = now
+                elif now - self._disconnected_since >= BRIDGE_DISCONNECT_GRACE_S:
+                    self._mark_bridge_failure(
+                        "the Discord voice connection disconnected while I was listening"
+                    )
+        failure = self._bridge_failure
+        if failure is None:
+            return
+        self.stop()
+        raise talk_audio.TalkAudioError(failure)
 
     def _touch_host_timer(self) -> None:
         """Tell the host somebody is talking (throttled, loop-marshalled).
@@ -601,6 +693,7 @@ class DiscordAudio:
         the pauses that separate sentences.
         """
 
+        self._fail_if_bridge_lost()
         now = time.monotonic()
         try:
             chunk = self._inbound.get_nowait()
@@ -697,6 +790,8 @@ __all__ = [
 #: conversation; a second would fight the first for the same connection.
 _SESSION: dict[str, Any] = {}
 _SESSION_LOCK = threading.Lock()
+_LAST_FAILURE: str | None = None
+_NOTIFICATION_TASKS: set[Any] = set()
 
 JOIN_USAGE = "Say `talk join` once I'm in a voice channel, or `talk leave` to hand it back."
 
@@ -707,9 +802,53 @@ def session_status() -> str:
     with _SESSION_LOCK:
         task = _SESSION.get("task")
         guild_id = _SESSION.get("guild_id")
+        last_failure = _LAST_FAILURE
     if task is None or task.done():
+        if last_failure:
+            return f"The last voice session failed: {last_failure}"
         return "No live voice session — I'm not talking in a voice channel right now."
     return f"Live in the voice channel on server {guild_id} — say `talk leave` to stop."
+
+
+async def _deliver_failure_receipt(adapter: Any, guild_id: int, receipt: str) -> bool:
+    """Put a failed-closed receipt in the voice channel's linked text room."""
+
+    try:
+        text_channels = getattr(adapter, "_voice_text_channels", None)
+        channel_id = text_channels.get(guild_id) if isinstance(text_channels, dict) else None
+        if channel_id is None:
+            return False
+
+        client = getattr(adapter, "_client", None)
+        channel = None
+        if client is not None:
+            get_channel = getattr(client, "get_channel", None)
+            if callable(get_channel):
+                channel = get_channel(int(channel_id))
+            if channel is None:
+                fetch_channel = getattr(client, "fetch_channel", None)
+                if callable(fetch_channel):
+                    channel = await fetch_channel(int(channel_id))
+        send_to_channel = getattr(channel, "send", None)
+        if callable(send_to_channel):
+            try:
+                await send_to_channel(receipt)
+                return True
+            except Exception:  # noqa: BLE001 — try the adapter's guarded path
+                _log.warning(
+                    "direct Discord voice failure receipt failed; trying adapter send",
+                    exc_info=True,
+                )
+
+        # Older/minimal adapters may expose only their public send path. It is
+        # also the guarded fallback when a cached channel object has gone stale.
+        adapter_send = getattr(adapter, "send", None)
+        if callable(adapter_send):
+            result = await adapter_send(str(channel_id), receipt)
+            return getattr(result, "success", True) is not False
+    except Exception:  # noqa: BLE001 — status remains the durable fallback
+        _log.warning("could not deliver Discord voice failure receipt", exc_info=True)
+    return False
 
 
 def start_session(guild_id: int | None = None) -> str:
@@ -718,6 +857,8 @@ def start_session(guild_id: int | None = None) -> str:
     Returns the sentence to speak back. Requires a running event loop —
     this is the gateway path; the terminal path is ``hermes talk``.
     """
+
+    global _LAST_FAILURE
 
     try:
         import asyncio as _asyncio
@@ -739,26 +880,49 @@ def start_session(guild_id: int | None = None) -> str:
     audio = DiscordAudio(bridge["guild_id"])
 
     def _done(finished) -> None:
-        with _SESSION_LOCK:
-            if _SESSION.get("task") is finished:
-                _SESSION.clear()
-        # The weakest receipt in this surface: a session that dies during
-        # mint or connect leaves a Discord operator hearing silence, because
-        # the failure lands on stderr where nobody in the channel is looking.
-        # `talk status` is the detector the join reply already hands them —
-        # this makes sure the reason is on the record when they go looking.
+        global _LAST_FAILURE
+
+        failure = None
         try:
             if not finished.cancelled():
                 error = finished.exception()
                 if error is not None:
-                    _log.warning("discord voice session ended: %r", error)
-                elif finished.result():
-                    _log.warning(
-                        "discord voice session exited %s — say `talk status`",
-                        finished.result(),
-                    )
-        except Exception:  # noqa: BLE001 — a receipt must not raise
-            _log.debug("could not read the session outcome", exc_info=True)
+                    failure = f"{type(error).__name__}: {error}"
+                else:
+                    status = finished.result()
+                    if status:
+                        failure = audio._bridge_failure or f"session exited with status {status}"
+        except Exception as exc:  # noqa: BLE001 — a receipt must not raise
+            failure = f"session outcome could not be read: {exc}"
+
+        with _SESSION_LOCK:
+            if _SESSION.get("task") is finished:
+                _SESSION.clear()
+            if failure:
+                _LAST_FAILURE = failure
+
+        if failure:
+            _log.warning("discord voice session failed: %s", failure)
+            receipt = (
+                f"Voice session failed closed: {failure}. The voice channel was handed "
+                "back; say `talk join` when you want to start a new session."
+            )
+
+            async def _notify() -> None:
+                global _LAST_FAILURE
+
+                delivered = await _deliver_failure_receipt(
+                    bridge["adapter"], bridge["guild_id"], receipt
+                )
+                if delivered:
+                    with _SESSION_LOCK:
+                        if failure == _LAST_FAILURE:
+                            _LAST_FAILURE = None
+
+            notification = loop.create_task(_notify())
+            _NOTIFICATION_TASKS.add(notification)
+            notification.add_done_callback(_NOTIFICATION_TASKS.discard)
+
         try:
             audio.stop()
         except Exception:  # noqa: BLE001 — teardown is best-effort
@@ -771,6 +935,7 @@ def start_session(guild_id: int | None = None) -> str:
         existing = _SESSION.get("task")
         if existing is not None and not existing.done():
             return "I'm already live in a voice channel — say `talk leave` first."
+        _LAST_FAILURE = None
         task = loop.create_task(talk_cli.run_talk_session(audio=audio))
         task.add_done_callback(_done)
         _SESSION.update({"task": task, "guild_id": bridge["guild_id"], "audio": audio})
@@ -803,5 +968,11 @@ def stop_session() -> str:
 
 
 def reset_for_tests() -> None:
+    global _LAST_FAILURE
+
     with _SESSION_LOCK:
         _SESSION.clear()
+        _LAST_FAILURE = None
+        for notification in _NOTIFICATION_TASKS:
+            notification.cancel()
+        _NOTIFICATION_TASKS.clear()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -280,6 +280,100 @@ def test_subagent_stop_messages_cap_the_summary_tail():
     assert len(text) < talk_cli.WATCH_OUTPUT_TAIL_CHARS + 400
 
 
+def test_audio_bridge_failure_tears_down_the_live_session(monkeypatch, capsys):
+    """A detached microphone failure must stop the receiver and fail the call."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("TALK_VOICE", raising=False)
+    monkeypatch.setattr(
+        talk_cli,
+        "_mint_session",
+        lambda *a, **k: types.SimpleNamespace(client_secret="ephemeral"),
+    )
+
+    class _FailingAudio:
+        played_ms = 0
+
+        def __init__(self):
+            self.stopped = False
+
+        def start(self):
+            pass
+
+        def stop(self):
+            self.stopped = True
+
+        def read_input_chunk(self):
+            raise talk_audio.TalkAudioError("Discord voice bridge lost")
+
+        def queue_playback(self, _pcm):  # pragma: no cover - no server audio
+            raise AssertionError("playback reached a dead bridge")
+
+        def drain_playback(self):
+            pass
+
+        def reset_played_ms(self):
+            pass
+
+    class _BlockingWebSocket:
+        def __init__(self):
+            self.receive_started = False
+            self.receive_cancelled = False
+            self.exited = False
+            self.sent: list[dict] = []
+            self._forever = asyncio.Event()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            self.exited = True
+
+        async def send_json(self, message):
+            self.sent.append(message)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            self.receive_started = True
+            try:
+                await self._forever.wait()
+            except asyncio.CancelledError:
+                self.receive_cancelled = True
+                raise
+            raise StopAsyncIteration  # pragma: no cover - event is never set
+
+    ws = _BlockingWebSocket()
+
+    class _ClientSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            pass
+
+        def ws_connect(self, *_args, **_kwargs):
+            return ws
+
+    monkeypatch.setattr(
+        talk_cli,
+        "_import_aiohttp",
+        lambda: types.SimpleNamespace(
+            ClientSession=_ClientSession,
+            WSMsgType=types.SimpleNamespace(TEXT=object()),
+        ),
+    )
+    audio = _FailingAudio()
+
+    assert asyncio.run(talk_cli.run_talk_session(audio=audio)) == 1
+    assert ws.receive_started, "the live receiver was never exercised"
+    assert ws.receive_cancelled, "sender failure left socket receive activity running"
+    assert ws.exited, "the websocket context was not closed"
+    assert audio.stopped
+    assert "Discord voice bridge lost" in capsys.readouterr().err
+
+
 def test_session_always_detaches_the_lifecycle_target(monkeypatch, capsys):
     # A session that dies mid-dial must not leave the hook bus holding a
     # callback into a dead loop — the outer finally owns the belt.

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -20,6 +20,7 @@ import types
 import pytest
 
 import talk_audio
+import talk_cli
 import talk_discord
 
 
@@ -238,6 +239,182 @@ def test_source_is_not_opus():
 # -- session lifecycle --------------------------------------------------------
 
 
+def test_bridge_loss_exits_session_cancels_socket_clears_slot_and_notifies(monkeypatch):
+    async def scenario():
+        _connection, _receiver, _vc, adapter = _wired_host(monkeypatch)
+        delivered: list[str] = []
+
+        class _Channel:
+            async def send(self, content):
+                delivered.append(content)
+
+        adapter._voice_text_channels = {7: 123}
+        adapter._client = types.SimpleNamespace(get_channel=lambda channel_id: _Channel())
+
+        class _FailingAudio:
+            played_ms = 0
+
+            def __init__(self):
+                self._bridge_failure = None
+                self.stopped = False
+
+            def start(self):
+                pass
+
+            def stop(self):
+                self.stopped = True
+
+            def read_input_chunk(self):
+                self._bridge_failure = "the Discord voice connection changed"
+                raise talk_audio.TalkAudioError(self._bridge_failure)
+
+            def queue_playback(self, _pcm):  # pragma: no cover - no server audio
+                raise AssertionError("playback reached a dead bridge")
+
+            def drain_playback(self):
+                pass
+
+            def reset_played_ms(self):
+                pass
+
+        audio = _FailingAudio()
+        monkeypatch.setattr(talk_discord, "DiscordAudio", lambda _guild_id: audio)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("TALK_VOICE", raising=False)
+        monkeypatch.setattr(talk_cli.talk_apiserver, "warm_in_background", lambda: None)
+        monkeypatch.setattr(
+            talk_cli,
+            "_mint_session",
+            lambda *a, **k: types.SimpleNamespace(client_secret="ephemeral"),
+        )
+
+        class _BlockingWebSocket:
+            def __init__(self):
+                self.receive_started = False
+                self.receive_cancelled = False
+                self.exited = False
+                self._forever = asyncio.Event()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
+                self.exited = True
+
+            async def send_json(self, _message):
+                pass
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                self.receive_started = True
+                try:
+                    await self._forever.wait()
+                except asyncio.CancelledError:
+                    self.receive_cancelled = True
+                    raise
+                raise StopAsyncIteration  # pragma: no cover - event is never set
+
+        ws = _BlockingWebSocket()
+
+        class _ClientSession:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
+                pass
+
+            def ws_connect(self, *_args, **_kwargs):
+                return ws
+
+        monkeypatch.setattr(
+            talk_cli,
+            "_import_aiohttp",
+            lambda: types.SimpleNamespace(
+                ClientSession=_ClientSession,
+                WSMsgType=types.SimpleNamespace(TEXT=object()),
+            ),
+        )
+
+        reply = talk_discord.start_session(7)
+        assert "Starting up" in reply
+        task = talk_discord._SESSION["task"]
+        for _ in range(20):
+            if task.done() and not talk_discord._SESSION:
+                break
+            await asyncio.sleep(0)
+        for _ in range(5):  # let the done callback's notification task run
+            await asyncio.sleep(0)
+
+        assert task.result() == 1
+        assert ws.receive_started
+        assert ws.receive_cancelled, "bridge loss left socket receive activity running"
+        assert ws.exited
+        assert audio.stopped
+        assert talk_discord._SESSION == {}, "failed session still owns the slot"
+        assert len(delivered) == 1
+        assert "voice session failed" in delivered[0].lower()
+        assert "connection changed" in delivered[0]
+
+    asyncio.run(scenario())
+
+
+def test_failure_receipt_falls_back_to_the_adapter_send_path(monkeypatch):
+    async def scenario():
+        _connection, _receiver, _vc, adapter = _wired_host(monkeypatch)
+        delivered: list[tuple[str, str]] = []
+
+        class _BrokenChannel:
+            async def send(self, _content):
+                raise RuntimeError("stale cached channel")
+
+        adapter._voice_text_channels = {7: 123}
+        adapter._client = types.SimpleNamespace(get_channel=lambda channel_id: _BrokenChannel())
+
+        async def adapter_send(chat_id, content):
+            delivered.append((chat_id, content))
+            return types.SimpleNamespace(success=True)
+
+        adapter.send = adapter_send
+
+        async def fail_from_bridge(audio):
+            audio._bridge_failure = "the Discord voice connection changed"
+            return 1
+
+        monkeypatch.setattr(talk_cli, "run_talk_session", fail_from_bridge)
+        talk_discord.start_session(7)
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert delivered and delivered[0][0] == "123"
+        assert "connection changed" in delivered[0][1]
+
+    asyncio.run(scenario())
+
+
+def test_undeliverable_failure_receipt_is_preserved_for_status(monkeypatch):
+    async def scenario():
+        _connection, _receiver, _vc, adapter = _wired_host(monkeypatch)
+        adapter._voice_text_channels = {}  # no linked text room is available
+
+        async def fail_from_bridge(audio):
+            audio._bridge_failure = "the Discord voice credentials changed"
+            return 1
+
+        monkeypatch.setattr(talk_cli, "run_talk_session", fail_from_bridge)
+        talk_discord.start_session(7)
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert talk_discord._SESSION == {}
+        status = talk_discord.session_status()
+        assert "last voice session failed" in status.lower()
+        assert "credentials changed" in status
+
+    asyncio.run(scenario())
+
+
 def test_status_with_no_session():
     assert "No live voice session" in talk_discord.session_status()
 
@@ -272,7 +449,10 @@ class _FakeConnection:
 
 
 class _FakeReceiver:
-    def __init__(self) -> None:
+    def __init__(self, voice_client=None) -> None:
+        self._vc = voice_client
+        self._secret_key = b"test-secret"
+        self._dave_session = None
         self._buffers: dict = {}
         self._lock = threading.Lock()
         self._running = True  # the host clears this in its own teardown
@@ -287,10 +467,16 @@ class _FakeReceiver:
 class _FakeVoiceClient:
     def __init__(self, connection) -> None:
         self._connection = connection
+        connection.secret_key = b"test-secret"
+        connection.dave_session = None
         self.playing = None
+        self.connected = True
 
     def is_playing(self) -> bool:
         return self.playing is not None
+
+    def is_connected(self) -> bool:
+        return self.connected
 
     def play(self, source) -> None:
         self.playing = source
@@ -301,9 +487,9 @@ class _FakeVoiceClient:
 
 def _wired_host(monkeypatch):
     connection = _FakeConnection()
-    receiver = _FakeReceiver()
-    connection.add_socket_listener(receiver._on_packet)  # as the host does
     vc = _FakeVoiceClient(connection)
+    receiver = _FakeReceiver(vc)
+    connection.add_socket_listener(receiver._on_packet)  # as the host does
     adapter = _fake_host(monkeypatch, clients={7: vc}, receivers={7: receiver})
     adapter._reset_voice_timeout = lambda gid: adapter.__dict__.setdefault(
         "timer_resets", []
@@ -448,6 +634,134 @@ def test_stop_does_not_rewake_a_torn_down_receiver(monkeypatch):
     receiver._running = False  # the host's own teardown ran
     bridge.stop()
     assert connection.callbacks == [], "re-registered a listener for a dead receiver"
+
+
+def test_receiver_replacement_fails_closed_on_the_next_old_packet(monkeypatch):
+    old_connection, old_receiver, old_vc, adapter = _wired_host(monkeypatch)
+    bridge = talk_discord.DiscordAudio(7)
+    bridge.start()
+
+    new_connection = _FakeConnection()
+    new_vc = _FakeVoiceClient(new_connection)
+    new_receiver = _FakeReceiver(new_vc)
+    new_connection.add_socket_listener(new_receiver._on_packet)
+    old_receiver._running = False
+    adapter._voice_clients[7] = new_vc
+    adapter._voice_receivers[7] = new_receiver
+
+    # A final packet can race with the host's replacement. It must detect
+    # that this callback is no longer the live bridge, not drain stale PCM.
+    old_connection.deliver(b"\x01\x02" * 8)
+    with pytest.raises(talk_audio.TalkAudioError, match="voice connection changed"):
+        bridge.read_input_chunk()
+
+    assert bridge._bridge is None
+    assert old_vc.playing is None
+    assert old_connection.callbacks == [], "a dead receiver was re-awakened"
+    assert new_connection.callbacks == [new_receiver._on_packet]
+
+
+def test_receiver_replacement_is_detected_even_when_the_old_socket_goes_silent(monkeypatch):
+    old_connection, _old_receiver, _old_vc, adapter = _wired_host(monkeypatch)
+    bridge = talk_discord.DiscordAudio(7)
+    bridge.start()
+
+    new_connection = _FakeConnection()
+    new_vc = _FakeVoiceClient(new_connection)
+    new_receiver = _FakeReceiver(new_vc)
+    new_connection.add_socket_listener(new_receiver._on_packet)
+    adapter._voice_clients[7] = new_vc
+    adapter._voice_receivers[7] = new_receiver
+
+    # A discarded socket normally delivers no final packet, so the session's
+    # polling path must independently validate the published bridge identity.
+    with pytest.raises(talk_audio.TalkAudioError, match="voice connection changed"):
+        bridge.read_input_chunk()
+    assert old_connection.callbacks == [], "the obsolete listener was re-registered"
+
+
+def test_sustained_disconnection_fails_closed_after_a_short_grace(monkeypatch):
+    connection, receiver, vc, adapter = _wired_host(monkeypatch)
+    original = connection.callbacks[0]
+    bridge = talk_discord.DiscordAudio(7)
+    bridge.start()
+
+    clock = [1000.0]
+    monkeypatch.setattr(talk_discord.time, "monotonic", lambda: clock[0])
+    vc.connected = False
+
+    # A single false sample can happen during a reconnect; do not tear down
+    # immediately, but do not call the bridge healthy indefinitely either.
+    bridge.read_input_chunk()
+    clock[0] += 0.9
+    bridge.read_input_chunk()
+    clock[0] += 0.2
+    with pytest.raises(talk_audio.TalkAudioError, match="voice connection disconnected"):
+        bridge.read_input_chunk()
+
+    assert bridge._bridge is None
+    assert vc.playing is None
+    assert connection.callbacks == [original]
+    assert receiver._on_packet == original
+    assert adapter._voice_mode_getter("c") == "all"
+
+
+def test_a_verified_reconnect_resets_the_disconnect_grace(monkeypatch):
+    _connection, _receiver, vc, _adapter = _wired_host(monkeypatch)
+    bridge = talk_discord.DiscordAudio(7)
+    bridge.start()
+
+    clock = [2000.0]
+    monkeypatch.setattr(talk_discord.time, "monotonic", lambda: clock[0])
+    vc.connected = False
+    bridge.read_input_chunk()
+
+    clock[0] += 0.8
+    vc.connected = True
+    bridge.read_input_chunk()
+
+    # A later outage gets its own full grace period; the first outage's
+    # timestamp must not poison a successfully verified reconnect.
+    clock[0] += 0.4
+    vc.connected = False
+    bridge.read_input_chunk()
+    clock[0] += 0.9
+    bridge.read_input_chunk()
+    clock[0] += 0.2
+    with pytest.raises(talk_audio.TalkAudioError, match="voice connection disconnected"):
+        bridge.read_input_chunk()
+
+
+def test_transport_rekey_fails_closed_instead_of_streaming_false_silence(monkeypatch):
+    connection, _receiver, vc, _adapter = _wired_host(monkeypatch)
+    bridge = talk_discord.DiscordAudio(7)
+    bridge.start()
+
+    # The legacy host receiver copied this value at start. Discord rotates
+    # the connection's key on a reconnect, leaving the receiver permanently
+    # unable to decrypt while the client can still report connected.
+    connection.secret_key = b"rotated-secret"
+    with pytest.raises(talk_audio.TalkAudioError, match="voice credentials changed"):
+        bridge.read_input_chunk()
+
+    assert bridge._bridge is None
+    assert vc.playing is None
+
+
+def test_dave_session_replacement_fails_closed_before_corrupt_audio_flows(monkeypatch):
+    connection, _receiver, vc, _adapter = _wired_host(monkeypatch)
+    bridge = talk_discord.DiscordAudio(7)
+    bridge.start()
+
+    # DAVE negotiation can replace the live session object while a legacy
+    # receiver retains its start-time None/object. Feeding that ciphertext
+    # to Opus can sound like speech, so silence-only detection is insufficient.
+    connection.dave_session = object()
+    with pytest.raises(talk_audio.TalkAudioError, match="voice credentials changed"):
+        bridge.read_input_chunk()
+
+    assert bridge._bridge is None
+    assert vc.playing is None
 
 
 def test_capture_remainders_do_not_bleed_between_speakers(monkeypatch):


### PR DESCRIPTION
## Summary
- detect Discord voice client/receiver replacement, disconnects, key rotation, and DAVE session replacement
- fail closed instead of leaving an apparently-live deaf/mute Talk session
- propagate microphone bridge failures through the shared session lifecycle and clear the live session slot
- deliver an operator-visible failure receipt through the linked Discord text channel, with guarded fallback and status preservation

## Verification
- ........................................................................ [ 14%]
........................................................................ [ 29%]
........................................................................ [ 44%]
........................................................................ [ 58%]
........................................................................ [ 73%]
........................................................................ [ 88%]
..........................................................               [100%]
490 passed in 7.12s — 490 passed
- All checks passed! — passed
-  — passed
- independent acceptance review — PASS

Closes #8