### PR TITLE
fix(lifecycle): scope announcements to parent session

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ shape.
 Needs Python ≥ 3.11 and a Hermes host ≥ v0.17. `redirect_agent`'s
 clean-abort path wants 0.20+ and [degrades honestly below it](#redirecting-work-thats-already-running).
 The plugin remains backward-compatible with older hosts, but session-owned
-subagent completion announcements require Hermes core commit `832b0cb` or a
-release containing it; without that ownership property, announcements are
-suppressed rather than guessed. Details are in
+subagent completion announcements require a Hermes release exposing
+`PluginContext.active_parent_session_id` (upstream
+[PR #79716](https://github.com/NousResearch/hermes-agent/pull/79716)); without
+that property, announcements are suppressed rather than guessed. Details are in
 [docs/OPERATING.md](docs/OPERATING.md#prerequisites).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ shape.
 
 ## Install
 
-Needs Python ≥ 3.11 and a Hermes host ≥ v0.17 (`redirect_agent`'s
-clean-abort path wants 0.20+ and [degrades honestly below it](#redirecting-work-thats-already-running)
-— details in [docs/OPERATING.md](docs/OPERATING.md#prerequisites)).
+Needs Python ≥ 3.11 and a Hermes host ≥ v0.17. `redirect_agent`'s
+clean-abort path wants 0.20+ and [degrades honestly below it](#redirecting-work-thats-already-running).
+The plugin remains backward-compatible with older hosts, but session-owned
+subagent completion announcements require Hermes core commit `832b0cb` or a
+release containing it; without that ownership property, announcements are
+suppressed rather than guessed. Details are in
+[docs/OPERATING.md](docs/OPERATING.md#prerequisites).
 
 ```bash
 hermes plugins install TheSmokeDev/hermes-talk --enable
@@ -235,7 +239,8 @@ operator log output is unchanged) — any DEBUG-guarded computation in that
 one module becomes active, a bounded perf cost traded for killing the
 false-"unconfirmed" class. And you often don't have to ask: the host's
 `subagent_stop` hook announces a finished background agent into the live
-call the moment it lands.
+call the moment it lands. Those hook events are filtered to the parent session
+that owns the call; foreign or ownership-less completions are never spoken.
 
 Four tools carry the surface, discovery-first:
 

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -13,8 +13,9 @@ to **prove** it's running instead of assuming it is.
   to the steer queue and the spoken reply says queued — never a fake
   abort. (See the README's [redirect section](../README.md#redirecting-work-thats-already-running).)
   Subagent completion announcements have a second compatibility boundary:
-  they require Hermes core commit `832b0cb` (or a release containing it),
-  which exposes the active parent session id to plugins. On older Hermes the
+  they require a Hermes release exposing
+  `PluginContext.active_parent_session_id` (upstream
+  [PR #79716](https://github.com/NousResearch/hermes-agent/pull/79716)). On older Hermes the
   rest of Talk remains compatible, but those announcements fail closed and
   stay silent rather than risking a foreign session's result being spoken.
 - **Audio**: the terminal session needs the `[audio]` extra

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -12,6 +12,11 @@ to **prove** it's running instead of assuming it is.
   host's public `AIAgent.redirect()` (**0.20+**). Below that it degrades
   to the steer queue and the spoken reply says queued — never a fake
   abort. (See the README's [redirect section](../README.md#redirecting-work-thats-already-running).)
+  Subagent completion announcements have a second compatibility boundary:
+  they require Hermes core commit `832b0cb` (or a release containing it),
+  which exposes the active parent session id to plugins. On older Hermes the
+  rest of Talk remains compatible, but those announcements fail closed and
+  stay silent rather than risking a foreign session's result being spoken.
 - **Audio**: the terminal session needs the `[audio]` extra
   (`sounddevice` + PortAudio). The dashboard tab uses the browser's mic
   instead and needs nothing installed locally.

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -256,6 +256,15 @@ def subagent_stop_messages(event: dict) -> list[dict]:
     return _announcement_messages(headline, tail)
 
 
+def _active_parent_session_id() -> str | None:
+    """Snapshot the bound Hermes session id, or fail closed on older hosts."""
+
+    ctx = talk_host.get_ctx()
+    if ctx is None:
+        return None
+    return getattr(ctx, "active_parent_session_id", None)
+
+
 def _import_aiohttp():
     try:
         import aiohttp
@@ -483,7 +492,12 @@ async def run_talk_session(audio: object | None = None) -> int:
                         announce_queue.put_nowait(messages)
 
                 loop = asyncio.get_running_loop()
-                talk_lifecycle.attach_session(loop, on_subagent_event)
+                # Snapshot ownership once for this socket. Older Hermes builds
+                # do not expose the property; None deliberately suppresses
+                # lifecycle announcements instead of guessing from global
+                # hook traffic.
+                owner_session_id = _active_parent_session_id()
+                talk_lifecycle.attach_session(loop, on_subagent_event, owner_session_id)
                 # The notifier fires on HOST drain threads — marshal onto the
                 # loop; a closed loop raises into talk_steer's own containment.
                 talk_steer.set_landed_notifier(

--- a/talk_lifecycle.py
+++ b/talk_lifecycle.py
@@ -50,7 +50,7 @@ _MAX_ROSTER = 100
 
 _LOCK = threading.Lock()
 _ROSTER: dict[str, dict] = {}
-_SESSION: tuple[Any, Callable[[dict], None]] | None = None
+_SESSION: tuple[Any, Callable[[dict], None], str | None] | None = None
 
 
 def on_subagent_start(**kwargs: Any) -> None:
@@ -129,13 +129,21 @@ def on_subagent_stop(**kwargs: Any) -> None:
 
 
 def _notify(event: dict) -> None:
-    """Marshal one lifecycle event onto the live session's loop, if any."""
+    """Marshal an event only to the Talk session that owns its parent.
+
+    Ownership fails closed in both directions: an older host that cannot name
+    the attached parent, and an event that cannot name its parent, are both
+    silent. Ledger degradation happens before this function and remains
+    global regardless of announcement ownership.
+    """
 
     with _LOCK:
         session = _SESSION
     if session is None:
         return
-    loop, callback = session
+    loop, callback, owner_session_id = session
+    if not owner_session_id or event.get("parent_session_id") != owner_session_id:
+        return
     try:
         loop.call_soon_threadsafe(callback, event)
     except RuntimeError:
@@ -146,17 +154,23 @@ def _notify(event: dict) -> None:
         _log.debug("lifecycle notify failed", exc_info=True)
 
 
-def attach_session(loop: Any, callback: Callable[[dict], None]) -> None:
+def attach_session(
+    loop: Any,
+    callback: Callable[[dict], None],
+    owner_session_id: str | None = None,
+) -> None:
     """Register the live Talk session as the announcement target.
 
     ``callback`` runs ON the loop thread (via ``call_soon_threadsafe``) and
-    owns its own scheduling. One session at a time — a new attach replaces
-    the old target, which matches one-terminal-one-call reality.
+    owns its own scheduling. ``owner_session_id`` is the Hermes parent session
+    this Talk call belongs to; absent ownership suppresses announcements
+    rather than guessing. One session at a time — a new attach replaces the
+    old target, which matches one-terminal-one-call reality.
     """
 
     global _SESSION
     with _LOCK:
-        _SESSION = (loop, callback)
+        _SESSION = (loop, callback, owner_session_id)
 
 
 def detach_session() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import types
 
 import talk_audio
 import talk_cli
+import talk_host
 
 
 def test_session_update_keeps_type_drops_model():
@@ -150,6 +151,22 @@ def test_subagent_stop_messages_verbs_track_the_host_statuses():
 
 def test_subagent_stop_messages_without_an_id_say_nothing():
     assert talk_cli.subagent_stop_messages({}) == []
+
+
+def test_active_parent_session_id_comes_from_the_bound_context():
+    talk_host.bind_ctx(types.SimpleNamespace(active_parent_session_id="parent-sess"))
+    try:
+        assert talk_cli._active_parent_session_id() == "parent-sess"
+    finally:
+        talk_host.bind_ctx(None)
+
+
+def test_old_host_without_active_parent_session_id_fails_closed():
+    talk_host.bind_ctx(types.SimpleNamespace())
+    try:
+        assert talk_cli._active_parent_session_id() is None
+    finally:
+        talk_host.bind_ctx(None)
 
 
 def test_landed_note_messages_are_trusted_but_keep_the_shape():

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -133,7 +133,7 @@ def test_nested_children_still_degrade_the_ledger():
 def test_stop_announces_a_top_level_child_through_the_loop():
     events: list[dict] = []
     loop = _StubLoop()
-    talk_lifecycle.attach_session(loop, events.append)
+    talk_lifecycle.attach_session(loop, events.append, "parent-sess")
     _start()
     _stop()
     assert loop.marshalled == 1
@@ -156,7 +156,7 @@ def test_roster_retains_the_parent_session():
 
 def test_nested_children_stop_silently():
     events: list[dict] = []
-    talk_lifecycle.attach_session(_StubLoop(), events.append)
+    talk_lifecycle.attach_session(_StubLoop(), events.append, "parent-sess")
     _start(csid="sess-nested", sid="sa-1-cccc", parent_subagent_id="sa-0-aaaa")
     _stop(csid="sess-nested")
     assert events == []
@@ -169,7 +169,7 @@ def test_no_attached_session_is_fine():
 
 def test_detach_stops_announcements():
     events: list[dict] = []
-    talk_lifecycle.attach_session(_StubLoop(), events.append)
+    talk_lifecycle.attach_session(_StubLoop(), events.append, "parent-sess")
     talk_lifecycle.detach_session()
     _start()
     _stop()
@@ -179,9 +179,48 @@ def test_detach_stops_announcements():
 def test_a_closed_loop_is_contained():
     # call_soon_threadsafe raises RuntimeError once a loop closes — the hook
     # must swallow it, because it is running on a HOST thread.
-    talk_lifecycle.attach_session(_StubLoop(raises=RuntimeError("loop closed")), lambda e: None)
+    talk_lifecycle.attach_session(
+        _StubLoop(raises=RuntimeError("loop closed")), lambda e: None, "parent-sess"
+    )
     _start()
     _stop()  # no exception is the assertion
+
+
+def test_foreign_parent_stop_is_not_announced_but_still_degrades_the_ledger():
+    events: list[dict] = []
+    talk_lifecycle.attach_session(_StubLoop(), events.append, "other-parent")
+    _start()
+    talk_steer.record_queued("sa-0-aaaa", "focus on pricing")
+
+    _stop()
+
+    assert events == []
+    assert "finished before I could confirm" in talk_steer.notes_summary()
+
+
+def test_missing_event_parent_is_not_announced_but_still_degrades_the_ledger():
+    events: list[dict] = []
+    talk_lifecycle.attach_session(_StubLoop(), events.append, "parent-sess")
+    _start(parent_session_id=None)
+    talk_steer.record_queued("sa-0-aaaa", "focus on pricing")
+
+    _stop()
+
+    assert events == []
+    assert "finished before I could confirm" in talk_steer.notes_summary()
+
+
+@pytest.mark.parametrize("owner_session_id", [None, ""])
+def test_missing_owner_rejects_all_announcements(owner_session_id):
+    events: list[dict] = []
+    talk_lifecycle.attach_session(_StubLoop(), events.append, owner_session_id)
+    _start()
+    talk_steer.record_queued("sa-0-aaaa", "focus on pricing")
+
+    _stop()
+
+    assert events == []
+    assert "finished before I could confirm" in talk_steer.notes_summary()
 
 
 # -- fail-open ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- bind each Talk session to the exact Hermes parent session ID
- suppress foreign or unowned subagent lifecycle announcements fail-closed
- preserve global steering-ledger degradation on child stops
- remain compatible with older Hermes builds by suppressing rather than guessing

## Dependency
Full announcement delivery activates when Hermes exposes PluginContext.active_parent_session_id: https://github.com/NousResearch/hermes-agent/pull/79716

## Verification
- 546-test integrated suite passes on current Talk main
- focused lifecycle ownership gate passed
- Ruff, Node syntax, and diff checks pass

Closes #4