### PR TITLE
fix(talk): serialize realtime tool continuations

### DIFF
--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -29,6 +29,7 @@
   /** Tab-scoped, not localStorage: the token dies with the tab, like a session. */
   const TOKEN_KEY = "hermes-talk-dashboard-token";
   const OFFER_TIMEOUT_MS = 30000;
+  const TOOL_TIMEOUT_MS = 6500;
   const RUN_POLL_MS = 5000;
   const IDLE_POLL_MS = 20000;
   /** How long to watch each run kind before letting go. The work continues. */
@@ -61,18 +62,26 @@
    * auth; the x-talk-token header carries hermes-talk's second gate, which is
    * what TALK_DASHBOARD_TOKEN checks.
    */
-  function apiCall(path, init) {
+  async function apiCall(path, init, timeoutMs) {
     const opts = Object.assign({}, init || {});
     const headers = Object.assign({}, opts.headers || {});
     const token = readToken();
     if (token) headers["x-talk-token"] = token;
     if (opts.body) headers["content-type"] = "application/json";
     opts.headers = headers;
-    return SDK.fetchJSON(API + path, opts);
+    if (!timeoutMs) return SDK.fetchJSON(API + path, opts);
+    const controller = new AbortController();
+    opts.signal = controller.signal;
+    const timer = window.setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await SDK.fetchJSON(API + path, opts);
+    } finally {
+      window.clearTimeout(timer);
+    }
   }
 
-  function apiPost(path, body) {
-    return apiCall(path, { method: "POST", body: JSON.stringify(body || {}) });
+  function apiPost(path, body, timeoutMs) {
+    return apiCall(path, { method: "POST", body: JSON.stringify(body || {}) }, timeoutMs);
   }
 
   /** fetchJSON throws Error("<status>: <body>") — the gate's refusals look like this. */
@@ -112,6 +121,9 @@
       this.offerAbort = null;
       this.closed = false;
       this.responseActive = false;
+      this.continuationPending = false;
+      this.toolBatch = null;
+      this.toolTail = Promise.resolve();
     }
 
     async start() {
@@ -198,6 +210,7 @@
 
     send(payload) {
       if (this.channel && this.channel.readyState === "open") {
+        if (payload && payload.type === "response.create") this.continuationPending = true;
         this.channel.send(JSON.stringify(payload));
       }
     }
@@ -221,11 +234,13 @@
           if (event.transcript) this.cb.onTranscript("assistant", event.transcript, true);
           return;
         case "response.created":
+          this.continuationPending = false;
           this.responseActive = true;
           this.cb.onStatus("Thinking…");
           return;
         case "response.done":
           this.responseActive = false;
+          this.finishToolResponse();
           this.cb.onStatus("Listening…");
           return;
         case "input_audio_buffer.speech_started":
@@ -238,7 +253,7 @@
           this.cb.onStatus("Processing…");
           return;
         case "response.function_call_arguments.done":
-          void this.handleFunctionCall(event);
+          this.enqueueFunctionCall(event);
           return;
         case "error":
           this.handleError(event.error);
@@ -266,6 +281,33 @@
      * back. The session survives a tool failure — the model speaks the error
      * text instead of the call dying.
      */
+    enqueueFunctionCall(event) {
+      if (typeof event.call_id !== "string" || typeof event.name !== "string" ||
+          !event.call_id || !event.name) return;
+      if (!this.toolBatch) this.toolBatch = { done: false, results: [] };
+      const batch = this.toolBatch;
+      const position = batch.results.length;
+      batch.results.push(null);
+      this.toolTail = this.toolTail.then(async () => {
+        batch.results[position] = await this.handleFunctionCall(event);
+        this.flushToolResponse(batch);
+      });
+    }
+
+    finishToolResponse() {
+      if (!this.toolBatch) return;
+      this.toolBatch.done = true;
+      this.flushToolResponse(this.toolBatch);
+    }
+
+    flushToolResponse(batch) {
+      if (this.toolBatch !== batch || !batch.done || batch.results.some((item) => !item)) return;
+      for (let i = 0; i < batch.results.length; i++) this.send(batch.results[i].message);
+      this.send({ type: "response.create" });
+      for (let i = 0; i < batch.results.length; i++) this.watchForRun(batch.results[i].output);
+      this.toolBatch = null;
+    }
+
     async handleFunctionCall(event) {
       const callId = typeof event.call_id === "string" ? event.call_id : "";
       const name = typeof event.name === "string" ? event.name : "";
@@ -280,17 +322,22 @@
       this.cb.onStatus("Using " + name + "…");
       let output;
       try {
-        const res = await apiPost("/tool", { name: name, arguments: args });
+        const res = await apiPost(
+          "/tool",
+          { name: name, arguments: args },
+          TOOL_TIMEOUT_MS
+        );
         output = res && res.output ? String(res.output) : "(no output)";
       } catch (err) {
         output = name + " failed: " + errorText(err);
       }
-      this.send({
-        type: "conversation.item.create",
-        item: { type: "function_call_output", call_id: callId, output: output },
-      });
-      this.send({ type: "response.create" });
-      this.watchForRun(output);
+      return {
+        output: output,
+        message: {
+          type: "conversation.item.create",
+          item: { type: "function_call_output", call_id: callId, output: output },
+        },
+      };
     }
 
     /** Start polling if this text announced background work. */
@@ -324,6 +371,10 @@
           return;
         }
         if (!run || run.status === "running") {
+          window.setTimeout(tick, RUN_POLL_MS);
+          return;
+        }
+        if (this.responseActive || this.continuationPending || this.toolBatch) {
           window.setTimeout(tick, RUN_POLL_MS);
           return;
         }
@@ -584,5 +635,8 @@
       h("div", { className: "ht-metric-value" }, props.value));
   }
 
+  if (window.__HERMES_TALK_TEST_HOOK__) {
+    window.__HERMES_TALK_TEST__ = { TalkTransport: TalkTransport };
+  }
   window.__HERMES_PLUGINS__.register("hermes-talk", TalkPage);
 })();

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -49,6 +49,7 @@ import talk_auth  # noqa: E402
 import talk_config  # noqa: E402
 import talk_host  # noqa: E402
 import talk_identity  # noqa: E402
+import talk_relay  # noqa: E402
 import talk_runs  # noqa: E402
 import talk_tools  # noqa: E402
 import talk_wire  # noqa: E402
@@ -100,6 +101,7 @@ LOOPBACK_ONLY_MESSAGE = (
 #: How many runs the panel asks for. Fixed rather than caller-supplied: the
 #: registry is a status board, not a query surface.
 RUNS_LIMIT = 20
+TOOL_EXECUTION_WAIT_S = talk_relay.TOOL_EXECUTION_WAIT_S
 
 
 # -- auth ---------------------------------------------------------------------
@@ -304,7 +306,31 @@ async def run_tool(request: Request) -> dict:
         # Off the event loop. A tool can probe the api_server, start a run, or
         # reach a bound agent — none of that may run where the dashboard's own
         # request loop lives.
-        output = await asyncio.to_thread(talk_tools.execute_talk_tool, name, arguments)
+        output = await talk_relay.run_bounded_on_daemon(
+            talk_tools.execute_talk_tool,
+            name,
+            arguments,
+            timeout=TOOL_EXECUTION_WAIT_S,
+        )
+    except talk_relay.ToolWorkerBusy:
+        output = (
+            f"Earlier tools are still running, so the {name or 'tool'} tool was not "
+            "started. Wait for them to finish, then ask me to try again."
+        )
+    except talk_relay.ToolExecutionTimeout as exc:
+        if exc.started:
+            output = (
+                f"The {name or 'tool'} tool is still running after "
+                f"{TOOL_EXECUTION_WAIT_S:g} seconds. I detached it so the call can "
+                "continue, but its eventual result won't return to this conversation. "
+                "Ask me to check again if you still need it."
+            )
+        else:
+            output = (
+                f"The {name or 'tool'} tool did not start within "
+                f"{TOOL_EXECUTION_WAIT_S:g} seconds because earlier tools were still "
+                "using the workers. Ask me to try again."
+            )
     except talk_tools.TalkToolError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"ok": True, "output": output}

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -160,14 +160,96 @@ def _announcement_messages(headline: str, report: str) -> list[dict]:
     ]
 
 
-#: How the announcement pump waits for the wire to go idle: poll interval and
-#: the bound after which the batch is sent anyway (a stuck response must not
-#: silence announcements forever).
+#: How the announcement pump waits for the wire to go idle. Session teardown
+#: cancels the pump; an active response is never overlapped just to meet a timer.
 ANNOUNCE_IDLE_POLL_S = 0.05
-ANNOUNCE_IDLE_MAX_WAIT_S = 5.0
+TOOL_SESSION_QUEUE_SIZE = 1
+TOOL_CLEANUP_WAIT_S = 6.0
 
 
-async def pump_announcements(announce_queue, relay, ws) -> None:
+class ToolResponseCoordinator:
+    """Collect one response's tool outputs and continue it exactly once.
+
+    Calls are admitted and executed in wire order. Queue saturation produces an
+    output in that same position, but never sends early. Only ``response.done``
+    closes the batch; once every position is resolved, all outputs and one
+    continuation are sent as a single socket batch.
+    """
+
+    def __init__(self, relay, send_batch, *, max_pending: int) -> None:
+        self.relay = relay
+        self.send_batch = send_batch
+        self.queue: asyncio.Queue = asyncio.Queue(maxsize=max_pending)
+        self.outputs: list[list[dict] | None] = []
+        self.closed = False
+        self.failed = False
+        self._flush_lock = asyncio.Lock()
+
+    def admit(self, event: dict) -> bool:
+        if self.closed:
+            raise RuntimeError("tool call arrived after response.done")
+        position = len(self.outputs)
+        self.outputs.append(None)
+        try:
+            self.queue.put_nowait((position, event))
+        except asyncio.QueueFull:
+            self.outputs[position] = self.relay.tool_queue_full_output(event)
+            return False
+        return True
+
+    async def response_done(self) -> None:
+        if not self.outputs:
+            return
+        self.closed = True
+        await self._flush_if_ready()
+
+    async def _flush_if_ready(self) -> None:
+        if not self.closed or not self.outputs or any(item is None for item in self.outputs):
+            return
+        async with self._flush_lock:
+            if not self.closed or not self.outputs or any(
+                item is None for item in self.outputs
+            ):
+                return
+            batch = [message for result in self.outputs for message in result or []]
+            batch.append({"type": "response.create"})
+            try:
+                await self.send_batch(batch)
+            except Exception:
+                self.failed = True
+                raise
+            self.outputs = []
+            self.closed = False
+
+    async def run(self) -> None:
+        while True:
+            position, event = await self.queue.get()
+            try:
+                self.outputs[position] = await self.relay.handle_event_async(event)
+                await self._flush_if_ready()
+            finally:
+                self.queue.task_done()
+
+    async def join(self) -> None:
+        await self.queue.join()
+        if not self.failed:
+            await self._flush_if_ready()
+
+    def discard_pending(self) -> None:
+        """Balance queue accounting during failed-send/session teardown."""
+
+        while True:
+            try:
+                self.queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            else:
+                self.queue.task_done()
+
+
+async def pump_announcements(
+    announce_queue, relay, ws, send_batch=None, response_busy=None
+) -> None:
     """Serialize every out-of-band announcement (Codex v0.6.1 finding 3).
 
     One consumer, one batch at a time: concurrent landings each spawning
@@ -181,13 +263,14 @@ async def pump_announcements(announce_queue, relay, ws) -> None:
 
     while True:
         batch = await announce_queue.get()
-        waited = 0.0
-        while relay.response_active and waited < ANNOUNCE_IDLE_MAX_WAIT_S:
+        while response_busy() if response_busy is not None else relay.response_active:
             await asyncio.sleep(ANNOUNCE_IDLE_POLL_S)
-            waited += ANNOUNCE_IDLE_POLL_S
         try:
-            for out in batch:
-                await ws.send_json(out)
+            if send_batch is not None:
+                await send_batch(batch)
+            else:
+                for out in batch:
+                    await ws.send_json(out)
         except Exception:  # noqa: BLE001 — a closing socket costs one batch
             pass
 
@@ -319,9 +402,9 @@ async def run_talk_session(audio: object | None = None) -> int:
     tools = talk_tools.default_talk_tools()
 
     # Find out NOW whether the api_server lane is up. The verdict is needed by
-    # the first tool call, and by then the answer has to be free: that call
-    # runs on the loop carrying the microphone. Fire-and-forget on a daemon
-    # thread — a session must never wait on this, and never fail because of it.
+    # the first tool call; warming it before then avoids spending that tool's
+    # bounded courtesy wait on a cold network probe. Fire-and-forget on a daemon
+    # thread — session startup must never wait on or fail because of it.
     talk_apiserver.warm_in_background()
 
     # Local checks before network: a missing microphone (or an unavailable
@@ -394,7 +477,28 @@ async def run_talk_session(audio: object | None = None) -> int:
                 timeout=CONNECT_TIMEOUT_S,
                 heartbeat=20.0,
             ) as ws:
-                await ws.send_json(session_update)
+                send_lock = asyncio.Lock()
+                continuation_pending = False
+
+                def start_watchers(messages: list[dict]) -> None:
+                    for run_id in started_run_ids(messages):
+                        if run_id in watched:
+                            continue
+                        watched.add(run_id)
+                        watchers.append(asyncio.create_task(watch_run(run_id)))
+
+                async def send_outgoing(outgoing: list[dict]) -> None:
+                    """Serialize every socket write; keep multi-message batches contiguous."""
+
+                    nonlocal continuation_pending
+                    async with send_lock:
+                        for out in outgoing:
+                            if out.get("type") == "response.create":
+                                continuation_pending = True
+                            await ws.send_json(out)
+                    start_watchers(outgoing)
+
+                await send_outgoing([session_update])
                 print(
                     f"talk: connected ({model}, voice {voice}, auth {auth.source}). "
                     "Ctrl+C to hang up.\n"
@@ -406,11 +510,11 @@ async def run_talk_session(audio: object | None = None) -> int:
                         if chunk is None:
                             await asyncio.sleep(IDLE_POLL_S)
                             continue
-                        await ws.send_json(
-                            {
+                        await send_outgoing(
+                            [{
                                 "type": "input_audio_buffer.append",
                                 "audio": base64.b64encode(chunk).decode("ascii"),
-                            }
+                            }]
                         )
 
                 async def watch_run(run_id: int) -> None:
@@ -429,19 +533,15 @@ async def run_talk_session(audio: object | None = None) -> int:
                         if run is None:
                             return
                         if run["status"] in talk_runs.TERMINAL_STATUSES:
-                            for out in run_finished_messages(run):
-                                await ws.send_json(out)
+                            await announce_queue.put(run_finished_messages(run))
                             return
 
-                def start_watchers(messages: list[dict]) -> None:
-                    for run_id in started_run_ids(messages):
-                        if run_id in watched:
-                            continue
-                        watched.add(run_id)
-                        watchers.append(asyncio.create_task(watch_run(run_id)))
+                tool_coordinator = ToolResponseCoordinator(
+                    relay, send_outgoing, max_pending=TOOL_SESSION_QUEUE_SIZE
+                )
 
                 async def receive_events() -> None:
-                    nonlocal spoken_item
+                    nonlocal continuation_pending, spoken_item
                     async for message in ws:
                         if message.type is not aiohttp.WSMsgType.TEXT:
                             continue
@@ -451,13 +551,18 @@ async def run_talk_session(audio: object | None = None) -> int:
                             continue
                         if not isinstance(event, dict):
                             continue
+                        if event.get("type") == "response.created":
+                            continuation_pending = False
+                        if event.get("type") == "response.function_call_arguments.done":
+                            tool_coordinator.admit(event)
+                            continue
                         outgoing = relay.handle_event(event)
+                        if event.get("type") == "response.done":
+                            await tool_coordinator.response_done()
                         if pending:
                             outgoing = [*outgoing, *pending]
                             pending.clear()
-                        for out in outgoing:
-                            await ws.send_json(out)
-                        start_watchers(outgoing)
+                        await send_outgoing(outgoing)
                         if relay.last_audio_item_id != spoken_item:
                             spoken_item = relay.last_audio_item_id
                             audio.reset_played_ms()
@@ -491,17 +596,61 @@ async def run_talk_session(audio: object | None = None) -> int:
                 )
 
                 sender = asyncio.create_task(send_microphone())
-                pump = asyncio.create_task(pump_announcements(announce_queue, relay, ws))
+                pump = asyncio.create_task(
+                    pump_announcements(
+                        announce_queue,
+                        relay,
+                        ws,
+                        send_outgoing,
+                        lambda: (
+                            relay.response_active
+                            or continuation_pending
+                            or bool(tool_coordinator.outputs)
+                        ),
+                    )
+                )
+                tool_worker = asyncio.create_task(tool_coordinator.run())
+                receiver = asyncio.create_task(receive_events())
+                drain = None
                 try:
-                    await receive_events()
+                    done, _pending_tasks = await asyncio.wait(
+                        {sender, receiver, tool_worker},
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if sender in done:
+                        await sender
+                        raise RuntimeError("microphone sender stopped unexpectedly")
+                    if tool_worker in done:
+                        await tool_worker
+                    await receiver
+                    drain = asyncio.create_task(tool_coordinator.join())
+                    done, _pending_tasks = await asyncio.wait(
+                        {drain, tool_worker},
+                        timeout=TOOL_CLEANUP_WAIT_S,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if tool_worker in done:
+                        await tool_worker
+                    if drain not in done:
+                        raise TimeoutError("tool cleanup exceeded its bound")
+                    await drain
                 finally:
                     talk_steer.set_landed_notifier(None)
                     talk_lifecycle.detach_session()
                     sender.cancel()
                     pump.cancel()
+                    receiver.cancel()
+                    tool_worker.cancel()
+                    if drain is not None:
+                        drain.cancel()
+                    tool_coordinator.discard_pending()
                     for watcher in watchers:
                         watcher.cancel()
-                    await asyncio.gather(sender, pump, *watchers, return_exceptions=True)
+                    await asyncio.gather(
+                        sender, pump, receiver, tool_worker,
+                        *([drain] if drain is not None else []), *watchers,
+                        return_exceptions=True
+                    )
     except asyncio.CancelledError:
         raise
     except Exception as exc:  # noqa: BLE001 — one line at the operator, not a traceback

--- a/talk_host.py
+++ b/talk_host.py
@@ -22,10 +22,10 @@ fall-through is announced in the returned text**:
    naming what is missing for a memory lookup
 
 Tiers 2 and 3 both return the ``WORK_STARTED`` receipt rather than an answer.
-That is not a preference: the relay executes tools synchronously on the event
-loop carrying the microphone, so a tool that waits for an agent is a call
-that goes silent. :mod:`talk_runs` already owns "start it, speak it when it
-lands", and both surfaces already watch for the receipt.
+That is not a preference: relay tool waits are bounded, so work that takes an
+agent turn cannot return its answer through the original function call.
+:mod:`talk_runs` already owns "start it, speak it when it lands", and both
+surfaces already watch for the receipt.
 
 The detached backend spawns ``hermes [--profile <name>] -z <task>``. The
 profile comes from ``TALK_AGENT_PROFILE`` or, unset, from auto-detection in
@@ -576,7 +576,7 @@ class HostAdapter:
 
         Three tiers, each fall-through said out loud (see the module docstring).
         Tier 2 answers with a receipt rather than the answer — an agent run is
-        seconds of work and this call is on the loop carrying the microphone.
+        seconds of work and outlives the relay's bounded tool courtesy wait.
         """
 
         ctx = get_ctx()

--- a/talk_relay.py
+++ b/talk_relay.py
@@ -1,10 +1,12 @@
 """The Realtime event loop — transport-agnostic.
 
 :class:`RealtimeRelay` takes one decoded Realtime server event and returns the
-wire messages to send back. It never touches a socket, a microphone, or
-asyncio, which is what lets the same loop serve the terminal session (aiohttp
-WebSocket) and, later, a browser data channel — and what lets the whole thing
-be tested against a scripted transcript with no network.
+wire messages to send back. It never touches a socket or a microphone, which
+lets the same loop serve the terminal session (aiohttp WebSocket) and, later,
+a browser data channel — and lets the whole thing be tested against a scripted
+transcript with no network. Its async entry point moves blocking tools off the
+transport's event loop; the synchronous entry point remains for loop-free
+callers and scripted tests.
 
 Audio, captions, barge-in, and errors leave through injected callbacks. Tool
 results come back as ``function_call_output`` items; a tool that fails speaks
@@ -14,10 +16,16 @@ error string rather than a result.
 
 from __future__ import annotations
 
+import asyncio
 import base64
+import concurrent.futures
+import contextvars
 import json
+import queue
+import threading
 from collections.abc import Callable
-from typing import ClassVar
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
 
 try:
     from .talk_tools import TalkToolError, execute_talk_tool
@@ -30,9 +38,128 @@ UNPARSEABLE_ARGS_TEXT = (
     "Say what you wanted and I'll try again."
 )
 
+#: Courtesy wait for an ordinary tool. The worker is deliberately allowed to
+#: finish after this bound (Python cannot safely kill a running thread), but
+#: the Realtime turn gets an honest output instead of permanent silence.
+TOOL_EXECUTION_WAIT_S = 5.0
+TOOL_WORKERS = 2
+TOOL_PENDING_JOBS = 4
+
 
 def _noop(*_args) -> None:
     """Default callback: the relay works with no consumers attached."""
+
+
+class ToolWorkerBusy(RuntimeError):
+    """The bounded tool worker pool cannot admit another job."""
+
+
+class ToolExecutionTimeout(TimeoutError):
+    """A courtesy wait expired, with truthful worker-start state."""
+
+    def __init__(self, *, started: bool) -> None:
+        super().__init__("tool execution courtesy wait expired")
+        self.started = started
+
+
+@dataclass
+class _ToolSubmission:
+    future: concurrent.futures.Future
+    started: threading.Event = field(default_factory=threading.Event)
+
+
+class _DaemonWorkerPool:
+    """A fixed daemon pool with bounded pending admission.
+
+    Python cannot stop a running thread safely. A wedged tool can therefore
+    occupy one worker, but it cannot create another worker or an unbounded
+    backlog: once both fixed workers and the small queue are occupied, callers
+    receive :class:`ToolWorkerBusy` immediately.
+    """
+
+    def __init__(self, *, max_workers: int, max_pending: int) -> None:
+        self._max_workers = max_workers
+        self._jobs: queue.Queue[tuple] = queue.Queue(maxsize=max_pending)
+        self._threads: list[threading.Thread] = []
+        self._start_lock = threading.Lock()
+
+    @property
+    def worker_count(self) -> int:
+        return len(self._threads)
+
+    def _ensure_started(self) -> None:
+        if self._threads:
+            return
+        with self._start_lock:
+            if self._threads:
+                return
+            for index in range(self._max_workers):
+                worker = threading.Thread(
+                    target=self._work,
+                    daemon=True,
+                    name=f"talk-tool-{index + 1}",
+                )
+                worker.start()
+                self._threads.append(worker)
+
+    def submit(self, fn: Callable[..., Any], *args: Any) -> _ToolSubmission:
+        self._ensure_started()
+        future: concurrent.futures.Future = concurrent.futures.Future()
+        submission = _ToolSubmission(future)
+        job = (submission, contextvars.copy_context(), fn, args)
+        try:
+            self._jobs.put_nowait(job)
+        except queue.Full as exc:
+            raise ToolWorkerBusy("tool worker capacity is full") from exc
+        return submission
+
+    def _work(self) -> None:
+        while True:
+            submission, context, fn, args = self._jobs.get()
+            future = submission.future
+            try:
+                if not future.set_running_or_notify_cancel():
+                    continue
+                submission.started.set()
+                try:
+                    future.set_result(context.run(fn, *args))
+                except BaseException as exc:  # noqa: BLE001 — Future preserves it
+                    future.set_exception(exc)
+            finally:
+                self._jobs.task_done()
+
+
+_TOOL_POOL = _DaemonWorkerPool(
+    max_workers=TOOL_WORKERS,
+    max_pending=TOOL_PENDING_JOBS,
+)
+
+
+async def _run_on_daemon(fn: Callable[..., Any], *args: Any) -> Any:
+    """Run blocking work on the bounded daemon pool.
+
+    The pool preserves ``contextvars`` like :func:`asyncio.to_thread`, while its
+    fixed daemon workers cannot hold process exit or grow after timeouts.
+    """
+
+    submission = _TOOL_POOL.submit(fn, *args)
+    return await asyncio.wrap_future(submission.future)
+
+
+async def run_bounded_on_daemon(
+    fn: Callable[..., Any], *args: Any, timeout: float
+) -> Any:
+    """Run one tool with a bounded wait and report whether it actually started."""
+
+    submission = _TOOL_POOL.submit(fn, *args)
+    try:
+        return await asyncio.wait_for(
+            asyncio.wrap_future(submission.future), timeout=timeout
+        )
+    except TimeoutError as exc:
+        raise ToolExecutionTimeout(
+            started=submission.started.is_set() or submission.future.running()
+        ) from exc
 
 
 class RealtimeRelay:
@@ -69,6 +196,72 @@ class RealtimeRelay:
         if handler is None:
             return []
         return handler(self, event)
+
+    async def handle_event_async(self, event: dict) -> list[dict]:
+        """Handle one event without running a blocking tool on the caller's loop.
+
+        Tool messages contain only their function output. The transport owns
+        response-level batching: it preserves call order and appends exactly
+        one ``response.create`` after ``response.done`` and every call settles.
+        Other event types stay on the loop because their callbacks are immediate
+        and transport-agnostic.
+        """
+
+        handler = self._DISPATCH.get(str(event.get("type") or ""))
+        if handler is None:
+            return []
+        if handler is self._DISPATCH["response.function_call_arguments.done"]:
+            try:
+                messages = await run_bounded_on_daemon(
+                    handler, self, event, timeout=TOOL_EXECUTION_WAIT_S
+                )
+                # The synchronous relay owns its continuation for legacy callers.
+                # Async transports batch every tool call in one Realtime response
+                # and append exactly one response.create after the batch settles.
+                return [
+                    message
+                    for message in messages
+                    if message.get("type") != "response.create"
+                ]
+            except ToolWorkerBusy:
+                call_id = str(event.get("call_id") or "")
+                name = str(event.get("name") or "tool")
+                return self._function_output(
+                    call_id,
+                    f"Earlier tools are still running, so the {name} tool was not "
+                    "started. Wait for them to finish, then ask me to try again.",
+                    continue_response=False,
+                )
+            except ToolExecutionTimeout as exc:
+                call_id = str(event.get("call_id") or "")
+                name = str(event.get("name") or "tool")
+                if exc.started:
+                    output = (
+                        f"The {name} tool is still running after "
+                        f"{TOOL_EXECUTION_WAIT_S:g} seconds. I detached it so the "
+                        "call can continue, but its eventual result won't return "
+                        "to this conversation. Ask me to check again if you still need it."
+                    )
+                else:
+                    output = (
+                        f"The {name} tool did not start within "
+                        f"{TOOL_EXECUTION_WAIT_S:g} seconds because earlier tools "
+                        "were still using the workers. Ask me to try again."
+                    )
+                return self._function_output(call_id, output, continue_response=False)
+        return handler(self, event)
+
+    def tool_queue_full_output(self, event: dict) -> list[dict]:
+        """Answer a tool event that the session's bounded queue could not admit."""
+
+        call_id = str(event.get("call_id") or "")
+        name = str(event.get("name") or "tool")
+        return self._function_output(
+            call_id,
+            f"Earlier tools are still running, so the {name} tool was not started. "
+            "Wait for them to finish, then ask me to try again.",
+            continue_response=False,
+        )
 
     # -- event handlers -------------------------------------------------------
 
@@ -153,8 +346,10 @@ class RealtimeRelay:
         return []
 
     @staticmethod
-    def _function_output(call_id: str, output: str) -> list[dict]:
-        return [
+    def _function_output(
+        call_id: str, output: str, *, continue_response: bool = True
+    ) -> list[dict]:
+        messages = [
             {
                 "type": "conversation.item.create",
                 "item": {
@@ -162,9 +357,11 @@ class RealtimeRelay:
                     "call_id": call_id,
                     "output": output,
                 },
-            },
-            {"type": "response.create"},
+            }
         ]
+        if continue_response:
+            messages.append({"type": "response.create"})
+        return messages
 
     _DISPATCH: ClassVar[dict[str, Callable[[RealtimeRelay, dict], list[dict]]]] = {
         "session.created": _on_session,
@@ -181,6 +378,10 @@ class RealtimeRelay:
 
 __all__ = [
     "BARGE_IN_MESSAGE",
+    "TOOL_EXECUTION_WAIT_S",
     "UNPARSEABLE_ARGS_TEXT",
     "RealtimeRelay",
+    "ToolExecutionTimeout",
+    "ToolWorkerBusy",
+    "run_bounded_on_daemon",
 ]

--- a/talk_vault.py
+++ b/talk_vault.py
@@ -15,9 +15,9 @@ the dashboard do not have — the two lanes most likely to be asked "what do
 you know about X". Loading the provider ourselves works on all three.
 
 Two costs, both measured on a 1,000-document vault and both shaping the
-design: the first resolve is ~0.9s and a search is ~0.3s. A tool call runs on
-the loop carrying the microphone, so the index is built ONCE behind a
-single-flight lock and kept, rather than rebuilt per lookup.
+design: the first resolve is ~0.9s and a search is ~0.3s. Tool waits are
+bounded, so the index is built ONCE behind a single-flight lock and kept,
+rather than rebuilt per lookup.
 
 That first resolve is paid while the SESSION IS BEING MINTED, not on the
 operator's first question: ``identity_sections`` builds the vault pointer and

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import inspect
+import json
+import threading
 import types
+
+import pytest
 
 import talk_audio
 import talk_cli
+import talk_relay
 
 
 def test_session_update_keeps_type_drops_model():
@@ -75,6 +81,382 @@ def test_missing_audio_stack_exits_one_before_dialling(monkeypatch, capsys):
 
     assert asyncio.run(talk_cli.run_talk_session()) == 1
     assert "hermes-talk[audio]" in capsys.readouterr().err
+
+
+def test_slow_tool_does_not_block_inbound_barge_in(monkeypatch):
+    """Receive and cancel keep moving while the serialized tool worker is busy."""
+
+    events: list[str] = []
+    tool_started = threading.Event()
+    barge_in_processed = threading.Event()
+
+    def slow_tool(_name, _arguments):
+        events.append("tool_started")
+        tool_started.set()
+        barge_in_processed.wait(timeout=0.5)
+        events.append("tool_finished")
+        return "done"
+
+    class _Audio:
+        played_ms = 0
+
+        def __init__(self):
+            self.sent = False
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def read_input_chunk(self):
+            return None
+
+        def queue_playback(self, _pcm):
+            pass
+
+        def drain_playback(self):
+            events.append("barge_in_processed")
+            barge_in_processed.set()
+
+        def reset_played_ms(self):
+            pass
+
+    class _Message:
+        type = "text"
+
+        def __init__(self, event):
+            self.data = json.dumps(event)
+
+    class _WS:
+        def __init__(self):
+            self.events = iter(
+                [
+                    {"type": "response.created"},
+                    {
+                        "type": "response.function_call_arguments.done",
+                        "call_id": "call_slow_1",
+                        "name": "slow_tool",
+                        "arguments": "{}",
+                    },
+                    {
+                        "type": "response.function_call_arguments.done",
+                        "call_id": "call_slow_2",
+                        "name": "slow_tool",
+                        "arguments": "{}",
+                    },
+                    {
+                        "type": "response.function_call_arguments.done",
+                        "call_id": "call_slow_3",
+                        "name": "slow_tool",
+                        "arguments": "{}",
+                    },
+                    {"type": "input_audio_buffer.speech_started"},
+                ]
+            )
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                event = next(self.events)
+            except StopIteration:
+                raise StopAsyncIteration from None
+            return _Message(event)
+
+        async def send_json(self, message):
+            events.append(message.get("type", ""))
+
+    ws = _WS()
+
+    class _ClientSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def ws_connect(self, *_args, **_kwargs):
+            return ws
+
+    host = types.SimpleNamespace(
+        resolve_auth=lambda: types.SimpleNamespace(token="token", source="test"),
+        identity_sections=lambda: {},
+    )
+    monkeypatch.setattr(talk_cli.talk_host, "host", lambda: host)
+    monkeypatch.setattr(
+        talk_cli,
+        "_mint_session",
+        lambda *a, **k: types.SimpleNamespace(client_secret="ephemeral"),
+    )
+    monkeypatch.setattr(
+        talk_cli,
+        "_import_aiohttp",
+        lambda: types.SimpleNamespace(
+            ClientSession=_ClientSession,
+            WSMsgType=types.SimpleNamespace(TEXT="text"),
+        ),
+    )
+    monkeypatch.setattr(talk_relay, "execute_talk_tool", slow_tool)
+
+    assert asyncio.run(talk_cli.run_talk_session(audio=_Audio())) == 0
+    assert events.index("barge_in_processed") < events.index("tool_finished")
+    assert events.index("response.cancel") < events.index("tool_finished")
+
+
+def test_microphone_and_tool_batches_share_the_only_socket_writer():
+    source = inspect.getsource(talk_cli.run_talk_session)
+    start = source.index("async def send_microphone")
+    end = source.index("async def watch_run")
+    microphone = source[start:end]
+
+    assert "await send_outgoing(" in microphone
+    assert source.count("ws.send_json(") == 1
+
+
+def test_tool_batch_orders_two_outputs_and_continues_once_after_response_done():
+    async def scenario():
+        sent: list[dict] = []
+        release_first = asyncio.Event()
+
+        class Relay:
+            async def handle_event_async(self, event):
+                if event["call_id"] == "call_1":
+                    await release_first.wait()
+                return [{
+                    "type": "conversation.item.create",
+                    "item": {
+                        "type": "function_call_output",
+                        "call_id": event["call_id"],
+                        "output": event["call_id"],
+                    },
+                }]
+
+            def tool_queue_full_output(self, _event):
+                raise AssertionError("queue should admit both calls")
+
+        async def send(batch):
+            sent.extend(batch)
+
+        coordinator = talk_cli.ToolResponseCoordinator(Relay(), send, max_pending=2)
+        worker = asyncio.create_task(coordinator.run())
+        coordinator.admit({"call_id": "call_1"})
+        coordinator.admit({"call_id": "call_2"})
+        await coordinator.response_done()
+        await asyncio.sleep(0)
+        assert sent == []
+        release_first.set()
+        await asyncio.wait_for(coordinator.join(), 0.2)
+        worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
+        return sent
+
+    sent = asyncio.run(scenario())
+    assert [m["item"]["call_id"] for m in sent[:-1]] == ["call_1", "call_2"]
+    assert sent[-1] == {"type": "response.create"}
+    assert sum(m["type"] == "response.create" for m in sent) == 1
+
+
+def test_tool_batch_strips_production_relays_per_call_continuations():
+    """The real relay must not leak one response.create per successful call."""
+
+    async def scenario():
+        sent: list[dict] = []
+        relay = talk_relay.RealtimeRelay(tool_executor=lambda name, _args: name)
+
+        async def send(batch):
+            sent.extend(batch)
+
+        coordinator = talk_cli.ToolResponseCoordinator(relay, send, max_pending=2)
+        worker = asyncio.create_task(coordinator.run())
+        for index in (1, 2):
+            coordinator.admit(
+                {
+                    "type": "response.function_call_arguments.done",
+                    "call_id": f"call_{index}",
+                    "name": f"tool_{index}",
+                    "arguments": "{}",
+                }
+            )
+        await coordinator.response_done()
+        await asyncio.wait_for(coordinator.join(), 0.5)
+        worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
+        return sent
+
+    sent = asyncio.run(scenario())
+    assert [
+        message["item"]["call_id"]
+        for message in sent
+        if message.get("type") == "conversation.item.create"
+    ] == ["call_1", "call_2"]
+    assert sum(message.get("type") == "response.create" for message in sent) == 1
+
+
+def test_queue_full_output_waits_for_active_tool_and_response_done():
+    async def scenario():
+        sent: list[dict] = []
+        release = asyncio.Event()
+
+        class Relay:
+            async def handle_event_async(self, event):
+                await release.wait()
+                return [{"type": "output", "call_id": event["call_id"]}]
+
+            def tool_queue_full_output(self, event):
+                return [{"type": "output", "call_id": event["call_id"], "busy": True}]
+
+        async def send(batch):
+            sent.extend(batch)
+
+        coordinator = talk_cli.ToolResponseCoordinator(Relay(), send, max_pending=1)
+        coordinator.admit({"call_id": "active"})
+        worker = asyncio.create_task(coordinator.run())
+        await asyncio.sleep(0)
+        coordinator.admit({"call_id": "queued"})
+        coordinator.admit({"call_id": "full"})
+        await coordinator.response_done()
+        await asyncio.sleep(0)
+        assert sent == []
+        release.set()
+        await asyncio.wait_for(coordinator.join(), 0.2)
+        worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
+        return sent
+
+    sent = asyncio.run(scenario())
+    assert [m.get("call_id") for m in sent[:-1]] == ["active", "queued", "full"]
+    assert sent[-1] == {"type": "response.create"}
+
+
+def test_tool_coordinator_send_failure_does_not_deadlock_queued_cleanup():
+    async def scenario():
+        async def send(_batch):
+            raise RuntimeError("socket failed")
+
+        class Relay:
+            async def handle_event_async(self, event):
+                return [{"type": "output", "call_id": event["call_id"]}]
+
+            def tool_queue_full_output(self, event):
+                return [{"type": "output", "call_id": event["call_id"]}]
+
+        coordinator = talk_cli.ToolResponseCoordinator(Relay(), send, max_pending=2)
+        coordinator.admit({"call_id": "first"})
+        coordinator.admit({"call_id": "second"})
+        await coordinator.response_done()
+        worker = asyncio.create_task(coordinator.run())
+        with pytest.raises(RuntimeError, match="socket failed"):
+            await asyncio.wait_for(worker, 0.2)
+        coordinator.discard_pending()
+        await asyncio.wait_for(coordinator.join(), 0.2)
+
+    asyncio.run(scenario())
+
+
+def test_microphone_send_failure_terminates_a_blocked_receiver(monkeypatch, capsys):
+    """A failed audio append must not leave the socket receiver live forever."""
+
+    class _Audio:
+        played_ms = 0
+
+        def __init__(self):
+            self.sent = False
+            self.stopped = False
+
+        def start(self):
+            pass
+
+        def stop(self):
+            self.stopped = True
+
+        def read_input_chunk(self):
+            if not self.sent:
+                self.sent = True
+                return b"microphone"
+            return None
+
+        def queue_playback(self, _pcm):
+            pass
+
+        def drain_playback(self):
+            pass
+
+        def reset_played_ms(self):
+            pass
+
+    class _WS:
+        def __init__(self):
+            self.receive_cancelled = False
+            self._forever = asyncio.Event()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def send_json(self, message):
+            if message.get("type") == "input_audio_buffer.append":
+                raise RuntimeError("microphone socket write failed")
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                await self._forever.wait()
+            except asyncio.CancelledError:
+                self.receive_cancelled = True
+                raise
+            raise StopAsyncIteration
+
+    ws = _WS()
+
+    class _ClientSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def ws_connect(self, *_args, **_kwargs):
+            return ws
+
+    host = types.SimpleNamespace(
+        resolve_auth=lambda: types.SimpleNamespace(token="token", source="test"),
+        identity_sections=lambda: {},
+    )
+    monkeypatch.setattr(talk_cli.talk_host, "host", lambda: host)
+    monkeypatch.setattr(
+        talk_cli,
+        "_mint_session",
+        lambda *a, **k: types.SimpleNamespace(client_secret="ephemeral"),
+    )
+    monkeypatch.setattr(
+        talk_cli,
+        "_import_aiohttp",
+        lambda: types.SimpleNamespace(
+            ClientSession=_ClientSession,
+            WSMsgType=types.SimpleNamespace(TEXT="text"),
+        ),
+    )
+    audio = _Audio()
+
+    result = asyncio.run(
+        asyncio.wait_for(talk_cli.run_talk_session(audio=audio), timeout=0.5)
+    )
+    assert result == 1
+    assert ws.receive_cancelled
+    assert audio.stopped
+    assert "microphone socket write failed" in capsys.readouterr().err
 
 
 def test_subagent_stop_messages_are_a_contained_announcement():

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -236,6 +236,57 @@ def test_failing_handler_answers_200_with_speakable_text(monkeypatch):
     assert "disk on fire" in body["output"]
 
 
+def test_dashboard_tool_wait_is_bounded_and_honest(monkeypatch):
+    def slow_tool(_name, _arguments):
+        # A finite wait keeps a broken implementation's RED run bounded too.
+        import time
+
+        time.sleep(0.2)
+        return "late result"
+
+    monkeypatch.setattr(api.talk_tools, "execute_talk_tool", slow_tool)
+    monkeypatch.setattr(api, "TOOL_EXECUTION_WAIT_S", 0.01)
+
+    async def scenario():
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        body = await api.run_tool(FakeRequest(body={"name": "slow_tool"}))
+        return body, loop.time() - started
+
+    body, elapsed = asyncio.run(scenario())
+
+    assert elapsed < 0.1
+    assert body["ok"] is True
+    assert "still running" in body["output"]
+    assert "result won't return" in body["output"]
+
+
+def test_dashboard_worker_saturation_reports_that_tool_was_not_started(monkeypatch):
+    import threading
+
+    release = threading.Event()
+
+    def stuck_tool(_name, _arguments):
+        release.wait()
+        return "late"
+
+    pool = api.talk_relay._DaemonWorkerPool(max_workers=1, max_pending=1)
+    monkeypatch.setattr(api.talk_relay, "_TOOL_POOL", pool)
+    monkeypatch.setattr(api.talk_tools, "execute_talk_tool", stuck_tool)
+    monkeypatch.setattr(api, "TOOL_EXECUTION_WAIT_S", 0.01)
+
+    async def scenario():
+        requests = [FakeRequest(body={"name": f"tool_{i}"}) for i in range(10)]
+        return await asyncio.gather(*(api.run_tool(request) for request in requests))
+
+    bodies = asyncio.run(scenario())
+    release.set()
+
+    refused = [body["output"] for body in bodies if "not started" in body["output"]]
+    assert refused
+    assert all("detached it" not in output for output in refused)
+
+
 def test_tool_arguments_reach_the_handler():
     seen: dict = {}
 

--- a/tests/test_dashboard_js.py
+++ b/tests/test_dashboard_js.py
@@ -1,0 +1,92 @@
+"""Executable dashboard transport protocol regressions (Node, no browser)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import run
+
+ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD_JS = ROOT / "dashboard" / "dist" / "index.js"
+
+
+def test_dashboard_serializes_tool_calls_and_continues_once_after_response_done():
+    script = r"""
+const fs = require("fs");
+const vm = require("vm");
+const source = fs.readFileSync(process.argv[1], "utf8");
+let releaseFirst;
+const firstGate = new Promise((resolve) => { releaseFirst = resolve; });
+const started = [];
+const sent = [];
+const window = {
+  __HERMES_TALK_TEST_HOOK__: true,
+  __HERMES_PLUGINS__: { register() {} },
+  __HERMES_PLUGIN_SDK__: {
+    React: { createElement() {} },
+    hooks: { useState() {}, useEffect() {}, useRef() {}, useCallback() {} },
+    components: {},
+    async fetchJSON(_url, opts) {
+      const name = JSON.parse(opts.body).name;
+      started.push(name);
+      if (name === "first") await firstGate;
+      return { output: "result-" + name };
+    },
+  },
+  sessionStorage: { getItem() { return ""; } },
+  setTimeout,
+  clearTimeout,
+};
+const context = { window, setTimeout, clearTimeout, AbortController, console };
+vm.runInNewContext(source, context, { filename: "index.js" });
+const Transport = window.__HERMES_TALK_TEST__.TalkTransport;
+const transport = new Transport({}, { onStatus() {}, onError() {} });
+transport.channel = {
+  readyState: "open",
+  send(payload) { sent.push(JSON.parse(payload)); },
+};
+const call = (id, name) => JSON.stringify({
+  type: "response.function_call_arguments.done",
+  call_id: id,
+  name,
+  arguments: "{}",
+});
+const waitFor = async (predicate, timeoutMs = 1000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("timed out waiting for dashboard transport");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+};
+(async () => {
+  transport.handleEvent(call("call-1", "first"));
+  transport.handleEvent(call("call-2", "second"));
+  transport.handleEvent(JSON.stringify({ type: "response.done" }));
+  await waitFor(() => started.length >= 1);
+  if (JSON.stringify(started) !== JSON.stringify(["first"])) {
+    throw new Error("calls launched concurrently: " + JSON.stringify(started));
+  }
+  if (sent.length !== 0) throw new Error("continued before tools resolved");
+  releaseFirst();
+  await waitFor(() => started.length === 2 && sent.some((m) => m.type === "response.create"));
+  if (JSON.stringify(started) !== JSON.stringify(["first", "second"])) {
+    throw new Error("wrong call order: " + JSON.stringify(started));
+  }
+  const ids = sent.slice(0, -1).map((m) => m.item.call_id);
+  if (JSON.stringify(ids) !== JSON.stringify(["call-1", "call-2"])) {
+    throw new Error("wrong output order: " + JSON.stringify(sent));
+  }
+  if (sent.filter((m) => m.type === "response.create").length !== 1) {
+    throw new Error("continuation count: " + JSON.stringify(sent));
+  }
+  process.exit(0);
+})().catch((error) => { console.error(error); process.exit(1); });
+"""
+    completed = run(
+        ["node", "-e", script, str(DASHBOARD_JS)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_dashboard_manifest.py
+++ b/tests/test_dashboard_manifest.py
@@ -68,6 +68,14 @@ def test_entry_registers_under_the_manifest_name(manifest):
     assert f'__HERMES_PLUGINS__.register("{manifest["name"]}"' in entry
 
 
+def test_dashboard_tool_request_has_a_client_abort_bound(manifest):
+    entry = (DASHBOARD_DIR / manifest["entry"]).read_text(encoding="utf-8")
+
+    assert "const TOOL_TIMEOUT_MS" in entry
+    assert "new AbortController()" in entry
+    assert re.search(r'apiPost\(\s*"/tool",[\s\S]*?TOOL_TIMEOUT_MS\s*\)', entry)
+
+
 def test_tab_declares_a_route(manifest):
     assert manifest["tab"]["path"].startswith("/")
     assert manifest["tab"]["position"]

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
+
 import fake_realtime as fr
 
 import talk_relay
@@ -24,6 +27,110 @@ def test_function_call_round_trip():
     assert item["type"] == "function_call_output"
     assert item["call_id"] == "call_1"
     assert item["output"] == "You shipped it Tuesday."
+
+
+def test_async_tool_wait_is_bounded_and_answers_honestly(monkeypatch):
+    release = threading.Event()
+
+    def stuck_tool(_name, _arguments):
+        release.wait()
+        return "late result"
+
+    async def scenario():
+        relay = talk_relay.RealtimeRelay(tool_executor=stuck_tool)
+        messages = await relay.handle_event_async(fr.function_call("slow_tool", "{}"))
+        release.set()
+        return messages
+
+    monkeypatch.setattr(talk_relay, "TOOL_EXECUTION_WAIT_S", 0.01)
+    messages = asyncio.run(scenario())
+
+    assert "still running" in messages[0]["item"]["output"]
+    assert "result won't return" in messages[0]["item"]["output"]
+    assert len(messages) == 1
+
+
+def test_async_tool_worker_cannot_hold_process_exit_open():
+    worker_was_daemon: list[bool] = []
+
+    def inspect_worker(_name, _arguments):
+        worker_was_daemon.append(threading.current_thread().daemon)
+        return "done"
+
+    async def scenario():
+        relay = talk_relay.RealtimeRelay(tool_executor=inspect_worker)
+        await relay.handle_event_async(fr.function_call("inspect", "{}"))
+
+    asyncio.run(scenario())
+
+    assert worker_was_daemon == [True]
+
+
+def test_timed_out_tools_have_bounded_worker_admission(monkeypatch):
+    release = threading.Event()
+    started = 0
+    started_lock = threading.Lock()
+
+    def stuck_tool(_name, _arguments):
+        nonlocal started
+        with started_lock:
+            started += 1
+        release.wait()
+        return "late"
+
+    pool = talk_relay._DaemonWorkerPool(max_workers=1, max_pending=1)
+    monkeypatch.setattr(talk_relay, "_TOOL_POOL", pool)
+    monkeypatch.setattr(talk_relay, "TOOL_EXECUTION_WAIT_S", 0.01)
+
+    async def scenario():
+        relays = [talk_relay.RealtimeRelay(tool_executor=stuck_tool) for _ in range(20)]
+        return await asyncio.gather(
+            *(relay.handle_event_async(fr.function_call("stuck", "{}")) for relay in relays)
+        )
+
+    messages = asyncio.run(scenario())
+    release.set()
+
+    assert pool.worker_count == 1
+    assert started <= 1
+    outputs = [result[0]["item"]["output"] for result in messages]
+    running = sum(
+        output.startswith("The stuck tool is still running") for output in outputs
+    )
+    assert running == started
+    assert all(
+        "still running" in output or "not started" in output or "did not start" in output
+        for output in outputs
+    )
+
+
+def test_pending_tool_timeout_says_it_never_started(monkeypatch):
+    release = threading.Event()
+    pool = talk_relay._DaemonWorkerPool(max_workers=1, max_pending=2)
+    monkeypatch.setattr(talk_relay, "_TOOL_POOL", pool)
+    monkeypatch.setattr(talk_relay, "TOOL_EXECUTION_WAIT_S", 0.02)
+
+    def blocked(_name, _arguments):
+        release.wait()
+        return "late"
+
+    async def scenario():
+        relay = talk_relay.RealtimeRelay(tool_executor=blocked)
+        first = asyncio.create_task(
+            relay.handle_event_async(fr.function_call("first", "{}", "call_first"))
+        )
+        await asyncio.sleep(0.005)
+        second = await relay.handle_event_async(
+            fr.function_call("second", "{}", "call_second")
+        )
+        release.set()
+        await first
+        return second
+
+    messages = asyncio.run(scenario())
+    output = messages[0]["item"]["output"]
+    assert "did not start" in output
+    assert "still running" not in output
 
 
 def test_barge_in_cancels_and_drains():


### PR DESCRIPTION
## Summary
- move blocking terminal and Discord tool calls off the realtime receive/microphone loop
- preserve inbound barge-in and audio processing while tools run
- batch multiple tool outputs in call order and emit exactly one continuation after the originating response completes
- bound worker admission, execution waits, queue cleanup, and dashboard tool requests with honest timeout/capacity receipts
- serialize all websocket writes and supervise sender/receiver/worker failures as one session lifecycle

## Verification
- targeted realtime/tool/dashboard suites — 83 passed
- ........................................................................ [ 14%]
........................................................................ [ 29%]
........................................................................ [ 43%]
........................................................................ [ 58%]
........................................................................ [ 72%]
........................................................................ [ 87%]
...............................................................          [100%]
495 passed in 7.11s — 495 passed
- All checks passed! — passed
-  — passed
-  — passed
- adversarial regressions cover barge-in during tools, multi-call continuation batching, queue saturation, socket-send cleanup, microphone-send failure, and dashboard ordering

Closes #11