### PR TITLE
feat(talk): render canonical replies with native realtime audio

### DIFF
--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -303,6 +303,9 @@ if _CORE_IMPORT_ERROR is None:
             self._active_responses: dict[str, tuple[str, _ResponseBinding]] = {}
             self._response_items: dict[str, str] = {}
             self._item_responses: dict[str, str] = {}
+            self._final_output_transcripts: dict[tuple[str, str], str] = {}
+            self._audio_delta_items: set[tuple[str, str]] = set()
+            self._audio_done_items: set[tuple[str, str]] = set()
             self._completed_responses: OrderedDict[str, str] = OrderedDict()
             self._consumed_correlations: OrderedDict[str, None] = OrderedDict()
             self._input_ledger: dict[str, str | None] = {}
@@ -378,8 +381,13 @@ if _CORE_IMPORT_ERROR is None:
                     or correlation in active_correlations
                 ):
                     raise ValueError("correlation token was already used")
-                if len(self._pending_responses) >= self._response_ledger_capacity:
-                    raise ValueError("pending response capacity exhausted")
+                accepted_responses = (
+                    len(self._pending_responses)
+                    + len(self._active_responses)
+                    + len(self._completed_responses)
+                )
+                if accepted_responses >= self._response_ledger_capacity:
+                    raise ValueError("response lifetime capacity exhausted")
                 self._pending_responses[correlation] = binding
             message = {
                 "type": "response.create",
@@ -460,18 +468,26 @@ if _CORE_IMPORT_ERROR is None:
             correlation = self._response_metadata(response)
             if correlation in self._consumed_correlations:
                 raise ValueError("replayed correlation token")
-            binding = self._pending_responses.pop(correlation, None)
+            binding = self._pending_responses.get(correlation)
             if binding is None:
                 raise ValueError("unknown or unsolicited correlation token")
-            if len(self._active_responses) >= self._response_ledger_capacity:
-                raise ValueError("active response capacity exhausted")
+            accepted_responses = (
+                len(self._pending_responses)
+                + len(self._active_responses)
+                + len(self._completed_responses)
+            )
+            if accepted_responses > self._response_ledger_capacity:
+                raise ValueError("response lifetime capacity exhausted")
             if len(self._consumed_correlations) >= self._response_ledger_capacity:
                 raise ValueError("consumed correlation capacity exhausted")
+            del self._pending_responses[correlation]
             self._consumed_correlations[correlation] = None
             self._active_responses[response_id] = (correlation, binding)
             return ResponseStarted(response_id=response_id, turn_id=binding.turn_marker)
 
-        def _active_response(self, event: Mapping[str, Any]) -> tuple[str, _ResponseBinding, str]:
+        def _validate_active_response(
+            self, event: Mapping[str, Any]
+        ) -> tuple[str, str, _ResponseBinding, str]:
             response_id = _validate_identifier(event.get("response_id"), "response_id")
             active = self._active_responses.get(response_id)
             if active is None:
@@ -483,9 +499,13 @@ if _CORE_IMPORT_ERROR is None:
                 raise ValueError("output item identity changed for response")
             if known_response is not None and known_response != response_id:
                 raise ValueError("output item is already bound to another response")
+            return response_id, active[0], active[1], item_id
+
+        def _active_response(self, event: Mapping[str, Any]) -> tuple[str, _ResponseBinding, str]:
+            response_id, correlation, binding, item_id = self._validate_active_response(event)
             self._response_items[response_id] = item_id
             self._item_responses[item_id] = response_id
-            return active[0], active[1], item_id
+            return correlation, binding, item_id
 
         def _complete_response(self, event: Mapping[str, Any]):
             response = event.get("response")
@@ -502,24 +522,61 @@ if _CORE_IMPORT_ERROR is None:
                 raise ValueError("response completion correlation mismatch")
             if response.get("status") != "completed":
                 raise ValueError("response status must be completed")
-            output = response.get("output", ())
+            if "output" not in response:
+                raise ValueError("response output is required")
+            output = response["output"]
             if not isinstance(output, (list, tuple)):
                 raise TypeError("response output must be a sequence")
-            for item in output:
-                if not isinstance(item, Mapping):
-                    raise TypeError("response output item must be an object")
-                if item.get("type") in {"function_call", "function_call_output"}:
-                    raise ValueError("function output is forbidden")
-                output_item_id = _validate_identifier(item.get("id"), "output item_id")
-                known_item_id = self._response_items.get(response_id)
-                if known_item_id is not None and output_item_id != known_item_id:
-                    raise ValueError("response completion output item identity changed")
+            if not output:
+                raise ValueError("response output must be nonempty")
+            if len(output) != 1:
+                raise ValueError("response output must contain exactly one item")
+            item = output[0]
+            if not isinstance(item, Mapping):
+                raise TypeError("response output item must be an object")
+            if item.get("type") != "message":
+                raise ValueError("response output item type must be message")
+            if item.get("role") != "assistant":
+                raise ValueError("response output item role must be assistant")
+            if "status" in item and item.get("status") != "completed":
+                raise ValueError("response output item status must be completed")
+            output_item_id = _validate_identifier(item.get("id"), "output item_id")
+            known_item_id = self._response_items.get(response_id)
+            if known_item_id is None or output_item_id != known_item_id:
+                raise ValueError("response completion output item identity changed")
+            content = item.get("content")
+            if not isinstance(content, (list, tuple)):
+                raise TypeError("response output content must be a sequence")
+            if len(content) != 1:
+                raise ValueError("response output content must contain exactly one part")
+            part = content[0]
+            if not isinstance(part, Mapping):
+                raise TypeError("response output content part must be an object")
+            if part.get("type") != "output_audio":
+                raise ValueError("response output content type must be output_audio")
+            if not set(part).issubset({"type", "transcript"}):
+                raise ValueError("response output_audio content has an invalid shape")
+            stream_key = (response_id, output_item_id)
+            final_transcript = self._final_output_transcripts.get(stream_key)
+            if final_transcript is None:
+                raise ValueError("response completion requires transcript done")
+            if "transcript" in part:
+                completion_transcript = _validate_text(part["transcript"], final=True)
+                if completion_transcript != final_transcript:
+                    raise ValueError("response completion transcript conflicts with final text")
+            if stream_key not in self._audio_delta_items:
+                raise ValueError("response completion requires audio delta")
+            if stream_key not in self._audio_done_items:
+                raise ValueError("response completion requires audio done")
             if len(self._completed_responses) >= self._response_ledger_capacity:
                 raise ValueError("completed response capacity exhausted")
             del self._active_responses[response_id]
             item_id = self._response_items.pop(response_id, None)
             if item_id is not None:
                 self._item_responses.pop(item_id, None)
+                self._final_output_transcripts.pop((response_id, item_id), None)
+                self._audio_delta_items.discard((response_id, item_id))
+                self._audio_done_items.discard((response_id, item_id))
             self._completed_responses[response_id] = correlation
             return ResponseCompleted(response_id=response_id, turn_id=binding.turn_marker)
 
@@ -551,7 +608,6 @@ if _CORE_IMPORT_ERROR is None:
             if event_type == "response.created":
                 return self._bind_response_created(event)
             if event_type == "response.output_audio.delta":
-                _correlation, binding, item_id = self._active_response(event)
                 delta = event.get("delta")
                 if not isinstance(delta, str) or not delta:
                     raise ValueError("output audio delta must be nonempty base64 text")
@@ -561,10 +617,16 @@ if _CORE_IMPORT_ERROR is None:
                     raise ValueError("output audio delta is malformed base64") from exc
                 if not data:
                     raise ValueError("output audio delta decoded to empty data")
+                response_id, _correlation, binding, item_id = (
+                    self._validate_active_response(event)
+                )
+                self._response_items[response_id] = item_id
+                self._item_responses[item_id] = response_id
+                self._audio_delta_items.add((response_id, item_id))
                 return OutputAudio(
                     data=data,
                     item_id=item_id,
-                    response_id=event["response_id"],
+                    response_id=response_id,
                     turn_id=binding.turn_marker,
                 )
             if event_type in {
@@ -572,13 +634,27 @@ if _CORE_IMPORT_ERROR is None:
                 "response.output_audio_transcript.done",
             }:
                 final = event_type.endswith(".done")
-                _correlation, binding, item_id = self._active_response(event)
                 text = _validate_text(
                     event.get("transcript" if final else "delta"), final=final
                 )
+                response_id, _correlation, binding, item_id = (
+                    self._validate_active_response(event)
+                )
+                transcript_key = (response_id, item_id)
+                terminal_text = self._final_output_transcripts.get(transcript_key)
+                if terminal_text is not None:
+                    if not final:
+                        raise ValueError("output transcript is already terminal")
+                    if terminal_text == text:
+                        raise ValueError("output transcript terminal event was replayed")
+                    raise ValueError("conflicting terminal output transcript")
+                self._response_items[response_id] = item_id
+                self._item_responses[item_id] = response_id
+                if final:
+                    self._final_output_transcripts[transcript_key] = text
                 return OutputTranscript(
                     item_id=item_id,
-                    response_id=event["response_id"],
+                    response_id=response_id,
                     turn_id=binding.turn_marker,
                     text=text,
                     final=final,
@@ -587,8 +663,18 @@ if _CORE_IMPORT_ERROR is None:
                 return self._complete_response(event)
             if "function_call" in event_type:
                 raise ValueError(f"function/tool output is forbidden: {event_type}")
+            if event_type == "response.output_audio.done":
+                response_id, _correlation, _binding, item_id = (
+                    self._validate_active_response(event)
+                )
+                stream_key = (response_id, item_id)
+                if stream_key in self._audio_done_items:
+                    raise ValueError("output audio done event was replayed")
+                self._response_items[response_id] = item_id
+                self._item_responses[item_id] = response_id
+                self._audio_done_items.add(stream_key)
+                return None
             if event_type in {
-                "response.output_audio.done",
                 "response.content_part.added",
                 "response.content_part.done",
                 "response.output_item.added",
@@ -647,6 +733,9 @@ if _CORE_IMPORT_ERROR is None:
                 self._active_responses.clear()
                 self._response_items.clear()
                 self._item_responses.clear()
+                self._final_output_transcripts.clear()
+                self._audio_delta_items.clear()
+                self._audio_done_items.clear()
                 self._completed_responses.clear()
                 self._consumed_correlations.clear()
 

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -13,7 +13,7 @@ import base64
 import binascii
 import secrets
 from collections import OrderedDict
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -183,6 +183,59 @@ if _CORE_IMPORT_ERROR is None:
     )
     _OUTPUT_ITEM_KEYS = frozenset({"id", "type", "role", "status", "content"})
     _OUTPUT_AUDIO_PART_KEYS = frozenset({"type", "transcript"})
+    _OUTPUT_EVENT_TYPES = frozenset(
+        {
+            "response.created",
+            "response.output_item.added",
+            "response.output_item.done",
+            "response.content_part.added",
+            "response.content_part.done",
+            "response.output_audio.delta",
+            "response.output_audio.done",
+            "response.output_audio_transcript.delta",
+            "response.output_audio_transcript.done",
+            "conversation.item.done",
+            "response.done",
+        }
+    )
+    _FORBIDDEN_OUTPUT_AUTHORITY_KEYS = frozenset(
+        {
+            "tool_calls",
+            "function_call",
+            "function",
+            "tool",
+            "tools",
+            "tool_choice",
+            "call_id",
+            "name",
+            "arguments",
+            "function_call_output",
+        }
+    )
+    _FORBIDDEN_OUTPUT_AUTHORITY_TYPES = frozenset(
+        {"function_call", "function_call_output", "tool", "tool_call"}
+    )
+
+    def _validate_output_event_authority(value: Any) -> None:
+        if isinstance(value, Mapping):
+            forbidden = _FORBIDDEN_OUTPUT_AUTHORITY_KEYS.intersection(value)
+            if forbidden:
+                raise ValueError(
+                    f"output event has forbidden structured authority: {sorted(forbidden)[0]}"
+                )
+            discriminator = value.get("type")
+            if (
+                isinstance(discriminator, str)
+                and discriminator in _FORBIDDEN_OUTPUT_AUTHORITY_TYPES
+            ):
+                raise ValueError(
+                    f"output event has forbidden structured authority type: {discriminator}"
+                )
+            for nested in value.values():
+                _validate_output_event_authority(nested)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            for nested in value:
+                _validate_output_event_authority(nested)
 
     @dataclass(frozen=True, slots=True)
     class _ResponseBinding:
@@ -644,6 +697,8 @@ if _CORE_IMPORT_ERROR is None:
             event_type = event.get("type")
             if not isinstance(event_type, str) or not event_type:
                 raise ValueError("provider event type must be a nonblank string")
+            if event_type in _OUTPUT_EVENT_TYPES:
+                _validate_output_event_authority(event)
             if event_type == "session.created":
                 session = event.get("session")
                 session_id = _validate_identifier(

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -181,6 +181,8 @@ if _CORE_IMPORT_ERROR is None:
             else set()
         )
     )
+    _OUTPUT_ITEM_KEYS = frozenset({"id", "type", "role", "status", "content"})
+    _OUTPUT_AUDIO_PART_KEYS = frozenset({"type", "transcript"})
 
     @dataclass(frozen=True, slots=True)
     class _ResponseBinding:
@@ -306,6 +308,11 @@ if _CORE_IMPORT_ERROR is None:
             self._final_output_transcripts: dict[tuple[str, str], str] = {}
             self._audio_delta_items: set[tuple[str, str]] = set()
             self._audio_done_items: set[tuple[str, str]] = set()
+            self._output_item_added: set[tuple[str, str]] = set()
+            self._content_part_added: set[tuple[str, str]] = set()
+            self._content_part_done: set[tuple[str, str]] = set()
+            self._output_item_done: set[tuple[str, str]] = set()
+            self._conversation_item_done: set[tuple[str, str]] = set()
             self._completed_responses: OrderedDict[str, str] = OrderedDict()
             self._consumed_correlations: OrderedDict[str, None] = OrderedDict()
             self._input_ledger: dict[str, str | None] = {}
@@ -507,6 +514,74 @@ if _CORE_IMPORT_ERROR is None:
             self._item_responses[item_id] = response_id
             return correlation, binding, item_id
 
+        def _validate_output_audio_part(
+            self,
+            part: Any,
+            *,
+            response_id: str,
+            item_id: str,
+            context: str,
+        ) -> Mapping[str, Any]:
+            if not isinstance(part, Mapping):
+                raise TypeError(f"{context} requires an output_audio part object")
+            if not set(part).issubset(_OUTPUT_AUDIO_PART_KEYS):
+                raise ValueError(f"{context} output_audio part has an invalid authority shape")
+            if part.get("type") != "output_audio":
+                raise ValueError(f"{context} content type must be output_audio")
+            if "transcript" in part:
+                transcript = _validate_text(part["transcript"], final=True)
+                terminal = self._final_output_transcripts.get((response_id, item_id))
+                if terminal is not None and transcript != terminal:
+                    raise ValueError(f"{context} transcript conflicts with final text")
+            return part
+
+        def _validate_output_item_shape(
+            self,
+            item: Any,
+            *,
+            response_id: str,
+            stage: str,
+        ) -> tuple[str, Mapping[str, Any] | None]:
+            if not isinstance(item, Mapping):
+                raise TypeError(f"{stage} requires an output item object")
+            if not set(item).issubset(_OUTPUT_ITEM_KEYS):
+                raise ValueError(f"{stage} output item has an invalid authority shape")
+            if item.get("type") != "message":
+                raise ValueError(f"{stage} output item type must be message")
+            if item.get("role") != "assistant":
+                raise ValueError(f"{stage} output item role must be assistant")
+            item_id = _validate_identifier(item.get("id"), "output item_id")
+            status = item.get("status")
+            if stage == "response.output_item.added":
+                if status is not None and status != "in_progress":
+                    raise ValueError("added output item status must be in_progress")
+            elif status is not None and status != "completed":
+                raise ValueError(f"{stage} output item status must be completed")
+            if "content" not in item:
+                raise ValueError(f"{stage} output item content is required")
+            content = item["content"]
+            if not isinstance(content, (list, tuple)):
+                raise TypeError(f"{stage} output item content must be a sequence")
+            if stage == "response.output_item.added" and not content:
+                return item_id, None
+            if len(content) != 1:
+                raise ValueError(f"{stage} output item content must contain exactly one part")
+            part = self._validate_output_audio_part(
+                content[0],
+                response_id=response_id,
+                item_id=item_id,
+                context=stage,
+            )
+            return item_id, part
+
+        @staticmethod
+        def _note_lifecycle_stage(
+            observed: set[tuple[str, str]], key: tuple[str, str], event_type: str
+        ) -> None:
+            if key in observed:
+                raise ValueError(f"{event_type} was replayed")
+            observed.add(key)
+
         def _complete_response(self, event: Mapping[str, Any]):
             response = event.get("response")
             if not isinstance(response, Mapping):
@@ -532,38 +607,18 @@ if _CORE_IMPORT_ERROR is None:
             if len(output) != 1:
                 raise ValueError("response output must contain exactly one item")
             item = output[0]
-            if not isinstance(item, Mapping):
-                raise TypeError("response output item must be an object")
-            if item.get("type") != "message":
-                raise ValueError("response output item type must be message")
-            if item.get("role") != "assistant":
-                raise ValueError("response output item role must be assistant")
-            if "status" in item and item.get("status") != "completed":
-                raise ValueError("response output item status must be completed")
-            output_item_id = _validate_identifier(item.get("id"), "output item_id")
+            output_item_id, _part = self._validate_output_item_shape(
+                item,
+                response_id=response_id,
+                stage="response.done",
+            )
             known_item_id = self._response_items.get(response_id)
             if known_item_id is None or output_item_id != known_item_id:
                 raise ValueError("response completion output item identity changed")
-            content = item.get("content")
-            if not isinstance(content, (list, tuple)):
-                raise TypeError("response output content must be a sequence")
-            if len(content) != 1:
-                raise ValueError("response output content must contain exactly one part")
-            part = content[0]
-            if not isinstance(part, Mapping):
-                raise TypeError("response output content part must be an object")
-            if part.get("type") != "output_audio":
-                raise ValueError("response output content type must be output_audio")
-            if not set(part).issubset({"type", "transcript"}):
-                raise ValueError("response output_audio content has an invalid shape")
             stream_key = (response_id, output_item_id)
             final_transcript = self._final_output_transcripts.get(stream_key)
             if final_transcript is None:
                 raise ValueError("response completion requires transcript done")
-            if "transcript" in part:
-                completion_transcript = _validate_text(part["transcript"], final=True)
-                if completion_transcript != final_transcript:
-                    raise ValueError("response completion transcript conflicts with final text")
             if stream_key not in self._audio_delta_items:
                 raise ValueError("response completion requires audio delta")
             if stream_key not in self._audio_done_items:
@@ -577,6 +632,11 @@ if _CORE_IMPORT_ERROR is None:
                 self._final_output_transcripts.pop((response_id, item_id), None)
                 self._audio_delta_items.discard((response_id, item_id))
                 self._audio_done_items.discard((response_id, item_id))
+                self._output_item_added.discard((response_id, item_id))
+                self._content_part_added.discard((response_id, item_id))
+                self._content_part_done.discard((response_id, item_id))
+                self._output_item_done.discard((response_id, item_id))
+                self._conversation_item_done.discard((response_id, item_id))
             self._completed_responses[response_id] = correlation
             return ResponseCompleted(response_id=response_id, turn_id=binding.turn_marker)
 
@@ -674,29 +734,64 @@ if _CORE_IMPORT_ERROR is None:
                 self._item_responses[item_id] = response_id
                 self._audio_done_items.add(stream_key)
                 return None
-            if event_type in {
-                "response.content_part.added",
-                "response.content_part.done",
-                "response.output_item.added",
-                "response.output_item.done",
-            }:
+            if event_type in {"response.output_item.added", "response.output_item.done"}:
+                response_id = _validate_identifier(event.get("response_id"), "response_id")
+                item_id, _part = self._validate_output_item_shape(
+                    event.get("item"),
+                    response_id=response_id,
+                    stage=event_type,
+                )
                 normalized = dict(event)
-                item = event.get("item")
-                if isinstance(item, Mapping):
-                    if item.get("type") in {"function_call", "function_call_output"}:
-                        raise ValueError("function/tool output is forbidden")
-                    normalized.setdefault("item_id", item.get("id"))
-                self._active_response(normalized)
+                normalized["item_id"] = item_id
+                response_id, _correlation, _binding, item_id = self._validate_active_response(
+                    normalized
+                )
+                observed = (
+                    self._output_item_added
+                    if event_type.endswith(".added")
+                    else self._output_item_done
+                )
+                self._note_lifecycle_stage(observed, (response_id, item_id), event_type)
+                self._response_items[response_id] = item_id
+                self._item_responses[item_id] = response_id
+                return None
+            if event_type in {"response.content_part.added", "response.content_part.done"}:
+                response_id, _correlation, _binding, item_id = self._validate_active_response(event)
+                self._validate_output_audio_part(
+                    event.get("part"),
+                    response_id=response_id,
+                    item_id=item_id,
+                    context=event_type,
+                )
+                observed = (
+                    self._content_part_added
+                    if event_type.endswith(".added")
+                    else self._content_part_done
+                )
+                self._note_lifecycle_stage(observed, (response_id, item_id), event_type)
+                self._response_items[response_id] = item_id
+                self._item_responses[item_id] = response_id
                 return None
             if event_type == "conversation.item.done":
                 item = event.get("item")
                 if not isinstance(item, Mapping):
                     raise TypeError("conversation.item.done requires an item object")
-                if item.get("type") in {"function_call", "function_call_output"}:
-                    raise ValueError("function/tool output is forbidden")
                 item_id = _validate_identifier(item.get("id"), "item_id")
-                if item_id not in self._item_responses:
+                response_id = self._item_responses.get(item_id)
+                if response_id is None or response_id not in self._active_responses:
                     raise ValueError("conversation item is not bound to an active response")
+                validated_item_id, _part = self._validate_output_item_shape(
+                    item,
+                    response_id=response_id,
+                    stage=event_type,
+                )
+                if validated_item_id != item_id:
+                    raise ValueError("conversation output item identity changed")
+                self._note_lifecycle_stage(
+                    self._conversation_item_done,
+                    (response_id, item_id),
+                    event_type,
+                )
                 return None
             if event_type == "error":
                 error = event.get("error")
@@ -736,6 +831,11 @@ if _CORE_IMPORT_ERROR is None:
                 self._final_output_transcripts.clear()
                 self._audio_delta_items.clear()
                 self._audio_done_items.clear()
+                self._output_item_added.clear()
+                self._content_part_added.clear()
+                self._content_part_done.clear()
+                self._output_item_done.clear()
+                self._conversation_item_done.clear()
                 self._completed_responses.clear()
                 self._consumed_correlations.clear()
 

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -1,4 +1,4 @@
-"""Defensive Hermes core API-v2 input-only OpenAI Realtime adapter.
+"""Defensive Hermes core API-v2 OpenAI Realtime adapter.
 
 The optional core boundary is deliberately contained in this module.  Legacy
 Talk never imports Hermes core through its OpenAI transport, and this module
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
+import secrets
+from collections import OrderedDict
 from collections.abc import AsyncIterator, Callable, Mapping
+from dataclasses import dataclass
 from typing import Any
 
 try:
@@ -27,7 +31,9 @@ except ImportError:  # pragma: no cover - flat-module fallback
     from talk_openai_realtime import OpenAIWireEOF, OpenAIWireError, _OpenAIWireSession
 
 _CORE_IMPORT_ERROR: BaseException | None = None
+_EXPLICIT_OUTPUT_AVAILABLE = False
 try:
+    from agent import realtime_voice_provider as _core_contract
     from agent.realtime_voice_provider import (
         REALTIME_VOICE_PROVIDER_API_VERSION,
         InputTranscript,
@@ -69,6 +75,35 @@ try:
     ):
         if not isinstance(enum_type, type) or any(not hasattr(enum_type, name) for name in names):
             raise ImportError("Hermes realtime voice API-v2 enum shape is incompatible")
+    try:
+        RealtimeInputAudioFormat = _core_contract.RealtimeInputAudioFormat
+        RealtimeOutputAudioFormat = _core_contract.RealtimeOutputAudioFormat
+        RealtimeResponseRequest = _core_contract.RealtimeResponseRequest
+        ResponseStarted = _core_contract.ResponseStarted
+        OutputAudio = _core_contract.OutputAudio
+        OutputTranscript = _core_contract.OutputTranscript
+        ResponseCompleted = _core_contract.ResponseCompleted
+        _EXPLICIT_OUTPUT_AVAILABLE = all(
+            isinstance(symbol, type)
+            for symbol in (
+                RealtimeInputAudioFormat,
+                RealtimeOutputAudioFormat,
+                RealtimeResponseRequest,
+                ResponseStarted,
+                OutputAudio,
+                OutputTranscript,
+                ResponseCompleted,
+            )
+        ) and all(
+            hasattr(RealtimeCapability, name)
+            for name in (
+                "EXPLICIT_RESPONSE",
+                "RESPONSE_METADATA_ECHO",
+                "OUTPUT_TRANSCRIPTION",
+            )
+        )
+    except (AttributeError, ImportError):
+        _EXPLICIT_OUTPUT_AVAILABLE = False
 except Exception as exc:  # noqa: BLE001 - optional core must never poison legacy imports
     _CORE_IMPORT_ERROR = exc
 
@@ -82,6 +117,12 @@ def core_provider_available() -> bool:
     """Return only whether the exact optional Hermes core API-v2 is importable."""
 
     return _CORE_IMPORT_ERROR is None
+
+
+def explicit_output_available() -> bool:
+    """Return whether the installed API-v2 exposes native explicit output."""
+
+    return _CORE_IMPORT_ERROR is None and _EXPLICIT_OUTPUT_AVAILABLE
 
 
 def core_provider_diagnostic() -> dict[str, bool]:
@@ -104,12 +145,49 @@ if _CORE_IMPORT_ERROR is None:
     SUPPORTED_AUDIO_FORMAT = RealtimeAudioFormat(
         mime_type="audio/pcm", sample_rate_hz=24_000, channels=1
     )
-    CORE_CAPABILITIES = frozenset(
-        {
-            RealtimeCapability.INPUT_TRANSCRIPTION,
-            RealtimeCapability.INPUT_COMMIT_EVENTS,
-        }
+    SUPPORTED_OUTPUT_AUDIO_FORMAT = (
+        RealtimeOutputAudioFormat(
+            mime_type="audio/pcm",
+            sample_rate_hz=24_000,
+            channels=1,
+            sample_encoding="pcm_s16le",
+            sample_width_bytes=2,
+            endianness="little",
+        )
+        if _EXPLICIT_OUTPUT_AVAILABLE
+        else None
     )
+    SUPPORTED_INPUT_AUDIO_FORMAT = (
+        RealtimeInputAudioFormat(
+            mime_type="audio/pcm",
+            sample_rate_hz=24_000,
+            channels=1,
+            sample_encoding="pcm_s16le",
+            sample_width_bytes=2,
+            endianness="little",
+        )
+        if _EXPLICIT_OUTPUT_AVAILABLE
+        else None
+    )
+    CORE_CAPABILITIES = frozenset(
+        {RealtimeCapability.INPUT_TRANSCRIPTION, RealtimeCapability.INPUT_COMMIT_EVENTS}
+        | (
+            {
+                RealtimeCapability.EXPLICIT_RESPONSE,
+                RealtimeCapability.RESPONSE_METADATA_ECHO,
+                RealtimeCapability.OUTPUT_TRANSCRIPTION,
+            }
+            if _EXPLICIT_OUTPUT_AVAILABLE
+            else set()
+        )
+    )
+
+    @dataclass(frozen=True, slots=True)
+    class _ResponseBinding:
+        durable_session_id: str
+        assistant_message_id: int
+        turn_marker: str
+        content_digest: str
 
     def _validate_identifier(value: Any, field_name: str) -> str:
         if (
@@ -164,6 +242,19 @@ if _CORE_IMPORT_ERROR is None:
             raise ValueError("the input-only core provider does not accept tools")
         if setup.audio is not None and setup.audio != SUPPORTED_AUDIO_FORMAT:
             raise ValueError("the input-only core provider requires audio/pcm at 24000 Hz mono")
+        if _EXPLICIT_OUTPUT_AVAILABLE:
+            if (
+                setup.input_audio is not None
+                and setup.input_audio != SUPPORTED_INPUT_AUDIO_FORMAT
+            ):
+                raise ValueError("the core provider requires exact 24kHz mono PCM input audio")
+            if (
+                setup.output_audio is not None
+                and setup.output_audio != SUPPORTED_OUTPUT_AUDIO_FORMAT
+            ):
+                raise ValueError("the core provider requires exact 24kHz mono PCM output audio")
+            if setup.automatic_response:
+                raise ValueError("automatic_response must remain false in the core lane")
         options = setup.provider_options
         unknown = set(options) - {"automatic_response", "capabilities"}
         if unknown:
@@ -196,11 +287,24 @@ if _CORE_IMPORT_ERROR is None:
             wire,
             audio_format: RealtimeAudioFormat,
             ledger_capacity: int,
+            voice: str,
+            response_ledger_capacity: int,
+            token_factory: Callable[[], str],
         ) -> None:
             super().__init__(CORE_CAPABILITIES)
             self._wire = wire
             self._audio_format = audio_format
             self._ledger_capacity = ledger_capacity
+            self._voice = voice
+            self._response_ledger_capacity = response_ledger_capacity
+            self._token_factory = token_factory
+            self._response_lock = asyncio.Lock()
+            self._pending_responses: dict[str, _ResponseBinding] = {}
+            self._active_responses: dict[str, tuple[str, _ResponseBinding]] = {}
+            self._response_items: dict[str, str] = {}
+            self._item_responses: dict[str, str] = {}
+            self._completed_responses: OrderedDict[str, str] = OrderedDict()
+            self._consumed_correlations: OrderedDict[str, None] = OrderedDict()
             self._input_ledger: dict[str, str | None] = {}
             self._provider_session_id: str | None = None
             self._terminal = False
@@ -253,6 +357,69 @@ if _CORE_IMPORT_ERROR is None:
             del batch_id, results
             raise RuntimeError("the input-only core provider does not accept tool results")
 
+        async def _start_response(self, request) -> None:
+            if request.output_audio_format != SUPPORTED_OUTPUT_AUDIO_FORMAT:
+                raise ValueError("explicit response output audio format is unsupported")
+            correlation = _validate_identifier(self._token_factory(), "correlation token")
+            binding = _ResponseBinding(
+                durable_session_id=request.durable_session_id,
+                assistant_message_id=request.assistant_message_id,
+                turn_marker=request.turn_marker,
+                content_digest=request.content_digest,
+            )
+            async with self._response_lock:
+                active_correlations = {
+                    active_correlation
+                    for active_correlation, _binding in self._active_responses.values()
+                }
+                if (
+                    correlation in self._pending_responses
+                    or correlation in self._consumed_correlations
+                    or correlation in active_correlations
+                ):
+                    raise ValueError("correlation token was already used")
+                if len(self._pending_responses) >= self._response_ledger_capacity:
+                    raise ValueError("pending response capacity exhausted")
+                self._pending_responses[correlation] = binding
+            message = {
+                "type": "response.create",
+                "event_id": f"evt-{secrets.token_urlsafe(24)}",
+                "response": {
+                    "conversation": "none",
+                    "metadata": {"correlation": correlation},
+                    "input": [
+                        {
+                            "type": "message",
+                            "role": "user",
+                            "content": [
+                                {"type": "input_text", "text": request.canonical_text}
+                            ],
+                        }
+                    ],
+                    "instructions": (
+                        "Render the sole user input as speech verbatim. Speak every character's "
+                        "words and punctuation naturally, but add, remove, or paraphrase nothing. "
+                        "Do not preface or explain."
+                    ),
+                    "output_modalities": ["audio"],
+                    "audio": {
+                        "output": {
+                            "voice": self._voice,
+                            "format": {"type": "audio/pcm", "rate": 24_000},
+                        }
+                    },
+                    "tools": [],
+                    "tool_choice": "none",
+                },
+            }
+            try:
+                await self._send_wire(message)
+            except BaseException:
+                async with self._response_lock:
+                    if self._pending_responses.get(correlation) == binding:
+                        del self._pending_responses[correlation]
+                raise
+
         def _input_transcript(self, event: Mapping[str, Any], *, final: bool) -> InputTranscript:
             explicit_finality = event.get("final")
             if "final" in event and not isinstance(explicit_finality, bool):
@@ -275,6 +442,86 @@ if _CORE_IMPORT_ERROR is None:
                 role=TranscriptRole.OPERATOR,
                 provenance=TranscriptProvenance.OPERATOR_INPUT,
             )
+
+        @staticmethod
+        def _response_metadata(response: Mapping[str, Any]) -> str:
+            metadata = response.get("metadata")
+            if not isinstance(metadata, Mapping) or set(metadata) != {"correlation"}:
+                raise ValueError("response metadata must contain only the correlation token")
+            return _validate_identifier(metadata.get("correlation"), "correlation token")
+
+        def _bind_response_created(self, event: Mapping[str, Any]):
+            response = event.get("response")
+            if not isinstance(response, Mapping):
+                raise TypeError("response.created requires a response object")
+            response_id = _validate_identifier(response.get("id"), "response_id")
+            if response_id in self._active_responses or response_id in self._completed_responses:
+                raise ValueError("duplicate or conflicting provider response_id")
+            correlation = self._response_metadata(response)
+            if correlation in self._consumed_correlations:
+                raise ValueError("replayed correlation token")
+            binding = self._pending_responses.pop(correlation, None)
+            if binding is None:
+                raise ValueError("unknown or unsolicited correlation token")
+            if len(self._active_responses) >= self._response_ledger_capacity:
+                raise ValueError("active response capacity exhausted")
+            if len(self._consumed_correlations) >= self._response_ledger_capacity:
+                raise ValueError("consumed correlation capacity exhausted")
+            self._consumed_correlations[correlation] = None
+            self._active_responses[response_id] = (correlation, binding)
+            return ResponseStarted(response_id=response_id, turn_id=binding.turn_marker)
+
+        def _active_response(self, event: Mapping[str, Any]) -> tuple[str, _ResponseBinding, str]:
+            response_id = _validate_identifier(event.get("response_id"), "response_id")
+            active = self._active_responses.get(response_id)
+            if active is None:
+                raise ValueError("output event references an unbound response")
+            item_id = _validate_identifier(event.get("item_id"), "item_id")
+            known_item = self._response_items.get(response_id)
+            known_response = self._item_responses.get(item_id)
+            if known_item is not None and known_item != item_id:
+                raise ValueError("output item identity changed for response")
+            if known_response is not None and known_response != response_id:
+                raise ValueError("output item is already bound to another response")
+            self._response_items[response_id] = item_id
+            self._item_responses[item_id] = response_id
+            return active[0], active[1], item_id
+
+        def _complete_response(self, event: Mapping[str, Any]):
+            response = event.get("response")
+            if not isinstance(response, Mapping):
+                raise TypeError("response.done requires a response object")
+            response_id = _validate_identifier(response.get("id"), "response_id")
+            if response_id in self._completed_responses:
+                raise ValueError("response completion was replayed")
+            active = self._active_responses.get(response_id)
+            if active is None:
+                raise ValueError("completion references an unbound response")
+            correlation, binding = active
+            if self._response_metadata(response) != correlation:
+                raise ValueError("response completion correlation mismatch")
+            if response.get("status") != "completed":
+                raise ValueError("response status must be completed")
+            output = response.get("output", ())
+            if not isinstance(output, (list, tuple)):
+                raise TypeError("response output must be a sequence")
+            for item in output:
+                if not isinstance(item, Mapping):
+                    raise TypeError("response output item must be an object")
+                if item.get("type") in {"function_call", "function_call_output"}:
+                    raise ValueError("function output is forbidden")
+                output_item_id = _validate_identifier(item.get("id"), "output item_id")
+                known_item_id = self._response_items.get(response_id)
+                if known_item_id is not None and output_item_id != known_item_id:
+                    raise ValueError("response completion output item identity changed")
+            if len(self._completed_responses) >= self._response_ledger_capacity:
+                raise ValueError("completed response capacity exhausted")
+            del self._active_responses[response_id]
+            item_id = self._response_items.pop(response_id, None)
+            if item_id is not None:
+                self._item_responses.pop(item_id, None)
+            self._completed_responses[response_id] = correlation
+            return ResponseCompleted(response_id=response_id, turn_id=binding.turn_marker)
 
         def _map_event(self, event: Mapping[str, Any]):
             event_type = event.get("type")
@@ -301,6 +548,70 @@ if _CORE_IMPORT_ERROR is None:
                 return self._input_transcript(event, final=False)
             if event_type == "conversation.item.input_audio_transcription.completed":
                 return self._input_transcript(event, final=True)
+            if event_type == "response.created":
+                return self._bind_response_created(event)
+            if event_type == "response.output_audio.delta":
+                _correlation, binding, item_id = self._active_response(event)
+                delta = event.get("delta")
+                if not isinstance(delta, str) or not delta:
+                    raise ValueError("output audio delta must be nonempty base64 text")
+                try:
+                    data = base64.b64decode(delta, validate=True)
+                except (binascii.Error, ValueError, TypeError) as exc:
+                    raise ValueError("output audio delta is malformed base64") from exc
+                if not data:
+                    raise ValueError("output audio delta decoded to empty data")
+                return OutputAudio(
+                    data=data,
+                    item_id=item_id,
+                    response_id=event["response_id"],
+                    turn_id=binding.turn_marker,
+                )
+            if event_type in {
+                "response.output_audio_transcript.delta",
+                "response.output_audio_transcript.done",
+            }:
+                final = event_type.endswith(".done")
+                _correlation, binding, item_id = self._active_response(event)
+                text = _validate_text(
+                    event.get("transcript" if final else "delta"), final=final
+                )
+                return OutputTranscript(
+                    item_id=item_id,
+                    response_id=event["response_id"],
+                    turn_id=binding.turn_marker,
+                    text=text,
+                    final=final,
+                )
+            if event_type == "response.done":
+                return self._complete_response(event)
+            if "function_call" in event_type:
+                raise ValueError(f"function/tool output is forbidden: {event_type}")
+            if event_type in {
+                "response.output_audio.done",
+                "response.content_part.added",
+                "response.content_part.done",
+                "response.output_item.added",
+                "response.output_item.done",
+            }:
+                normalized = dict(event)
+                item = event.get("item")
+                if isinstance(item, Mapping):
+                    if item.get("type") in {"function_call", "function_call_output"}:
+                        raise ValueError("function/tool output is forbidden")
+                    normalized.setdefault("item_id", item.get("id"))
+                self._active_response(normalized)
+                return None
+            if event_type == "conversation.item.done":
+                item = event.get("item")
+                if not isinstance(item, Mapping):
+                    raise TypeError("conversation.item.done requires an item object")
+                if item.get("type") in {"function_call", "function_call_output"}:
+                    raise ValueError("function/tool output is forbidden")
+                item_id = _validate_identifier(item.get("id"), "item_id")
+                if item_id not in self._item_responses:
+                    raise ValueError("conversation item is not bound to an active response")
+                return None
             if event_type == "error":
                 error = event.get("error")
                 detail = error.get("message") if isinstance(error, Mapping) else error
@@ -328,8 +639,16 @@ if _CORE_IMPORT_ERROR is None:
 
         async def _terminate(self) -> None:
             self._terminal = True
-            await self._wire.close()
-            self._input_ledger.clear()
+            try:
+                await self._wire.close()
+            finally:
+                self._input_ledger.clear()
+                self._pending_responses.clear()
+                self._active_responses.clear()
+                self._response_items.clear()
+                self._item_responses.clear()
+                self._completed_responses.clear()
+                self._consumed_correlations.clear()
 
         def _take_send_failure(self) -> Exception | None:
             failure, self._pending_send_failure = self._pending_send_failure, None
@@ -403,6 +722,8 @@ if _CORE_IMPORT_ERROR is None:
             auth_resolver: Callable[[], Any] = talk_auth.resolve_auth,
             wire_factory: Callable[..., Any] = _OpenAIWireSession,
             ledger_capacity: int = DEFAULT_INPUT_LEDGER_CAPACITY,
+            response_ledger_capacity: int = 1024,
+            token_factory: Callable[[], str] = lambda: secrets.token_urlsafe(32),
         ) -> None:
             if isinstance(ledger_capacity, bool) or not isinstance(ledger_capacity, int):
                 raise TypeError("ledger_capacity must be a positive integer")
@@ -411,6 +732,16 @@ if _CORE_IMPORT_ERROR is None:
             self._auth_resolver = auth_resolver
             self._wire_factory = wire_factory
             self._ledger_capacity = ledger_capacity
+            if (
+                isinstance(response_ledger_capacity, bool)
+                or not isinstance(response_ledger_capacity, int)
+                or response_ledger_capacity <= 0
+            ):
+                raise ValueError("response_ledger_capacity must be a positive integer")
+            if not callable(token_factory):
+                raise TypeError("token_factory must be callable")
+            self._response_ledger_capacity = response_ledger_capacity
+            self._token_factory = token_factory
 
         @property
         def name(self) -> str:
@@ -418,6 +749,8 @@ if _CORE_IMPORT_ERROR is None:
 
         @property
         def display_name(self) -> str:
+            if _EXPLICIT_OUTPUT_AVAILABLE:
+                return "Hermes Talk OpenAI Realtime (native explicit output)"
             return "Hermes Talk OpenAI Realtime (input only)"
 
         def is_available(self) -> bool:
@@ -432,7 +765,13 @@ if _CORE_IMPORT_ERROR is None:
             return bool(model and auth.get("configured"))
 
         def list_models(self):
-            return ({"id": talk_config.talk_model(), "input_only": True},)
+            return (
+                {
+                    "id": talk_config.talk_model(),
+                    "input_only": not _EXPLICIT_OUTPUT_AVAILABLE,
+                    "native_explicit_output": _EXPLICIT_OUTPUT_AVAILABLE,
+                },
+            )
 
         def list_voices(self):
             return tuple({"id": voice} for voice in talk_config.OPENAI_REALTIME_VOICES)
@@ -465,10 +804,15 @@ if _CORE_IMPORT_ERROR is None:
                 wire=wire,
                 audio_format=SUPPORTED_AUDIO_FORMAT,
                 ledger_capacity=self._ledger_capacity,
+                voice=voice,
+                response_ledger_capacity=self._response_ledger_capacity,
+                token_factory=self._token_factory,
             )
 
 else:
     SUPPORTED_AUDIO_FORMAT = None
+    SUPPORTED_INPUT_AUDIO_FORMAT = None
+    SUPPORTED_OUTPUT_AUDIO_FORMAT = None
     CORE_CAPABILITIES = frozenset()
     TalkOpenAIRealtimeProvider = None
 
@@ -478,9 +822,12 @@ __all__ = [
     "DEFAULT_INPUT_LEDGER_CAPACITY",
     "PROVIDER_NAME",
     "SUPPORTED_AUDIO_FORMAT",
+    "SUPPORTED_INPUT_AUDIO_FORMAT",
+    "SUPPORTED_OUTPUT_AUDIO_FORMAT",
     "OpenAIWireEOF",
     "OpenAIWireError",
     "TalkOpenAIRealtimeProvider",
     "core_provider_available",
     "core_provider_diagnostic",
+    "explicit_output_available",
 ]

--- a/talk_core_session.py
+++ b/talk_core_session.py
@@ -18,24 +18,37 @@ CORE_AUDIO_POLL_S = 0.01
 
 
 def build_core_setup():
-    """Build the exact input-only Hermes realtime setup for canonical ingress."""
+    """Build the compatible Hermes realtime setup for canonical Talk ingress."""
 
     if not talk_core_realtime.core_provider_available():
         raise RuntimeError("Hermes realtime voice API-v2 is unavailable")
-    return talk_core_realtime.RealtimeVoiceSetup(
-        model=talk_config.talk_model(),
-        voice=talk_config.talk_voice(),
-        instructions="",
-        tools=(),
-        audio=talk_core_realtime.SUPPORTED_AUDIO_FORMAT,
-        provider_options={
+    setup = {
+        "model": talk_config.talk_model(),
+        "voice": talk_config.talk_voice(),
+        "instructions": "",
+        "tools": (),
+        "audio": talk_core_realtime.SUPPORTED_AUDIO_FORMAT,
+    }
+    if talk_core_realtime.explicit_output_available():
+        setup.update(
+            input_audio=talk_core_realtime.SUPPORTED_INPUT_AUDIO_FORMAT,
+            output_audio=talk_core_realtime.SUPPORTED_OUTPUT_AUDIO_FORMAT,
+            automatic_response=False,
+            provider_options={
+                "capabilities": tuple(
+                    sorted(capability.value for capability in talk_core_realtime.CORE_CAPABILITIES)
+                )
+            },
+        )
+    else:
+        setup["provider_options"] = {
             "automatic_response": False,
             "capabilities": (
                 "input_transcription",
                 "input_commit_events",
             ),
-        },
-    )
+        }
+    return talk_core_realtime.RealtimeVoiceSetup(**setup)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -133,6 +133,77 @@ def collect(session):
     return asyncio.run(scenario())
 
 
+def bind_response(session, correlation, *, response_id="resp-1"):
+    return session._map_event(
+        {
+            "type": "response.created",
+            "response": {"id": response_id, "metadata": {"correlation": correlation}},
+        }
+    )
+
+
+def response_done_event(
+    correlation,
+    *,
+    response_id="resp-1",
+    item_id="item-1",
+    transcript="words",
+    output=None,
+):
+    if output is None:
+        output = [
+            {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": transcript}],
+            }
+        ]
+    return {
+        "type": "response.done",
+        "response": {
+            "id": response_id,
+            "status": "completed",
+            "metadata": {"correlation": correlation},
+            "output": output,
+        },
+    }
+
+
+def complete_bound_response(
+    session, correlation, *, response_id="resp-1", item_id="item-1", transcript="words"
+):
+    for event in (
+        {
+            "type": "response.output_audio.delta",
+            "response_id": response_id,
+            "item_id": item_id,
+            "delta": "cGNt",
+        },
+        {
+            "type": "response.output_audio_transcript.done",
+            "response_id": response_id,
+            "item_id": item_id,
+            "transcript": transcript,
+        },
+        {
+            "type": "response.output_audio.done",
+            "response_id": response_id,
+            "item_id": item_id,
+        },
+    ):
+        session._map_event(event)
+    return session._map_event(
+        response_done_event(
+            correlation,
+            response_id=response_id,
+            item_id=item_id,
+            transcript=transcript,
+        )
+    )
+
+
 def test_exact_api_v2_contract_and_fixed_capabilities():
     expected = frozenset(
         {
@@ -533,6 +604,360 @@ def test_response_capacity_and_close_cleanup_are_fail_closed():
     assert not session._active_responses
     assert not session._completed_responses
     assert not session._consumed_correlations
+
+
+@pytest.mark.parametrize("saturated_stage", ["pending", "bound", "completed"])
+def test_response_lifetime_capacity_is_reserved_before_provider_send(saturated_stage):
+    tokens = iter(("token-1", "token-2"))
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(
+            token_factory=lambda: next(tokens), response_ledger_capacity=1
+        ).open_session(setup())
+        await session.start_response(response_request())
+        if saturated_stage != "pending":
+            bind_response(session, "token-1")
+        if saturated_stage == "completed":
+            complete_bound_response(session, "token-1")
+        with pytest.raises(ValueError, match="capacity"):
+            await session.start_response(
+                response_request(
+                    assistant_message_id=42,
+                    turn_marker="turn-42",
+                    canonical_text="other",
+                    content_digest=hashlib.sha256(b"other").hexdigest(),
+                )
+            )
+        return session
+
+    session = asyncio.run(scenario())
+    assert len(harness.wire.sent) == 1
+    assert "token-2" not in session._pending_responses
+
+
+def test_response_created_validation_is_atomic_and_preserves_pending_reservation():
+    tokens = iter(("token-1", "token-2"))
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(
+            token_factory=lambda: next(tokens), response_ledger_capacity=2
+        ).open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        await session.start_response(
+            response_request(
+                assistant_message_id=42,
+                turn_marker="turn-42",
+                canonical_text="other",
+                content_digest=hashlib.sha256(b"other").hexdigest(),
+            )
+        )
+        before = dict(session._pending_responses)
+        with pytest.raises(ValueError, match="duplicate"):
+            bind_response(session, "token-2", response_id="resp-1")
+        assert session._pending_responses == before
+        with pytest.raises(ValueError, match="metadata"):
+            session._map_event(
+                {
+                    "type": "response.created",
+                    "response": {
+                        "id": "resp-2",
+                        "metadata": {"correlation": "token-2", "extra": True},
+                    },
+                }
+            )
+        assert session._pending_responses == before
+        assert bind_response(session, "token-2", response_id="resp-2") == ResponseStarted(
+            response_id="resp-2", turn_id="turn-42"
+        )
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "late_event,match",
+    [
+        (
+            {
+                "type": "response.output_audio_transcript.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "later",
+            },
+            "terminal",
+        ),
+        (
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "words",
+            },
+            "replayed",
+        ),
+        (
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "changed",
+            },
+            "conflicting",
+        ),
+    ],
+)
+def test_output_transcript_finality_is_terminal_and_exact(late_event, match):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        final = session._map_event(
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "words",
+            }
+        )
+        with pytest.raises(ValueError, match=match):
+            session._map_event(late_event)
+        return session, final
+
+    session, final = asyncio.run(scenario())
+    assert final == OutputTranscript(
+        item_id="item-1",
+        response_id="resp-1",
+        turn_id="turn-41",
+        text="words",
+        final=True,
+    )
+    assert session._final_output_transcripts == {("resp-1", "item-1"): "words"}
+
+
+@pytest.mark.parametrize(
+    "output,match",
+    [
+        ([], "nonempty"),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+            ],
+            "exactly one",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "function_call",
+                    "role": "assistant",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                }
+            ],
+            "message",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                }
+            ],
+            "assistant",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "words"}],
+                }
+            ],
+            "output_audio",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_audio", "transcript": "words"},
+                        {"type": "output_text", "text": "words"},
+                    ],
+                }
+            ],
+            "exactly one",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_audio",
+                            "transcript": "words",
+                            "function_call": {"name": "forbidden"},
+                        }
+                    ],
+                }
+            ],
+            "shape",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_audio", "transcript": "changed"}],
+                }
+            ],
+            "conflicts",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                }
+            ],
+            "status",
+        ),
+        ({"id": "item-1"}, "sequence"),
+    ],
+)
+def test_response_done_rejects_non_exact_audio_only_schema_without_consuming_active(
+    output, match
+):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        for event in (
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            },
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "words",
+            },
+            {
+                "type": "response.output_audio.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+            },
+        ):
+            session._map_event(event)
+        event = response_done_event("token-1", output=output)
+        with pytest.raises((TypeError, ValueError), match=match):
+            session._map_event(event)
+        assert "resp-1" in session._active_responses
+        assert "resp-1" not in session._completed_responses
+
+    asyncio.run(scenario())
+
+
+def test_response_done_requires_output_member():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        event = response_done_event("token-1")
+        del event["response"]["output"]
+        with pytest.raises(ValueError, match="output"):
+            session._map_event(event)
+        assert "resp-1" in session._active_responses
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("omitted", ["audio_delta", "audio_done", "transcript_done"])
+def test_response_done_requires_observed_audio_and_transcript_terminals(omitted):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        events = {
+            "audio_delta": {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            },
+            "audio_done": {
+                "type": "response.output_audio.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+            },
+            "transcript_done": {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "words",
+            },
+        }
+        for name, event in events.items():
+            if name != omitted:
+                session._map_event(event)
+        with pytest.raises(ValueError, match=omitted.replace("_", " ")):
+            session._map_event(response_done_event("token-1"))
+        assert "resp-1" in session._active_responses
+
+    asyncio.run(scenario())
+
+
+def test_response_done_accepts_proven_audio_only_shape_and_clears_stream_state():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        completed = complete_bound_response(session, "token-1")
+        return session, completed
+
+    session, completed = asyncio.run(scenario())
+    assert completed == ResponseCompleted(response_id="resp-1", turn_id="turn-41")
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._final_output_transcripts
+    assert not session._audio_delta_items
+    assert not session._audio_done_items
 
 
 def test_explicit_response_send_failure_cleans_pending_and_is_terminally_visible():

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -204,6 +204,86 @@ def complete_bound_response(
     )
 
 
+def valid_output_lifecycle_events(
+    correlation="token-1", *, response_id="resp-1", item_id="item-1", transcript="words"
+):
+    return [
+        {
+            "type": "response.output_item.added",
+            "response_id": response_id,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "in_progress",
+                "content": [],
+            },
+        },
+        {
+            "type": "response.content_part.added",
+            "response_id": response_id,
+            "item_id": item_id,
+            "part": {"type": "output_audio"},
+        },
+        {
+            "type": "response.output_audio.delta",
+            "response_id": response_id,
+            "item_id": item_id,
+            "delta": "cGNt",
+        },
+        {
+            "type": "response.output_audio_transcript.delta",
+            "response_id": response_id,
+            "item_id": item_id,
+            "delta": transcript[:1],
+        },
+        {
+            "type": "response.output_audio_transcript.done",
+            "response_id": response_id,
+            "item_id": item_id,
+            "transcript": transcript,
+        },
+        {
+            "type": "response.output_audio.done",
+            "response_id": response_id,
+            "item_id": item_id,
+        },
+        {
+            "type": "response.content_part.done",
+            "response_id": response_id,
+            "item_id": item_id,
+            "part": {"type": "output_audio", "transcript": transcript},
+        },
+        {
+            "type": "response.output_item.done",
+            "response_id": response_id,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": transcript}],
+            },
+        },
+        {
+            "type": "conversation.item.done",
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": transcript}],
+            },
+        },
+        response_done_event(
+            correlation,
+            response_id=response_id,
+            item_id=item_id,
+            transcript=transcript,
+        ),
+    ]
+
+
 def test_exact_api_v2_contract_and_fixed_capabilities():
     expected = frozenset(
         {
@@ -321,7 +401,13 @@ def test_bound_response_maps_started_audio_transcript_and_completed():
         {
             "type": "response.output_item.added",
             "response_id": "resp-1",
-            "item": {"id": "item-out-1", "type": "message", "role": "assistant"},
+            "item": {
+                "id": "item-out-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "in_progress",
+                "content": [],
+            },
         },
         {
             "type": "response.content_part.added",
@@ -356,16 +442,28 @@ def test_bound_response_maps_started_audio_transcript_and_completed():
             "type": "response.content_part.done",
             "response_id": "resp-1",
             "item_id": "item-out-1",
-            "part": {"type": "output_audio"},
+            "part": {"type": "output_audio", "transcript": "Exact words, exactly."},
         },
         {
             "type": "response.output_item.done",
             "response_id": "resp-1",
-            "item": {"id": "item-out-1", "type": "message", "role": "assistant"},
+            "item": {
+                "id": "item-out-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": "Exact words, exactly."}],
+            },
         },
         {
             "type": "conversation.item.done",
-            "item": {"id": "item-out-1", "type": "message", "role": "assistant"},
+            "item": {
+                "id": "item-out-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": "Exact words, exactly."}],
+            },
         },
         {
             "type": "response.done",
@@ -958,6 +1056,529 @@ def test_response_done_accepts_proven_audio_only_shape_and_clears_stream_state()
     assert not session._final_output_transcripts
     assert not session._audio_delta_items
     assert not session._audio_done_items
+
+
+@pytest.mark.parametrize(
+    ("prefix", "bad_event"),
+    [
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "tool",
+                    "status": "in_progress",
+                    "content": [],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "output_text",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "function_call",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                    "tool_calls": [],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                    "function": {"name": "forbidden"},
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                    "tool": {"name": "forbidden"},
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": {},
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [{"type": "output_text", "text": "forbidden"}],
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "response.output_item.done",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-wrong",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.done",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.done",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": {"type": "output_audio"},
+                },
+            },
+        ),
+        ([], {"type": "response.content_part.added", "response_id": "resp-1", "item_id": "item-1"}),
+        (
+            [],
+            {
+                "type": "response.content_part.added",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": "output_audio",
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.content_part.added",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {"type": "output_text", "text": "forbidden"},
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {"type": "function_call", "name": "forbidden"},
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {"type": "tool", "name": "forbidden"},
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-1",
+                "item_id": "item-wrong",
+                "part": {"type": "output_audio", "transcript": "words"},
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-wrong",
+                "item_id": "item-1",
+                "part": {"type": "output_audio", "transcript": "words"},
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {"type": "output_audio", "transcript": 7},
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "user",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "function_call",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "forbidden"}],
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                    "function_call": {"name": "forbidden"},
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                    "tool": {"name": "forbidden"},
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                    "tool_calls": [],
+                },
+            },
+        ),
+    ],
+)
+def test_contradictory_output_lifecycle_event_fails_before_sanitized_completion(prefix, bad_event):
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    harness = Harness([created, *prefix, bad_event, *valid_output_lifecycle_events(correlation)])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert harness.wire.closed is True
+    assert session._terminal is True
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"tool_calls": []},
+        {"function_call": {"name": "forbidden"}},
+        {"tool": {"name": "forbidden"}},
+        {"call_id": "call-forbidden"},
+        {"name": "forbidden", "arguments": "{}"},
+        {"content": [{"type": "output_audio", "transcript": "words", "tool": {}}]},
+    ],
+)
+def test_response_done_rejects_extra_authority_before_mutating_direct_state(extra):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        for event in valid_output_lifecycle_events()[:6]:
+            session._map_event(event)
+        output = response_done_event("token-1")["response"]["output"]
+        item = output[0]
+        if "content" in extra:
+            item["content"] = extra["content"]
+        else:
+            item.update(extra)
+        before = (
+            dict(session._active_responses),
+            dict(session._response_items),
+            dict(session._item_responses),
+            dict(session._final_output_transcripts),
+            set(session._audio_delta_items),
+            set(session._audio_done_items),
+            dict(session._completed_responses),
+        )
+        with pytest.raises((TypeError, ValueError)):
+            session._complete_response(response_done_event("token-1", output=output))
+        assert before == (
+            session._active_responses,
+            session._response_items,
+            session._item_responses,
+            session._final_output_transcripts,
+            session._audio_delta_items,
+            session._audio_done_items,
+            session._completed_responses,
+        )
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "bad_event",
+    [
+        {
+            "type": "response.content_part.done",
+            "response_id": "resp-1",
+            "item_id": "item-1",
+            "part": {"type": "output_audio", "transcript": "changed"},
+        },
+        {
+            "type": "response.output_item.done",
+            "response_id": "resp-1",
+            "item": {
+                "id": "item-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": "changed"}],
+            },
+        },
+        {
+            "type": "conversation.item.done",
+            "item": {
+                "id": "item-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": "changed"}],
+            },
+        },
+    ],
+)
+def test_final_lifecycle_transcript_must_match_terminal_text_before_mutation(bad_event):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        for event in valid_output_lifecycle_events()[:6]:
+            session._map_event(event)
+        before = (
+            dict(session._response_items),
+            dict(session._item_responses),
+            set(session._content_part_done),
+            set(session._output_item_done),
+            set(session._conversation_item_done),
+        )
+        with pytest.raises(ValueError, match="conflicts"):
+            session._map_event(bad_event)
+        assert before == (
+            session._response_items,
+            session._item_responses,
+            session._content_part_done,
+            session._output_item_done,
+            session._conversation_item_done,
+        )
+
+    asyncio.run(scenario())
+
+
+def test_response_done_extra_authority_fails_event_pump_and_cleans_terminal_state():
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    done = response_done_event(correlation)
+    done["response"]["output"][0]["tool_calls"] = []
+    harness = Harness([created, *valid_output_lifecycle_events(correlation)[:-1], done])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert session._terminal is True
+    assert not session._active_responses
+    assert not session._completed_responses
+
+
+def test_valid_live_output_lifecycle_completes_exactly_once_and_cleans_terminal_state():
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    harness = Harness([created, *valid_output_lifecycle_events(correlation)])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert sum(isinstance(event, ResponseCompleted) for event in received) == 1
+    assert received[-1] == SessionClosed()
+    assert session._terminal is True
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._completed_responses
+
+
+def test_invalid_intermediate_shape_does_not_mutate_binding_state_directly():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        before = (
+            dict(session._response_items),
+            dict(session._item_responses),
+            dict(session._final_output_transcripts),
+        )
+        with pytest.raises((TypeError, ValueError)):
+            session._map_event(
+                {
+                    "type": "response.output_item.added",
+                    "response_id": "resp-1",
+                    "item": {
+                        "id": "item-1",
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "in_progress",
+                        "content": [],
+                        "tool_calls": [],
+                    },
+                }
+            )
+        assert before == (
+            session._response_items,
+            session._item_responses,
+            session._final_output_transcripts,
+        )
+
+    asyncio.run(scenario())
 
 
 def test_explicit_response_send_failure_cleans_pending_and_is_terminally_visible():

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -866,7 +866,7 @@ def test_output_transcript_finality_is_terminal_and_exact(late_event, match):
                     "content": [{"type": "output_audio", "transcript": "words"}],
                 }
             ],
-            "message",
+            "authority",
         ),
         (
             [
@@ -919,7 +919,7 @@ def test_output_transcript_finality_is_terminal_and_exact(late_event, match):
                     ],
                 }
             ],
-            "shape",
+            "authority",
         ),
         (
             [
@@ -1499,6 +1499,269 @@ def test_final_lifecycle_transcript_must_match_terminal_text_before_mutation(bad
     asyncio.run(scenario())
 
 
+def output_envelope_authority_cases():
+    return [
+        pytest.param(
+            {
+                "type": "response.created",
+                "response": {
+                    "id": "resp-1",
+                    "metadata": {"correlation": "token-1"},
+                    "tool_calls": [],
+                },
+            },
+            ResponseStarted,
+            id="response-created-nested-tool-calls-empty",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                },
+                "tools": [],
+            },
+            ResponseCompleted,
+            id="output-item-added-top-level-tools-empty",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_item.done",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                    "metadata": {"type": "tool_call"},
+                },
+                "function": {},
+            },
+            ResponseCompleted,
+            id="output-item-done-recursive-type-and-function-empty",
+        ),
+        pytest.param(
+            {
+                "type": "response.content_part.added",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {"type": "output_audio"},
+                "tool": {},
+            },
+            ResponseCompleted,
+            id="content-part-added-top-level-tool-empty",
+        ),
+        pytest.param(
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {
+                    "type": "output_audio",
+                    "transcript": "words",
+                    "tool_choice": "none",
+                },
+            },
+            ResponseCompleted,
+            id="content-part-done-nested-tool-choice",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+                "function_call": {"name": "forbidden"},
+            },
+            OutputAudio,
+            id="output-audio-delta-function-call",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_audio.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "arguments": "{}",
+            },
+            ResponseCompleted,
+            id="output-audio-done-arguments-empty-object",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_audio_transcript.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "w",
+                "call_id": "call-forbidden",
+            },
+            OutputTranscript,
+            id="output-transcript-delta-call-id",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "words",
+                "function_call_output": "",
+            },
+            OutputTranscript,
+            id="output-transcript-done-function-call-output-empty",
+        ),
+        pytest.param(
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+                "function_call": {},
+            },
+            ResponseCompleted,
+            id="conversation-item-done-top-level-function-call-empty",
+        ),
+        pytest.param(
+            {**response_done_event("token-1"), "name": "forbidden"},
+            ResponseCompleted,
+            id="response-done-top-level-name",
+        ),
+        pytest.param(
+            {
+                **response_done_event("token-1"),
+                "response": {
+                    **response_done_event("token-1")["response"],
+                    "tools": [],
+                },
+            },
+            ResponseCompleted,
+            id="response-done-nested-response-tools-empty",
+        ),
+    ]
+
+
+def output_authority_state(session):
+    return (
+        dict(session._pending_responses),
+        dict(session._active_responses),
+        dict(session._response_items),
+        dict(session._item_responses),
+        dict(session._final_output_transcripts),
+        set(session._audio_delta_items),
+        set(session._audio_done_items),
+        set(session._output_item_added),
+        set(session._content_part_added),
+        set(session._content_part_done),
+        set(session._output_item_done),
+        set(session._conversation_item_done),
+        dict(session._completed_responses),
+        dict(session._consumed_correlations),
+    )
+
+
+@pytest.mark.parametrize(("bad_event", "forbidden_output"), output_envelope_authority_cases())
+def test_every_output_event_envelope_authority_fails_before_emission(
+    bad_event, forbidden_output
+):
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    prefix = [] if bad_event["type"] == "response.created" else [created]
+    harness = Harness([*prefix, bad_event, *valid_output_lifecycle_events(correlation)])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return [event async for event in session.events()]
+
+    received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert "authority" in received[-1].message
+    assert not any(isinstance(event, forbidden_output) for event in received)
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert harness.wire.closed is True
+
+
+@pytest.mark.parametrize(("bad_event", "_forbidden_output"), output_envelope_authority_cases())
+def test_every_output_event_envelope_authority_preserves_direct_state(
+    bad_event, _forbidden_output
+):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        if bad_event["type"] != "response.created":
+            bind_response(session, "token-1")
+        before = output_authority_state(session)
+        with pytest.raises(ValueError, match="authority"):
+            session._map_event(bad_event)
+        assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "discriminator",
+    ["function_call", "function_call_output", "tool", "tool_call"],
+)
+def test_recursive_output_authority_discriminator_is_rejected(discriminator):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        before = output_authority_state(session)
+        with pytest.raises(ValueError, match="authority type"):
+            session._map_event(
+                {
+                    "type": "response.output_audio.done",
+                    "response_id": "resp-1",
+                    "item_id": "item-1",
+                    "metadata": {"nested": [{"type": discriminator}]},
+                }
+            )
+        assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+def test_output_event_envelope_authority_fails_before_response_started():
+    correlation = "token-1"
+    bad_created = {
+        "type": "response.created",
+        "response": {
+            "id": "resp-1",
+            "metadata": {"correlation": correlation},
+            "tool_calls": [],
+        },
+    }
+    harness = Harness([bad_created, *valid_output_lifecycle_events(correlation)])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert "authority" in received[-1].message
+    assert not any(isinstance(event, ResponseStarted) for event in received)
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert session._terminal is True
+
+
 def test_response_done_extra_authority_fails_event_pump_and_cleans_terminal_state():
     correlation = "token-1"
     created = {
@@ -1543,6 +1806,34 @@ def test_valid_live_output_lifecycle_completes_exactly_once_and_cleans_terminal_
     assert not session._response_items
     assert not session._item_responses
     assert not session._completed_responses
+
+
+def test_live_proven_output_envelopes_accept_event_ids_and_indexes_once():
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "event_id": "evt-created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    events = valid_output_lifecycle_events(correlation)
+    for index, event in enumerate(events):
+        event["event_id"] = f"evt-{index}"
+        if event["type"].startswith("response."):
+            event["output_index"] = 0
+        if event["type"].startswith("response.content_part") or "output_audio" in event["type"]:
+            event["content_index"] = 0
+    harness = Harness([created, *events])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return [event async for event in session.events()]
+
+    received = asyncio.run(scenario())
+    assert sum(isinstance(event, ResponseStarted) for event in received) == 1
+    assert sum(isinstance(event, OutputAudio) for event in received) == 1
+    assert sum(isinstance(event, ResponseCompleted) for event in received) == 1
+    assert received[-1] == SessionClosed()
 
 
 def test_invalid_intermediate_shape_does_not_mutate_binding_state_directly():

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import importlib
+import sys
+import types
 from collections.abc import Mapping
 
 import pytest
@@ -13,10 +17,17 @@ pytest.importorskip(
 )
 from agent.realtime_voice_provider import (
     InputTranscript,
+    OutputAudio,
+    OutputTranscript,
     RealtimeAudioFormat,
     RealtimeCapability,
+    RealtimeInputAudioFormat,
+    RealtimeOutputAudioFormat,
+    RealtimeResponseRequest,
     RealtimeTool,
     RealtimeVoiceSetup,
+    ResponseCompleted,
+    ResponseStarted,
     SessionClosed,
     SessionFailure,
     SessionReady,
@@ -74,11 +85,18 @@ class Harness:
         self.wire_calls += 1
         return self.wire
 
-    def provider(self, *, ledger_capacity=1024):
+    def provider(
+        self, *, ledger_capacity=1024, token_factory=None, response_ledger_capacity=1024
+    ):
+        kwargs = {}
+        if token_factory is not None:
+            kwargs["token_factory"] = token_factory
         return core_rt.TalkOpenAIRealtimeProvider(
             auth_resolver=self.resolve_auth,
             wire_factory=self.wire_factory,
             ledger_capacity=ledger_capacity,
+            response_ledger_capacity=response_ledger_capacity,
+            **kwargs,
         )
 
 
@@ -93,6 +111,21 @@ def setup(**changes):
     return RealtimeVoiceSetup(**values)
 
 
+def response_request(**changes):
+    text = changes.pop("canonical_text", "Exact words, exactly.")
+    values = {
+        "durable_session_id": "durable-1",
+        "assistant_message_id": 41,
+        "turn_marker": "turn-41",
+        "canonical_text": text,
+        "content_digest": hashlib.sha256(text.encode()).hexdigest(),
+        "output_audio_format": core_rt.SUPPORTED_OUTPUT_AUDIO_FORMAT,
+        "allow_tools": False,
+    }
+    values.update(changes)
+    return RealtimeResponseRequest(**values)
+
+
 def collect(session):
     async def scenario():
         return [event async for event in session.events()]
@@ -105,6 +138,9 @@ def test_exact_api_v2_contract_and_fixed_capabilities():
         {
             RealtimeCapability.INPUT_TRANSCRIPTION,
             RealtimeCapability.INPUT_COMMIT_EVENTS,
+            RealtimeCapability.EXPLICIT_RESPONSE,
+            RealtimeCapability.RESPONSE_METADATA_ECHO,
+            RealtimeCapability.OUTPUT_TRANSCRIPTION,
         }
     )
 
@@ -122,6 +158,435 @@ def test_exact_api_v2_contract_and_fixed_capabilities():
             await session.close()
 
     asyncio.run(scenario())
+
+
+def test_explicit_output_format_is_exact_pcm_s16le():
+    assert RealtimeOutputAudioFormat(
+        mime_type="audio/pcm",
+        sample_rate_hz=24_000,
+        channels=1,
+        sample_encoding="pcm_s16le",
+        sample_width_bytes=2,
+        endianness="little",
+    ) == core_rt.SUPPORTED_OUTPUT_AUDIO_FORMAT
+
+
+def test_explicit_response_sends_exact_causally_opaque_no_tool_payload():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "opaque-token-1").open_session(
+            setup(output_audio=core_rt.SUPPORTED_OUTPUT_AUDIO_FORMAT)
+        )
+        await session.start_response(response_request())
+        await session.close()
+
+    asyncio.run(scenario())
+    message = harness.wire.sent[0]
+    assert message.pop("event_id").startswith("evt-")
+    assert message == {
+        "type": "response.create",
+        "response": {
+            "conversation": "none",
+            "metadata": {"correlation": "opaque-token-1"},
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Exact words, exactly."}],
+                }
+            ],
+            "instructions": (
+                "Render the sole user input as speech verbatim. Speak every character's "
+                "words and punctuation naturally, but add, remove, or paraphrase nothing. "
+                "Do not preface or explain."
+            ),
+            "output_modalities": ["audio"],
+            "audio": {
+                "output": {
+                    "voice": "cedar",
+                    "format": {"type": "audio/pcm", "rate": 24000},
+                }
+            },
+            "tools": [],
+            "tool_choice": "none",
+        },
+    }
+    assert not {
+        "durable_session_id",
+        "assistant_message_id",
+        "turn_marker",
+        "content_digest",
+    }.intersection(message["response"]["metadata"])
+
+
+def test_output_format_mismatch_is_rejected_before_provider_send():
+    harness = Harness()
+    wrong = RealtimeOutputAudioFormat(
+        mime_type="audio/pcm",
+        sample_rate_hz=16_000,
+        channels=1,
+        sample_encoding="pcm_s16le",
+        sample_width_bytes=2,
+        endianness="little",
+    )
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "unused").open_session(setup())
+        with pytest.raises(ValueError, match="output audio format"):
+            await session.start_response(response_request(output_audio_format=wrong))
+
+    asyncio.run(scenario())
+    assert harness.wire.sent == []
+
+
+def test_bound_response_maps_started_audio_transcript_and_completed():
+    correlation = "opaque-bound-token"
+    events = [
+        {
+            "type": "response.created",
+            "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+        },
+        {
+            "type": "response.output_item.added",
+            "response_id": "resp-1",
+            "item": {"id": "item-out-1", "type": "message", "role": "assistant"},
+        },
+        {
+            "type": "response.content_part.added",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+            "part": {"type": "output_audio"},
+        },
+        {
+            "type": "response.output_audio.delta",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+            "delta": "cGNt",
+        },
+        {
+            "type": "response.output_audio_transcript.delta",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+            "delta": "Exact ",
+        },
+        {
+            "type": "response.output_audio_transcript.done",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+            "transcript": "Exact words, exactly.",
+        },
+        {
+            "type": "response.output_audio.done",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+        },
+        {
+            "type": "response.content_part.done",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+            "part": {"type": "output_audio"},
+        },
+        {
+            "type": "response.output_item.done",
+            "response_id": "resp-1",
+            "item": {"id": "item-out-1", "type": "message", "role": "assistant"},
+        },
+        {
+            "type": "conversation.item.done",
+            "item": {"id": "item-out-1", "type": "message", "role": "assistant"},
+        },
+        {
+            "type": "response.done",
+            "response": {
+                "id": "resp-1",
+                "status": "completed",
+                "metadata": {"correlation": correlation},
+                "output": [
+                    {
+                        "id": "item-out-1",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_audio", "transcript": "Exact words, exactly."}
+                        ],
+                    }
+                ],
+            },
+        },
+    ]
+    harness = Harness(events)
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert received[:-1] == [
+        ResponseStarted(response_id="resp-1", turn_id="turn-41"),
+        OutputAudio(
+            data=b"pcm", item_id="item-out-1", response_id="resp-1", turn_id="turn-41"
+        ),
+        OutputTranscript(
+            item_id="item-out-1",
+            response_id="resp-1",
+            turn_id="turn-41",
+            text="Exact ",
+            final=False,
+        ),
+        OutputTranscript(
+            item_id="item-out-1",
+            response_id="resp-1",
+            turn_id="turn-41",
+            text="Exact words, exactly.",
+            final=True,
+        ),
+        ResponseCompleted(response_id="resp-1", turn_id="turn-41"),
+    ]
+    assert received[-1] == SessionClosed()
+    assert not session._pending_responses
+    assert not session._active_responses
+    assert not session._completed_responses
+
+
+@pytest.mark.parametrize(
+    "bad_event,match",
+    [
+        (
+            {
+                "type": "response.created",
+                "response": {"id": "resp-1", "metadata": {"correlation": "unknown"}},
+            },
+            "correlation",
+        ),
+        (
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-wrong",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            },
+            "response",
+        ),
+        (
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "%%%",
+            },
+            "base64",
+        ),
+        (
+            {"type": "response.function_call_arguments.done", "response_id": "resp-1"},
+            "function",
+        ),
+        (
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "resp-1",
+                    "status": "failed",
+                    "metadata": {"correlation": "opaque-bad-token"},
+                },
+            },
+            "completed",
+        ),
+        (
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "resp-1",
+                    "status": "completed",
+                    "metadata": {"correlation": "opaque-bad-token"},
+                    "output": [{"id": "wrong-item", "type": "message"}],
+                },
+            },
+            "item",
+        ),
+    ],
+)
+def test_explicit_output_protocol_violations_fail_closed(bad_event, match):
+    correlation = "opaque-bad-token"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    if bad_event["type"] == "response.created":
+        events = [bad_event]
+    elif match == "item":
+        events = [
+            created,
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            },
+            bad_event,
+        ]
+    else:
+        events = [created, bad_event]
+    harness = Harness(events)
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return [event async for event in session.events()]
+
+    received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert match in received[-1].message
+    assert harness.wire.closed is True
+
+
+def test_replayed_correlation_and_changed_item_identity_fail_closed():
+    correlation = "one-time-token"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    replay_events = [
+        created,
+        {
+            "type": "response.created",
+            "response": {"id": "resp-2", "metadata": {"correlation": correlation}},
+        },
+    ]
+    wrong_item_events = [
+        created,
+        {
+            "type": "response.output_audio.delta",
+            "response_id": "resp-1",
+            "item_id": "item-1",
+            "delta": "cGNt",
+        },
+        {
+            "type": "response.output_audio.delta",
+            "response_id": "resp-1",
+            "item_id": "item-2",
+            "delta": "cGNt",
+        },
+    ]
+    for events, match in ((replay_events, "replayed"), (wrong_item_events, "identity")):
+        harness = Harness(events)
+
+        async def scenario(harness=harness, correlation=correlation):
+            provider = harness.provider(token_factory=lambda: correlation)
+            session = await provider.open_session(setup())
+            await session.start_response(response_request())
+            return [event async for event in session.events()]
+
+        received = asyncio.run(scenario())
+        assert isinstance(received[-1], SessionFailure)
+        assert match in received[-1].message
+
+
+def test_exact_setup_formats_are_validated_before_credentials_or_network():
+    wrong_input = RealtimeInputAudioFormat(
+        mime_type="audio/pcm",
+        sample_rate_hz=16_000,
+        channels=1,
+        sample_encoding="pcm_s16le",
+        sample_width_bytes=2,
+        endianness="little",
+    )
+    wrong_output = RealtimeOutputAudioFormat(
+        mime_type="audio/pcm",
+        sample_rate_hz=24_000,
+        channels=2,
+        sample_encoding="pcm_s16le",
+        sample_width_bytes=2,
+        endianness="little",
+    )
+    for bad_setup in (setup(input_audio=wrong_input), setup(output_audio=wrong_output)):
+        harness = Harness()
+        with pytest.raises(ValueError, match="audio"):
+            asyncio.run(harness.provider().open_session(bad_setup))
+        assert harness.auth_calls == harness.wire_calls == 0
+
+
+def test_response_capacity_and_close_cleanup_are_fail_closed():
+    tokens = iter(("token-1", "token-2"))
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(
+            token_factory=lambda: next(tokens), response_ledger_capacity=1
+        ).open_session(setup())
+        await session.start_response(response_request())
+        with pytest.raises(ValueError, match="capacity"):
+            await session.start_response(
+                response_request(
+                    assistant_message_id=42,
+                    turn_marker="turn-42",
+                    content_digest=hashlib.sha256(b"other").hexdigest(),
+                    canonical_text="other",
+                )
+            )
+        await session.close()
+        return session
+
+    session = asyncio.run(scenario())
+    assert not session._pending_responses
+    assert not session._active_responses
+    assert not session._completed_responses
+    assert not session._consumed_correlations
+
+
+def test_explicit_response_send_failure_cleans_pending_and_is_terminally_visible():
+    harness = Harness()
+    harness.wire.send_error = core_rt.OpenAIWireError("response send exploded")
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "failed-token").open_session(setup())
+        with pytest.raises(core_rt.OpenAIWireError, match="response send exploded"):
+            await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert not session._pending_responses
+    assert received == [
+        SessionFailure(
+            code="explicit_response_failed",
+            message="explicit response provider send failed",
+        )
+    ]
+    assert harness.wire.closed is True
+
+
+def test_missing_task1_symbols_leave_legacy_input_only_contract_available(monkeypatch):
+    contract = sys.modules["agent.realtime_voice_provider"]
+    shim = types.ModuleType(contract.__name__)
+    optional = {
+        "RealtimeInputAudioFormat",
+        "RealtimeOutputAudioFormat",
+        "RealtimeResponseRequest",
+        "ResponseStarted",
+        "OutputAudio",
+        "OutputTranscript",
+        "ResponseCompleted",
+    }
+    shim.__dict__.update(
+        {name: value for name, value in contract.__dict__.items() if name not in optional}
+    )
+    agent_package = sys.modules["agent"]
+    monkeypatch.setitem(sys.modules, "agent.realtime_voice_provider", shim)
+    monkeypatch.setattr(agent_package, "realtime_voice_provider", shim)
+    legacy = importlib.reload(core_rt)
+    try:
+        assert legacy.core_provider_available() is True
+        assert frozenset(
+            {
+                legacy.RealtimeCapability.INPUT_TRANSCRIPTION,
+                legacy.RealtimeCapability.INPUT_COMMIT_EVENTS,
+            }
+        ) == legacy.CORE_CAPABILITIES
+        assert legacy.SUPPORTED_OUTPUT_AUDIO_FORMAT is None
+    finally:
+        monkeypatch.undo()
+        importlib.reload(core_rt)
 
 
 def test_passive_diagnostic_distinguishes_contract_from_provider_readiness(monkeypatch):
@@ -155,7 +620,7 @@ def test_passive_diagnostic_distinguishes_contract_from_provider_readiness(monke
         setup(
             tools=(RealtimeTool(name="forbidden", description="must stay inert", parameters={}),)
         ),
-        setup(provider_options={"automatic_response": True}),
+        setup(automatic_response=True),
         setup(provider_options={"capabilities": ["tool_calling"]}),
         setup(audio=RealtimeAudioFormat("audio/pcm", 16_000, 1)),
         setup(audio=RealtimeAudioFormat("audio/wav", 24_000, 1)),
@@ -316,10 +781,10 @@ def test_exact_input_item_identity_maps_partial_and_final_operator_transcripts()
             ],
             "conflicting terminal transcript",
         ),
-        ([{"type": "response.created", "response": {"id": "response-1"}}], "unsolicited"),
+        ([{"type": "response.created", "response": {"id": "response-1"}}], "correlation"),
         (
             [{"type": "response.function_call_arguments.done", "call_id": "call-1"}],
-            "unsolicited",
+            "function",
         ),
         (
             [

--- a/tests/test_core_session.py
+++ b/tests/test_core_session.py
@@ -94,21 +94,60 @@ def test_operator_id_cannot_be_rebound():
         admitted.speaker_user_id = 7
 
 
-def test_core_setup_is_input_only_and_requests_only_commit_transcription():
+def test_core_setup_uses_task1_shared_fields_and_actual_capabilities():
     _requires_core_api()
+    realtime = talk_core_session.talk_core_realtime
+    if not realtime.explicit_output_available():
+        pytest.skip("Task1 explicit-output contract is not installed")
+
     setup = talk_core_session.build_core_setup()
 
     assert setup.model == talk_core_session.talk_config.talk_model()
     assert setup.voice == talk_core_session.talk_config.talk_voice()
     assert setup.instructions == ""
     assert setup.tools == ()
-    assert setup.audio == talk_core_session.talk_core_realtime.SUPPORTED_AUDIO_FORMAT
+    assert setup.audio == realtime.SUPPORTED_AUDIO_FORMAT
+    assert setup.input_audio == realtime.SUPPORTED_INPUT_AUDIO_FORMAT
+    assert setup.output_audio == realtime.SUPPORTED_OUTPUT_AUDIO_FORMAT
+    assert setup.automatic_response is False
     assert setup.provider_options == {
-        "automatic_response": False,
-        "capabilities": (
-            "input_transcription",
-            "input_commit_events",
-        ),
+        "capabilities": tuple(sorted(capability.value for capability in realtime.CORE_CAPABILITIES))
+    }
+
+
+def test_core_setup_preserves_exact_legacy_input_only_constructor(monkeypatch):
+    realtime = talk_core_session.talk_core_realtime
+    input_capabilities = frozenset(
+        {
+            realtime.RealtimeCapability.INPUT_TRANSCRIPTION,
+            realtime.RealtimeCapability.INPUT_COMMIT_EVENTS,
+        }
+    )
+    captured = {}
+
+    def legacy_setup(**kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(realtime, "explicit_output_available", lambda: False)
+    monkeypatch.setattr(realtime, "CORE_CAPABILITIES", input_capabilities)
+    monkeypatch.setattr(realtime, "RealtimeVoiceSetup", legacy_setup)
+
+    talk_core_session.build_core_setup()
+
+    assert captured == {
+        "model": talk_core_session.talk_config.talk_model(),
+        "voice": talk_core_session.talk_config.talk_voice(),
+        "instructions": "",
+        "tools": (),
+        "audio": realtime.SUPPORTED_AUDIO_FORMAT,
+        "provider_options": {
+            "automatic_response": False,
+            "capabilities": (
+                "input_transcription",
+                "input_commit_events",
+            ),
+        },
     }
 
 

--- a/tests/test_core_session.py
+++ b/tests/test_core_session.py
@@ -117,21 +117,15 @@ def test_core_setup_uses_task1_shared_fields_and_actual_capabilities():
 
 def test_core_setup_preserves_exact_legacy_input_only_constructor(monkeypatch):
     realtime = talk_core_session.talk_core_realtime
-    input_capabilities = frozenset(
-        {
-            realtime.RealtimeCapability.INPUT_TRANSCRIPTION,
-            realtime.RealtimeCapability.INPUT_COMMIT_EVENTS,
-        }
-    )
     captured = {}
 
     def legacy_setup(**kwargs):
         captured.update(kwargs)
         return types.SimpleNamespace(**kwargs)
 
+    monkeypatch.setattr(realtime, "core_provider_available", lambda: True)
     monkeypatch.setattr(realtime, "explicit_output_available", lambda: False)
-    monkeypatch.setattr(realtime, "CORE_CAPABILITIES", input_capabilities)
-    monkeypatch.setattr(realtime, "RealtimeVoiceSetup", legacy_setup)
+    monkeypatch.setattr(realtime, "RealtimeVoiceSetup", legacy_setup, raising=False)
 
     talk_core_session.build_core_setup()
 


### PR DESCRIPTION
## Summary

Adds the Talk adapter layer for rendering a host-authoritative canonical Hermes reply through the existing OpenAI Realtime session.

- maps one digest-bound host request to explicit `response.create`
- keeps automatic responses off and provider tools disabled
- uses opaque one-time correlation metadata rather than provider-owned authority
- binds real provider response/item IDs before exposing native PCM or transcripts
- validates the full assistant-message/`output_audio` lifecycle fail-closed
- preserves the older API-v2 input-only lane when the new Agent contract is absent

## Audio contract

- signed 16-bit little-endian PCM
- 24 kHz
- mono
- no MP3/OGG, Edge TTS, attachment fallback, or autonomous provider answer

## Scope

This PR stops at the provider adapter boundary. It does not add Discord playback leases, gateway ownership, barge-in, runtime mapping, activation, or a live canary.

## Verification

- 955 Talk tests passed, 1 skipped
- final spec/authority review: PASS
- final quality/security/concurrency review: APPROVED
- Ruff, `py_compile`, and `git diff --check`: passed

Stacked on #26 so the installed canonical Discord attachment baseline remains explicit.