### PR TITLE
fix(steer): ground receipts in agent identity artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,12 +229,14 @@ Ask `check_work` and you hear the note's state in those words — never "they
 got it" unless the artifact that proves it exists. Since v0.6 every note
 travels as `[tk-xxxxxxxx] note` — the token is what the drain preview is
 matched on, so two agents holding identical text can never land each
-other's receipts. One substrate note: watching the pre-API drain lowers the
-host's `agent.conversation_loop` logger to DEBUG (with a gate filter so
-operator log output is unchanged) — any DEBUG-guarded computation in that
-one module becomes active, a bounded perf cost traded for killing the
-false-"unconfirmed" class. And you often don't have to ask: the host's
-`subagent_stop` hook announces a finished background agent into the live
+other's receipts. If a truncated sibling receipt has no exact agent reference,
+it stays queued/unconfirmed: receipt order and a reused public subagent id never
+let it inherit another receipt's generation. One substrate note: watching the
+pre-API drain lowers the host's `agent.conversation_loop` logger to DEBUG (with
+a gate filter so operator log output is unchanged) — any DEBUG-guarded
+computation in that one module becomes active, a bounded perf cost traded for
+killing the false-"unconfirmed" class. And you often don't have to ask: the
+host's `subagent_stop` hook announces a finished background agent into the live
 call the moment it lands.
 
 Four tools carry the surface, discovery-first:

--- a/talk_host.py
+++ b/talk_host.py
@@ -796,17 +796,14 @@ class HostAdapter:
         Mid-tool it degrades to ``steer()`` inside the host, so the tool
         finishes at a safe boundary.
 
-        The receipt comes from the RETURN VALUE, not a log line: the
-        model-request path emits no Delivered line, so ``True`` is itself
-        the artifact — but ``True`` means ACCEPTED, and only that. The host
-        picks the mechanism internally (abort-and-retry, Codex native
-        steer, or a steer-queue write when a tool is executing), and the
-        ``_executing_tools`` peek below can be stale by the time
-        ``redirect()`` runs. So no spoken sentence may claim the abort:
-        every ``True`` is worded to be true on EITHER path ("current step,
-        or its very next one"). The peek only picks between that sentence
-        and the more specific mid-tool queued-language, where a stale peek
-        under-claims (queued wording for an aborted turn) — never over.
+        ``True`` proves acceptance, but not which mechanism the host chose.
+        The receipt therefore comes from the post-call state artifact: this
+        token in ``_pending_redirect`` proves abort-and-retry, this token in
+        ``_pending_steer`` proves the tool-boundary queue, and a successful
+        Codex native call proves its own redirect. If those transient slots
+        were consumed before inspection, the ledger deliberately degrades to
+        ``queued``. The pre-call ``_executing_tools`` peek is wording-only and
+        never selects the receipt state.
 
         ``False`` means no live turn — the correction falls back to the
         steer queue, spoken as exactly that.
@@ -888,18 +885,32 @@ class HostAdapter:
                 "Want me to list what's running?"
             )
 
-        if executing_tools:
-            # The host degraded the redirect to a steer at the tool boundary.
-            # Same queue, same drain artifacts, same honest queued claim.
+        # Classify the mechanism from a positive host artifact after the call,
+        # never from the advisory pre-call peek.  A raced tool transition puts
+        # this exact token in the steer queue; a hard redirect stashes it in
+        # the redirect slot.  If either slot was consumed before we can see it,
+        # degrade to queued rather than inventing the stronger claim.
+        pending_steer = getattr(agent, "_pending_steer", None)
+        pending_redirect = getattr(agent, "_pending_redirect", None)
+        queued_artifact = isinstance(pending_steer, str) and wire_text in pending_steer
+        redirected_artifact = (
+            isinstance(pending_redirect, str) and wire_text in pending_redirect
+        ) or getattr(agent, "api_mode", None) == "codex_app_server"
+
+        if queued_artifact or not redirected_artifact:
             talk_steer.record_queued(agent_id, wire_text, token=token, agent=agent)
+            if executing_tools or queued_artifact:
+                return (
+                    f"{agent_id} is mid-tool, so the correction is queued for "
+                    "the moment the tool finishes — I'll confirm when it lands."
+                )
             return (
-                f"{agent_id} is mid-tool, so the correction lands the moment "
-                "the tool finishes — I'll confirm when it does."
+                f"Redirect accepted by {agent_id}; I couldn't prove which path "
+                "the host took, so I'm tracking it as queued and will only "
+                "confirm if a delivery artifact appears."
             )
 
         talk_steer.record_redirected(agent_id, wire_text, token=token, agent=agent)
-        # True on this branch is abort-and-retry OR a steer-queue write that
-        # raced the peek — the sentence must hold on both.
         return (
             f"Redirect accepted — {agent_id} takes the correction at its "
             "current step, or its very next one if a tool was mid-flight."

--- a/talk_steer.py
+++ b/talk_steer.py
@@ -54,9 +54,9 @@ Everything here is fail-open: a missing host module, a renamed logger, or an
 operator log level above INFO degrades to ``unconfirmed`` — never an
 exception on the voice path, and never a claim without its artifact.
 
-Ref-less compatibility receipts can join a pre-API batch only when the nearest
+Ref-less compatibility receipts can join a drained batch only when the nearest
 preceding receipt for that subagent id carries the exact draining agent
-reference.  The public id alone is never a landing artifact: hosts may recycle
+reference. The public id alone is never a landing artifact: hosts may recycle
 it for another agent instance.
 """
 
@@ -155,12 +155,11 @@ class _DrainWatcher(logging.Handler):
     """Flips queued receipts to ``landed`` when the post-tool drain line fires.
 
     The line does not name WHICH agent drained, so matching is token-first:
-    a receipt lands when its correlation token appears in the drained
-    preview (exact). The v0.5 text match stays as the tokenless fallback —
-    prefix matches stay exact, loose containment only for substantial text.
-    Steers queued before one drain concatenate with newlines, so a match on
-    any receipt lands every queued receipt for that same agent (the whole
-    batch drained together).
+    a receipt lands when its correlation token appears in the drained preview
+    (exact). The synchronous host frame still carries ``agent``, grounding
+    expansion to the same identity/generation. The v0.5 text match stays as
+    the tokenless fallback — prefix matches stay exact, loose containment only
+    for substantial text.
     """
 
     def emit(self, record: logging.LogRecord) -> None:  # pragma: no branch
@@ -510,6 +509,9 @@ def mark_landed_from_preview(preview: str, *, agent: object | None = None) -> in
     oracle: the host drains before it logs, so a note whose token is still
     pending at emit time was queued after this drain and stays ``queued``
     instead of being swept into ``landed`` with the batch.
+    Batch expansion is generation-aware: it requires either this exact agent
+    or a live reference on a directly matched receipt. A public id alone can
+    land only the directly matched receipt, never truncated siblings.
     """
 
     preview = (preview or "").strip()
@@ -526,6 +528,7 @@ def mark_landed_from_preview(preview: str, *, agent: object | None = None) -> in
         # reopened exactly the race the exclusion exists to close.
         still_pending = _still_pending_text(agent)
         matched_agents: set[str] = set()
+        matched_receipts: list[dict] = []
         for receipt in _RECEIPTS:
             if receipt["state"] != STATE_QUEUED:
                 continue
@@ -536,6 +539,7 @@ def mark_landed_from_preview(preview: str, *, agent: object | None = None) -> in
                 receipt["state"] = STATE_LANDED
                 flipped += 1
                 matched_agents.add(receipt["subagent_id"])
+                matched_receipts.append(receipt)
                 continue
             own = receipt["preview"].strip()
             head = own[: len(preview)] or own
@@ -549,22 +553,46 @@ def mark_landed_from_preview(preview: str, *, agent: object | None = None) -> in
                 receipt["state"] = STATE_LANDED
                 flipped += 1
                 matched_agents.add(receipt["subagent_id"])
+                matched_receipts.append(receipt)
         if matched_agents:
             # Steers concatenate WITHIN one agent's pending queue and drain
             # as a single batch — so a match on any receipt lands every
-            # queued receipt for that same agent, even ones whose text (and
-            # token) the 120-char preview truncated away. Except, again,
-            # anything provably still sitting in the pending queue.
+            # queued receipt in that same identity-anchored generation, even
+            # ones whose text (and token) the 120-char preview truncated away.
+            # A bare public id never anchors expansion because hosts recycle it.
+            batch_targets: dict[str, list[object]] = {}
+            if agent is not None:
+                for subagent_id in matched_agents:
+                    batch_targets[subagent_id] = [agent]
+            else:
+                for receipt in matched_receipts:
+                    ref = receipt.get("agent_ref")
+                    target = ref() if ref is not None else None
+                    if target is not None:
+                        batch_targets.setdefault(receipt["subagent_id"], []).append(
+                            target
+                        )
+
+            generation_targets: dict[str, object | None] = {}
             for receipt in _RECEIPTS:
+                subagent_id = receipt["subagent_id"]
+                ref = receipt.get("agent_ref")
+                if ref is not None:
+                    generation_targets[subagent_id] = ref()
+                targets = batch_targets.get(subagent_id, ())
                 if (
-                    receipt["state"] == STATE_QUEUED
-                    and receipt["subagent_id"] in matched_agents
+                    receipt["state"] != STATE_QUEUED
+                    or not any(
+                        generation_targets.get(subagent_id) is target
+                        for target in targets
+                    )
                 ):
-                    token = receipt.get("token")
-                    if token is not None and token in still_pending:
-                        continue
-                    receipt["state"] = STATE_LANDED
-                    flipped += 1
+                    continue
+                token = receipt.get("token")
+                if token is not None and token in still_pending:
+                    continue
+                receipt["state"] = STATE_LANDED
+                flipped += 1
     if matched_agents:
         _push_landed(sorted(matched_agents))
     return flipped

--- a/talk_steer.py
+++ b/talk_steer.py
@@ -54,10 +54,9 @@ Everything here is fail-open: a missing host module, a renamed logger, or an
 operator log level above INFO degrades to ``unconfirmed`` — never an
 exception on the voice path, and never a claim without its artifact.
 
-Ref-less compatibility receipts can join a drained batch only when the nearest
-preceding receipt for that subagent id carries the exact draining agent
-reference. The public id alone is never a landing artifact: hosts may recycle
-it for another agent instance.
+Ref-less receipts land only from their own positive token/text drain artifact.
+They never inherit a sibling's exact agent reference: ledger order cannot prove
+generation membership when hosts may recycle a public subagent id.
 """
 
 from __future__ import annotations
@@ -509,9 +508,9 @@ def mark_landed_from_preview(preview: str, *, agent: object | None = None) -> in
     oracle: the host drains before it logs, so a note whose token is still
     pending at emit time was queued after this drain and stays ``queued``
     instead of being swept into ``landed`` with the batch.
-    Batch expansion is generation-aware: it requires either this exact agent
-    or a live reference on a directly matched receipt. A public id alone can
-    land only the directly matched receipt, never truncated siblings.
+    Batch expansion requires an exact live agent reference on each expanded
+    receipt. A ref-less receipt can land only by its own token/text match and
+    stays queued when the preview truncates it.
     """
 
     preview = (preview or "").strip()
@@ -573,19 +572,14 @@ def mark_landed_from_preview(preview: str, *, agent: object | None = None) -> in
                             target
                         )
 
-            generation_targets: dict[str, object | None] = {}
             for receipt in _RECEIPTS:
                 subagent_id = receipt["subagent_id"]
                 ref = receipt.get("agent_ref")
-                if ref is not None:
-                    generation_targets[subagent_id] = ref()
                 targets = batch_targets.get(subagent_id, ())
                 if (
                     receipt["state"] != STATE_QUEUED
-                    or not any(
-                        generation_targets.get(subagent_id) is target
-                        for target in targets
-                    )
+                    or ref is None
+                    or not any(ref() is target for target in targets)
                 ):
                     continue
                 token = receipt.get("token")
@@ -603,11 +597,9 @@ def mark_landed_for_agent(agent: object) -> int:
 
     The pre-API drain empties the ENTIRE pending queue for one agent, so a
     hit lands every queued receipt attributed to it by captured reference
-    (exact). A following ref-less compatibility receipt may join that same
-    identity-anchored generation; a bare subagent-id match never suffices,
-    because hosts may recycle ids. Receipts whose token is STILL in the
-    agent's pending queue at emit time were queued after the drain and are
-    skipped on both passes.
+    (exact). Ref-less receipts never inherit that identity from ledger order,
+    because hosts may recycle ids. Receipts whose token is STILL in the agent's
+    pending queue at emit time were queued after the drain and are skipped.
     """
 
     if agent is None:
@@ -630,28 +622,7 @@ def mark_landed_for_agent(agent: object) -> int:
                 receipt["state"] = STATE_LANDED
                 flipped += 1
                 matched_agents.add(receipt["subagent_id"])
-        if matched_agents:
-            # Walk in ledger order and anchor each id generation to its most
-            # recent captured reference.  This preserves old/ref-less sibling
-            # receipts recorded AFTER an exact receipt, but never sweeps an
-            # earlier generation merely because a host recycled its public id.
-            generation_targets: dict[str, object | None] = {}
-            for receipt in _RECEIPTS:
-                subagent_id = receipt["subagent_id"]
-                ref = receipt.get("agent_ref")
-                if ref is not None:
-                    generation_targets[subagent_id] = ref()
-                    continue
-                if (
-                    receipt["state"] == STATE_QUEUED
-                    and subagent_id in matched_agents
-                    and generation_targets.get(subagent_id) is agent
-                ):
-                    token = receipt.get("token")
-                    if token is not None and token in still_pending:
-                        continue
-                    receipt["state"] = STATE_LANDED
-                    flipped += 1
+
     if matched_agents:
         _push_landed(sorted(matched_agents))
     return flipped

--- a/talk_steer.py
+++ b/talk_steer.py
@@ -38,12 +38,10 @@ So a note has exactly these knowable states:
 - ``landed``      — a drain artifact matched this receipt. Positive-only:
                     absence of a match never proves absence of delivery
                     (the pre-API put-back path is silent by design).
-- ``redirected``  — ``AIAgent.redirect()`` returned True on a live turn.
-                    The artifact is the return value itself: the model
-                    request was aborted (or Codex accepted a native steer),
-                    so the correction applies to the CURRENT step. The
-                    model-request path emits no Delivered line — this state
-                    never waits on one.
+- ``redirected``  — post-call host state held this exact correction in its
+                    active-turn redirect slot (or Codex accepted its native
+                    steer). The model-request path emits no Delivered line —
+                    this state never waits on one.
 - ``unconfirmed`` — the child is gone and no landing was observed.
 - ``missed``      — the host's completion entry carried the note back as
                     undelivered (``missed_steer`` — present only on hosts
@@ -56,11 +54,10 @@ Everything here is fail-open: a missing host module, a renamed logger, or an
 operator log level above INFO degrades to ``unconfirmed`` — never an
 exception on the voice path, and never a claim without its artifact.
 
-Recorded assumption (Kimi v0.6 gate): the subagent-id-based second sweep in
-:func:`mark_landed_for_agent` assumes one live agent instance per
-``subagent_id`` — true on the 0.20 host, where ids are minted per spawn. A
-host that recycles ids could false-``landed`` a ref-less receipt
-(hermes-talk#7).
+Ref-less compatibility receipts can join a pre-API batch only when the nearest
+preceding receipt for that subagent id carries the exact draining agent
+reference.  The public id alone is never a landing artifact: hosts may recycle
+it for another agent instance.
 """
 
 from __future__ import annotations
@@ -492,11 +489,10 @@ def record_redirected(
 ) -> str:
     """Ledger an accepted redirect. Returns the receipt id.
 
-    The artifact is ``AIAgent.redirect()``'s return value — True on a live
-    turn means the in-flight model request was aborted with the correction
-    stashed for the retry (or Codex accepted a native turn/steer). No log
-    line exists on that path, so this state is terminal at call time and
-    never waits on a drain artifact.
+    The caller has already observed the host's post-call redirect artifact:
+    this exact correction in the active-turn redirect slot, or acceptance by
+    Codex's native turn/steer. No drain log exists on that path, so this state
+    is terminal at call time and never waits on a drain artifact.
     """
 
     receipt = _make_receipt(subagent_id, text, STATE_REDIRECTED, token, agent)
@@ -578,11 +574,12 @@ def mark_landed_for_agent(agent: object) -> int:
     """Land queued receipts held against this live agent. Returns count.
 
     The pre-API drain empties the ENTIRE pending queue for one agent, so a
-    hit lands every queued receipt attributed to it — by captured reference
-    first (exact), then by subagent id for receipts recorded without one
-    (same batch, same agent). Receipts whose token is STILL in the agent's
-    pending queue at emit time were queued after the drain and are skipped
-    on both passes.
+    hit lands every queued receipt attributed to it by captured reference
+    (exact). A following ref-less compatibility receipt may join that same
+    identity-anchored generation; a bare subagent-id match never suffices,
+    because hosts may recycle ids. Receipts whose token is STILL in the
+    agent's pending queue at emit time were queued after the drain and are
+    skipped on both passes.
     """
 
     if agent is None:
@@ -606,10 +603,21 @@ def mark_landed_for_agent(agent: object) -> int:
                 flipped += 1
                 matched_agents.add(receipt["subagent_id"])
         if matched_agents:
+            # Walk in ledger order and anchor each id generation to its most
+            # recent captured reference.  This preserves old/ref-less sibling
+            # receipts recorded AFTER an exact receipt, but never sweeps an
+            # earlier generation merely because a host recycled its public id.
+            generation_targets: dict[str, object | None] = {}
             for receipt in _RECEIPTS:
+                subagent_id = receipt["subagent_id"]
+                ref = receipt.get("agent_ref")
+                if ref is not None:
+                    generation_targets[subagent_id] = ref()
+                    continue
                 if (
                     receipt["state"] == STATE_QUEUED
-                    and receipt["subagent_id"] in matched_agents
+                    and subagent_id in matched_agents
+                    and generation_targets.get(subagent_id) is agent
                 ):
                     token = receipt.get("token")
                     if token is not None and token in still_pending:

--- a/tests/test_steer.py
+++ b/tests/test_steer.py
@@ -553,6 +553,8 @@ class _FakeRedirectAgent(_FakeAgent):
         if self.redirect_raises is not None:
             raise self.redirect_raises
         self.redirected.append(text)
+        if self.redirect_accepted and not self._executing_tools:
+            self._pending_redirect = text
         return self.redirect_accepted
 
 
@@ -581,9 +583,8 @@ def test_redirect_accepted_mid_thought_claims_accepted_never_the_abort(monkeypat
     _install_host(monkeypatch, {"sa-0-aaaa": {"agent": agent}})
     out = talk_host.host().redirect_agent("sa-0-aaaa", "wrong repo, use taskchad-ship")
     assert "redirect accepted" in out.lower()
-    # The peek can be stale (redirect() may have degraded to a steer-queue
-    # write and still returned True) — so the sentence must hold on either
-    # path and may NEVER claim the current work was dropped.
+    # The fake exposes the same post-call redirect-slot artifact as the host;
+    # even then the sentence never claims that already completed work vanished.
     assert "current step, or its very next one" in out.lower()
     assert "drops what it was doing" not in out.lower()
     # The wire text leads with the correlation token — both verbs share it.
@@ -603,6 +604,28 @@ def test_redirect_mid_tool_speaks_queued_not_redirected(monkeypatch):
     assert "mid-tool" in out.lower()
     assert "queued" in talk_steer.notes_summary()
     assert "redirect accepted" not in talk_steer.notes_summary()
+
+
+def test_redirect_that_races_into_tools_is_queued_and_can_be_superseded(monkeypatch):
+    class _RacingToolAgent(_FakeRedirectAgent):
+        def redirect(self, text: str) -> bool:
+            # The adapter's pre-call peek saw False; the host crosses into a
+            # tool before redirect() chooses its mechanism and queues instead.
+            self._executing_tools = True
+            self._pending_steer = text
+            self.redirected.append(text)
+            return True
+
+    agent = _RacingToolAgent()
+    _install_host(monkeypatch, {"sa-0-aaaa": {"agent": agent}})
+
+    out = talk_host.host().redirect_agent("sa-0-aaaa", "wrong repo")
+    talk_steer.mark_superseded("sa-0-aaaa")
+
+    assert "queued" in out.lower()
+    summary = talk_steer.notes_summary()
+    assert "stopped — the note may not have been read" in summary
+    assert "redirect accepted" not in summary
 
 
 def test_redirect_false_falls_back_to_the_steer_queue(monkeypatch):

--- a/tests/test_steer_ledger.py
+++ b/tests/test_steer_ledger.py
@@ -184,11 +184,11 @@ def test_identical_notes_on_two_agents_land_only_by_token():
     assert "note to sa-1-bbbb: queued" in summary
 
 
-def test_token_match_still_batch_lands_the_same_agents_later_notes():
+def test_token_match_leaves_truncated_ref_less_sibling_queued():
     # One agent, two notes queued before one drain: the joined preview only
     # shows the FIRST token, but the whole batch drained together. The second
-    # receipt deliberately lacks a ref: the first exact ref anchors it to this
-    # generation for compatibility with callers that cannot always resolve it.
+    # receipt deliberately lacks a ref, so ledger order cannot prove it belongs
+    # to this generation and the truncated sibling must remain unconfirmed.
     agent = _Steerable()
     token_a = talk_steer.new_token()
     token_b = talk_steer.new_token()
@@ -206,17 +206,18 @@ def test_token_match_still_batch_lands_the_same_agents_later_notes():
     preview = talk_steer.compose_wire_text(token_a, "first note about auth")[
         : talk_steer.DRAIN_PREVIEW_CHARS
     ]
-    assert talk_steer.mark_landed_from_preview(preview, agent=agent) == 2
+    assert talk_steer.mark_landed_from_preview(preview, agent=agent) == 1
+    assert "queued" in talk_steer.notes_summary()
 
 
-def test_post_tool_batch_uses_matched_receipt_ref_when_stack_identity_is_absent():
+def test_post_tool_batch_uses_each_receipts_ref_when_stack_identity_is_absent():
     agent = _Steerable()
     token_a = talk_steer.new_token()
     token_b = talk_steer.new_token()
     wire_a = talk_steer.compose_wire_text(token_a, "first note about auth")
     wire_b = talk_steer.compose_wire_text(token_b, "truncated compatibility sibling")
     talk_steer.record_queued("sa-0-aaaa", wire_a, token=token_a, agent=agent)
-    talk_steer.record_queued("sa-0-aaaa", wire_b, token=token_b)
+    talk_steer.record_queued("sa-0-aaaa", wire_b, token=token_b, agent=agent)
 
     assert talk_steer.mark_landed_from_preview(wire_a) == 2
 
@@ -323,14 +324,14 @@ def test_pre_api_drain_for_another_agent_flips_nothing(monkeypatch):
     assert "queued" in talk_steer.notes_summary()
 
 
-def test_pre_api_batch_lands_same_agent_receipts_without_a_ref():
-    # The pre-API drain empties the agent's WHOLE queue — receipts recorded
-    # without an agent ref still flip when a sibling receipt attributes the
-    # drain to their subagent id.
+def test_pre_api_batch_leaves_ref_less_sibling_queued():
+    # The drain empties one agent's whole queue, but ledger order cannot prove
+    # that a ref-less sibling belongs to that agent rather than a recycled id.
     agent = _Steerable()
     talk_steer.record_queued("sa-0-aaaa", "with a ref", agent=agent)
     talk_steer.record_queued("sa-0-aaaa", "without a ref")
-    assert talk_steer.mark_landed_for_agent(agent) == 2
+    assert talk_steer.mark_landed_for_agent(agent) == 1
+    assert "queued" in talk_steer.notes_summary()
 
 
 def test_pre_api_drain_does_not_land_ref_less_receipt_from_recycled_id():
@@ -345,6 +346,20 @@ def test_pre_api_drain_does_not_land_ref_less_receipt_from_recycled_id():
     summary = talk_steer.notes_summary()
     assert "note to sa-0-aaaa: queued" in summary
     assert "note to sa-0-aaaa: landed" in summary
+
+
+def test_pre_api_old_agent_drain_does_not_inherit_replacement_ref_less_receipt():
+    # Reverse recycled-id ordering: the old generation has the exact ref, then
+    # a replacement generation reuses the id but its receipt has no ref. The
+    # old agent's later drain cannot prove anything about that replacement.
+    old_agent = _Steerable()
+    talk_steer.record_queued("sa-0-aaaa", "old agent with a ref", agent=old_agent)
+    talk_steer.record_queued("sa-0-aaaa", "replacement without a ref")
+
+    assert talk_steer.mark_landed_for_agent(old_agent) == 1
+    summary = talk_steer.notes_summary()
+    assert summary.count("landed") == 1
+    assert summary.count("queued") == 1
 
 
 def test_pre_api_watcher_forces_debug_but_gates_other_lines(monkeypatch):
@@ -392,18 +407,16 @@ class _PendingAgent(_Steerable):
         self._pending_steer = pending
 
 
-def test_post_tool_drain_does_not_land_receipt_from_recycled_id():
+def test_post_tool_drain_does_not_land_ref_less_receipt_from_recycled_id():
     # The public id was reused for a replacement child. A token match from
-    # the replacement's drain must not batch-expand into the old generation.
-    old_agent = _PendingAgent()
+    # the replacement's drain must not batch-expand into the old ref-less
+    # generation.
     replacement = _PendingAgent()
     old_token = talk_steer.new_token()
     new_token = talk_steer.new_token()
     old_wire = talk_steer.compose_wire_text(old_token, "old agent note")
     new_wire = talk_steer.compose_wire_text(new_token, "replacement agent note")
-    talk_steer.record_queued(
-        "sa-0-aaaa", old_wire, token=old_token, agent=old_agent
-    )
+    talk_steer.record_queued("sa-0-aaaa", old_wire, token=old_token)
     talk_steer.record_queued(
         "sa-0-aaaa", new_wire, token=new_token, agent=replacement
     )
@@ -411,6 +424,29 @@ def test_post_tool_drain_does_not_land_receipt_from_recycled_id():
     flipped = talk_steer.mark_landed_from_preview(new_wire, agent=replacement)
 
     assert flipped == 1
+    summary = talk_steer.notes_summary()
+    assert summary.count("landed") == 1
+    assert summary.count("queued") == 1
+
+
+def test_post_tool_old_agent_drain_does_not_inherit_replacement_ref_less_receipt():
+    # Same reverse recycled-id ordering on the preview drain path. Only the old
+    # receipt has a positive token/text artifact in this drain preview.
+    old_agent = _PendingAgent()
+    old_token = talk_steer.new_token()
+    replacement_token = talk_steer.new_token()
+    old_wire = talk_steer.compose_wire_text(old_token, "old agent note")
+    replacement_wire = talk_steer.compose_wire_text(
+        replacement_token, "replacement agent note"
+    )
+    talk_steer.record_queued(
+        "sa-0-aaaa", old_wire, token=old_token, agent=old_agent
+    )
+    talk_steer.record_queued(
+        "sa-0-aaaa", replacement_wire, token=replacement_token
+    )
+
+    assert talk_steer.mark_landed_from_preview(old_wire, agent=old_agent) == 1
     summary = talk_steer.notes_summary()
     assert summary.count("landed") == 1
     assert summary.count("queued") == 1

--- a/tests/test_steer_ledger.py
+++ b/tests/test_steer_ledger.py
@@ -51,9 +51,14 @@ def test_drain_preview_is_truncated_at_120_chars_and_still_matches():
 def test_concatenated_drain_lands_the_whole_batch():
     # Two steers queued before one drain concatenate with newlines; the
     # preview only shows the head. The earlier receipt must land too.
-    talk_steer.record_queued("sa-0-aaaa", "first note about auth")
-    talk_steer.record_queued("sa-0-aaaa", "second note far past the preview window")
-    flipped = talk_steer.mark_landed_from_preview("first note about auth\nsecond")
+    agent = _Steerable()
+    talk_steer.record_queued("sa-0-aaaa", "first note about auth", agent=agent)
+    talk_steer.record_queued(
+        "sa-0-aaaa", "second note far past the preview window", agent=agent
+    )
+    flipped = talk_steer.mark_landed_from_preview(
+        "first note about auth\nsecond", agent=agent
+    )
     assert flipped == 2
 
 
@@ -181,13 +186,17 @@ def test_identical_notes_on_two_agents_land_only_by_token():
 
 def test_token_match_still_batch_lands_the_same_agents_later_notes():
     # One agent, two notes queued before one drain: the joined preview only
-    # shows the FIRST token, but the whole batch drained together.
+    # shows the FIRST token, but the whole batch drained together. The second
+    # receipt deliberately lacks a ref: the first exact ref anchors it to this
+    # generation for compatibility with callers that cannot always resolve it.
+    agent = _Steerable()
     token_a = talk_steer.new_token()
     token_b = talk_steer.new_token()
     talk_steer.record_queued(
         "sa-0-aaaa",
         talk_steer.compose_wire_text(token_a, "first note about auth"),
         token=token_a,
+        agent=agent,
     )
     talk_steer.record_queued(
         "sa-0-aaaa",
@@ -197,7 +206,19 @@ def test_token_match_still_batch_lands_the_same_agents_later_notes():
     preview = talk_steer.compose_wire_text(token_a, "first note about auth")[
         : talk_steer.DRAIN_PREVIEW_CHARS
     ]
-    assert talk_steer.mark_landed_from_preview(preview) == 2
+    assert talk_steer.mark_landed_from_preview(preview, agent=agent) == 2
+
+
+def test_post_tool_batch_uses_matched_receipt_ref_when_stack_identity_is_absent():
+    agent = _Steerable()
+    token_a = talk_steer.new_token()
+    token_b = talk_steer.new_token()
+    wire_a = talk_steer.compose_wire_text(token_a, "first note about auth")
+    wire_b = talk_steer.compose_wire_text(token_b, "truncated compatibility sibling")
+    talk_steer.record_queued("sa-0-aaaa", wire_a, token=token_a, agent=agent)
+    talk_steer.record_queued("sa-0-aaaa", wire_b, token=token_b)
+
+    assert talk_steer.mark_landed_from_preview(wire_a) == 2
 
 
 # -- the redirected state (return-value artifact) -----------------------------
@@ -369,6 +390,30 @@ class _PendingAgent(_Steerable):
 
     def __init__(self, pending: str = ""):
         self._pending_steer = pending
+
+
+def test_post_tool_drain_does_not_land_receipt_from_recycled_id():
+    # The public id was reused for a replacement child. A token match from
+    # the replacement's drain must not batch-expand into the old generation.
+    old_agent = _PendingAgent()
+    replacement = _PendingAgent()
+    old_token = talk_steer.new_token()
+    new_token = talk_steer.new_token()
+    old_wire = talk_steer.compose_wire_text(old_token, "old agent note")
+    new_wire = talk_steer.compose_wire_text(new_token, "replacement agent note")
+    talk_steer.record_queued(
+        "sa-0-aaaa", old_wire, token=old_token, agent=old_agent
+    )
+    talk_steer.record_queued(
+        "sa-0-aaaa", new_wire, token=new_token, agent=replacement
+    )
+
+    flipped = talk_steer.mark_landed_from_preview(new_wire, agent=replacement)
+
+    assert flipped == 1
+    summary = talk_steer.notes_summary()
+    assert summary.count("landed") == 1
+    assert summary.count("queued") == 1
 
 
 def test_drain_sweep_spares_a_note_queued_after_the_drain():

--- a/tests/test_steer_ledger.py
+++ b/tests/test_steer_ledger.py
@@ -2,9 +2,9 @@
 
 What is being proved: every state transition rides a REAL artifact — the
 post-tool drain INFO line or the pre-API drain DEBUG line for ``landed``,
-``AIAgent.redirect()``'s return value for ``redirected``, registry
-disappearance for ``unconfirmed``, a patched host's ``missed_steer`` for
-``missed`` — and absence of evidence never upgrades a claim.
+post-call active-turn state (or Codex native acceptance) for ``redirected``,
+registry disappearance for ``unconfirmed``, a patched host's ``missed_steer``
+for ``missed`` — and absence of evidence never upgrades a claim.
 """
 
 from __future__ import annotations
@@ -310,6 +310,20 @@ def test_pre_api_batch_lands_same_agent_receipts_without_a_ref():
     talk_steer.record_queued("sa-0-aaaa", "with a ref", agent=agent)
     talk_steer.record_queued("sa-0-aaaa", "without a ref")
     assert talk_steer.mark_landed_for_agent(agent) == 2
+
+
+def test_pre_api_drain_does_not_land_ref_less_receipt_from_recycled_id():
+    # A host may recycle the public id for a later agent instance.  The old
+    # ref-less receipt has no identity artifact tying it to the new child, so
+    # an exact match on the new receipt must not sweep the old one into landed.
+    talk_steer.record_queued("sa-0-aaaa", "old agent without a ref")
+    replacement = _Steerable()
+    talk_steer.record_queued("sa-0-aaaa", "replacement with a ref", agent=replacement)
+
+    assert talk_steer.mark_landed_for_agent(replacement) == 1
+    summary = talk_steer.notes_summary()
+    assert "note to sa-0-aaaa: queued" in summary
+    assert "note to sa-0-aaaa: landed" in summary
 
 
 def test_pre_api_watcher_forces_debug_but_gates_other_lines(monkeypatch):


### PR DESCRIPTION
## Summary
- classify redirect receipts from post-call Hermes artifacts instead of advisory pre-call state
- prevent recycled subagent IDs from falsely upgrading old steering receipts to landed
- remove unsafe generation inheritance for ref-less receipts across both post-tool and pre-API drains
- deliberately underclaim ambiguous truncated siblings rather than report false delivery

## Verification
- ........................................................................ [ 14%]
........................................................................ [ 29%]
........................................................................ [ 44%]
........................................................................ [ 59%]
........................................................................ [ 74%]
........................................................................ [ 88%]
......................................................                   [100%]
486 passed in 6.72s — 486 passed
- targeted steering suites — 92 passed
- recycled-ID ordering/path matrix — 4/4 passed
- All checks passed! — passed
-  — passed
- independent final gate — PASS

Closes #6
Closes #7