### PR TITLE
feat(realtime): add response-local cancellation

### DIFF
--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -701,6 +701,7 @@ if _CORE_IMPORT_ERROR is None:
             if status == "cancelled":
                 if response_id not in self._cancelling_responses:
                     raise ValueError("cancelled response terminal was not requested")
+                self._validate_cancelled_response_terminal(response, response_id=response_id)
                 if len(self._completed_responses) >= self._response_ledger_capacity:
                     raise ValueError("completed response capacity exhausted")
                 self._clear_response_state(response_id)
@@ -739,6 +740,80 @@ if _CORE_IMPORT_ERROR is None:
             self._clear_response_state(response_id)
             self._completed_responses[response_id] = correlation
             return ResponseCompleted(response_id=response_id, turn_id=binding.turn_marker)
+
+        def _validate_cancelled_response_terminal(
+            self, response: Mapping[str, Any], *, response_id: str
+        ) -> None:
+            """Validate requested cancellation evidence without minting item authority."""
+
+            _validate_output_event_authority(response)
+            status_details = response.get("status_details")
+            if status_details is not None:
+                if not isinstance(status_details, Mapping):
+                    raise TypeError("cancelled response status_details must be an object")
+                if set(status_details) not in (
+                    {"type", "reason"},
+                    {"type", "reason", "error"},
+                ):
+                    raise ValueError("cancelled response status_details has an invalid shape")
+                detail_type = status_details.get("type")
+                reason = status_details.get("reason")
+                if type(detail_type) is not str or detail_type != "cancelled":
+                    raise ValueError("cancelled response status_details type must be cancelled")
+                if type(reason) is not str or reason not in {
+                    "client_cancelled",
+                    "turn_detected",
+                }:
+                    raise ValueError("cancelled response status_details reason is incompatible")
+                if status_details.get("error") is not None:
+                    raise ValueError("cancelled response status_details error must be null")
+
+            if "output" not in response:
+                return
+            output = response["output"]
+            if type(output) is not list:
+                raise TypeError("cancelled response output must be a list")
+            if not output:
+                return
+            if len(output) != 1:
+                raise ValueError("cancelled response output must contain at most one item")
+            known_item_id = self._response_items.get(response_id)
+            if known_item_id is None:
+                raise ValueError("cancelled response cannot bind a new output item")
+            item = output[0]
+            if not isinstance(item, Mapping):
+                raise TypeError("cancelled response output item must be an object")
+            if set(item) != _OUTPUT_ITEM_KEYS:
+                raise ValueError("cancelled response output item has an invalid authority shape")
+            if item.get("type") != "message":
+                raise ValueError("cancelled response output item type must be message")
+            if item.get("role") != "assistant":
+                raise ValueError("cancelled response output item role must be assistant")
+            if item.get("status") != "incomplete":
+                raise ValueError("cancelled response output item status must be incomplete")
+            item_id = _validate_identifier(item.get("id"), "cancelled output item_id")
+            if item_id != known_item_id or self._item_responses.get(item_id) != response_id:
+                raise ValueError("cancelled response output item identity changed")
+            content = item.get("content")
+            if type(content) is not list:
+                raise TypeError("cancelled response output item content must be a list")
+            if len(content) > 1:
+                raise ValueError("cancelled response output item has too many content parts")
+            if not content:
+                return
+            part = content[0]
+            if not isinstance(part, Mapping):
+                raise TypeError("cancelled response output_audio part must be an object")
+            if not set(part).issubset(_OUTPUT_AUDIO_PART_KEYS):
+                raise ValueError("cancelled response output_audio part has invalid authority")
+            if part.get("type") != "output_audio":
+                raise ValueError("cancelled response content type must be output_audio")
+            if "transcript" in part:
+                transcript = part["transcript"]
+                if type(transcript) is not str:
+                    raise TypeError("cancelled response partial transcript must be a string")
+                if len(transcript) > MAX_TRANSCRIPT_LENGTH:
+                    raise ValueError("cancelled response partial transcript is too long")
 
         def _clear_response_state(self, response_id: str) -> None:
             del self._active_responses[response_id]

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -32,6 +32,7 @@ except ImportError:  # pragma: no cover - flat-module fallback
 
 _CORE_IMPORT_ERROR: BaseException | None = None
 _EXPLICIT_OUTPUT_AVAILABLE = False
+_RESPONSE_CANCELLATION_AVAILABLE = False
 try:
     from agent import realtime_voice_provider as _core_contract
     from agent.realtime_voice_provider import (
@@ -104,6 +105,23 @@ try:
         )
     except (AttributeError, ImportError):
         _EXPLICIT_OUTPUT_AVAILABLE = False
+    try:
+        InputSpeechStarted = _core_contract.InputSpeechStarted
+        Interruption = _core_contract.Interruption
+        _RESPONSE_CANCELLATION_AVAILABLE = (
+            _EXPLICIT_OUTPUT_AVAILABLE
+            and isinstance(InputSpeechStarted, type)
+            and isinstance(Interruption, type)
+            and hasattr(RealtimeCapability, "RESPONSE_CANCELLATION")
+            and callable(getattr(RealtimeVoiceSession, "cancel_response", None))
+            and callable(getattr(RealtimeVoiceSession, "_cancel_response", None))
+            and getattr(RealtimeVoiceSession, "_CAPABILITY_HOOKS", {}).get(
+                RealtimeCapability.RESPONSE_CANCELLATION
+            )
+            == "_cancel_response"
+        )
+    except (AttributeError, ImportError):
+        _RESPONSE_CANCELLATION_AVAILABLE = False
 except Exception as exc:  # noqa: BLE001 - optional core must never poison legacy imports
     _CORE_IMPORT_ERROR = exc
 
@@ -178,6 +196,11 @@ if _CORE_IMPORT_ERROR is None:
                 RealtimeCapability.OUTPUT_TRANSCRIPTION,
             }
             if _EXPLICIT_OUTPUT_AVAILABLE
+            else set()
+        )
+        | (
+            {RealtimeCapability.RESPONSE_CANCELLATION}
+            if _RESPONSE_CANCELLATION_AVAILABLE
             else set()
         )
     )
@@ -368,6 +391,7 @@ if _CORE_IMPORT_ERROR is None:
             self._conversation_item_done: set[tuple[str, str]] = set()
             self._completed_responses: OrderedDict[str, str] = OrderedDict()
             self._consumed_correlations: OrderedDict[str, None] = OrderedDict()
+            self._cancelling_responses: set[str] = set()
             self._input_ledger: dict[str, str | None] = {}
             self._provider_session_id: str | None = None
             self._terminal = False
@@ -486,6 +510,31 @@ if _CORE_IMPORT_ERROR is None:
                 async with self._response_lock:
                     if self._pending_responses.get(correlation) == binding:
                         del self._pending_responses[correlation]
+                raise
+
+        async def _cancel_response(self, response_id: str) -> None:
+            response_id = _validate_identifier(response_id, "response_id")
+            async with self._response_lock:
+                if response_id in self._completed_responses:
+                    raise ValueError("response is already completed")
+                if response_id not in self._active_responses:
+                    raise ValueError("response cancellation requires an active bound response")
+                if response_id in self._cancelling_responses:
+                    raise ValueError("response cancellation is already in progress")
+                if len(self._cancelling_responses) >= self._response_ledger_capacity:
+                    raise ValueError("response cancellation capacity exhausted")
+                self._cancelling_responses.add(response_id)
+            try:
+                await self._send_wire(
+                    {
+                        "type": "response.cancel",
+                        "event_id": f"evt-{secrets.token_urlsafe(24)}",
+                        "response_id": response_id,
+                    }
+                )
+            except BaseException:
+                async with self._response_lock:
+                    self._cancelling_responses.discard(response_id)
                 raise
 
         def _input_transcript(self, event: Mapping[str, Any], *, final: bool) -> InputTranscript:
@@ -648,8 +697,17 @@ if _CORE_IMPORT_ERROR is None:
             correlation, binding = active
             if self._response_metadata(response) != correlation:
                 raise ValueError("response completion correlation mismatch")
-            if response.get("status") != "completed":
-                raise ValueError("response status must be completed")
+            status = response.get("status")
+            if status == "cancelled":
+                if response_id not in self._cancelling_responses:
+                    raise ValueError("cancelled response terminal was not requested")
+                if len(self._completed_responses) >= self._response_ledger_capacity:
+                    raise ValueError("completed response capacity exhausted")
+                self._clear_response_state(response_id)
+                self._completed_responses[response_id] = correlation
+                return Interruption(response_id=response_id, turn_id=binding.turn_marker)
+            if status != "completed":
+                raise ValueError("response status must be completed or requested cancelled")
             if "output" not in response:
                 raise ValueError("response output is required")
             output = response["output"]
@@ -678,6 +736,11 @@ if _CORE_IMPORT_ERROR is None:
                 raise ValueError("response completion requires audio done")
             if len(self._completed_responses) >= self._response_ledger_capacity:
                 raise ValueError("completed response capacity exhausted")
+            self._clear_response_state(response_id)
+            self._completed_responses[response_id] = correlation
+            return ResponseCompleted(response_id=response_id, turn_id=binding.turn_marker)
+
+        def _clear_response_state(self, response_id: str) -> None:
             del self._active_responses[response_id]
             item_id = self._response_items.pop(response_id, None)
             if item_id is not None:
@@ -690,14 +753,16 @@ if _CORE_IMPORT_ERROR is None:
                 self._content_part_done.discard((response_id, item_id))
                 self._output_item_done.discard((response_id, item_id))
                 self._conversation_item_done.discard((response_id, item_id))
-            self._completed_responses[response_id] = correlation
-            return ResponseCompleted(response_id=response_id, turn_id=binding.turn_marker)
+            self._cancelling_responses.discard(response_id)
 
         def _map_event(self, event: Mapping[str, Any]):
             event_type = event.get("type")
             if not isinstance(event_type, str) or not event_type:
                 raise ValueError("provider event type must be a nonblank string")
-            if event_type in _OUTPUT_EVENT_TYPES:
+            if event_type in _OUTPUT_EVENT_TYPES or (
+                _RESPONSE_CANCELLATION_AVAILABLE
+                and event_type == "input_audio_buffer.speech_started"
+            ):
                 _validate_output_event_authority(event)
             if event_type == "session.created":
                 session = event.get("session")
@@ -716,6 +781,20 @@ if _CORE_IMPORT_ERROR is None:
             if event_type == "input_audio_buffer.committed":
                 self._reserve_input(event.get("item_id"))
                 return None
+            if (
+                _RESPONSE_CANCELLATION_AVAILABLE
+                and event_type == "input_audio_buffer.speech_started"
+            ):
+                item_id = event.get("item_id")
+                if type(item_id) is not str:
+                    raise TypeError("speech_started item_id must be an exact string")
+                item_id = _validate_identifier(item_id, "item_id")
+                offset_ms = event.get("audio_start_ms")
+                if type(offset_ms) is not int:
+                    raise TypeError("audio_start_ms must be a nonnegative exact integer")
+                if offset_ms < 0:
+                    raise ValueError("audio_start_ms must be nonnegative")
+                return InputSpeechStarted(item_id=item_id, offset_ms=offset_ms)
             if event_type == "conversation.item.input_audio_transcription.delta":
                 return self._input_transcript(event, final=False)
             if event_type == "conversation.item.input_audio_transcription.completed":
@@ -891,6 +970,7 @@ if _CORE_IMPORT_ERROR is None:
                 self._content_part_done.clear()
                 self._output_item_done.clear()
                 self._conversation_item_done.clear()
+                self._cancelling_responses.clear()
                 self._completed_responses.clear()
                 self._consumed_correlations.clear()
 

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -205,6 +205,8 @@ if _CORE_IMPORT_ERROR is None:
         )
     )
     _OUTPUT_ITEM_KEYS = frozenset({"id", "type", "role", "status", "content"})
+    _OUTPUT_ITEM_ALLOWED_KEYS = _OUTPUT_ITEM_KEYS | {"object"}
+    _OUTPUT_ITEM_OBJECT = "realtime.item"
     _OUTPUT_AUDIO_PART_KEYS = frozenset({"type", "transcript"})
     _OUTPUT_EVENT_TYPES = frozenset(
         {
@@ -616,6 +618,24 @@ if _CORE_IMPORT_ERROR is None:
             self._item_responses[item_id] = response_id
             return correlation, binding, item_id
 
+        @staticmethod
+        def _validate_output_item_authority_shape(
+            item: Any, *, context: str
+        ) -> Mapping[str, Any]:
+            if not isinstance(item, Mapping):
+                raise TypeError(f"{context} requires an output item object")
+            if not set(item).issubset(_OUTPUT_ITEM_ALLOWED_KEYS):
+                raise ValueError(f"{context} output item has an invalid authority shape")
+            if "object" in item:
+                item_object = item["object"]
+                if type(item_object) is not str:
+                    raise TypeError(f"{context} output item object must be an exact string")
+                if item_object != _OUTPUT_ITEM_OBJECT:
+                    raise ValueError(
+                        f"{context} output item object must be {_OUTPUT_ITEM_OBJECT}"
+                    )
+            return item
+
         def _validate_output_audio_part(
             self,
             part: Any,
@@ -644,10 +664,7 @@ if _CORE_IMPORT_ERROR is None:
             response_id: str,
             stage: str,
         ) -> tuple[str, Mapping[str, Any] | None]:
-            if not isinstance(item, Mapping):
-                raise TypeError(f"{stage} requires an output item object")
-            if not set(item).issubset(_OUTPUT_ITEM_KEYS):
-                raise ValueError(f"{stage} output item has an invalid authority shape")
+            item = self._validate_output_item_authority_shape(item, context=stage)
             if item.get("type") != "message":
                 raise ValueError(f"{stage} output item type must be message")
             if item.get("role") != "assistant":
@@ -780,11 +797,13 @@ if _CORE_IMPORT_ERROR is None:
             known_item_id = self._response_items.get(response_id)
             if known_item_id is None:
                 raise ValueError("cancelled response cannot bind a new output item")
-            item = output[0]
-            if not isinstance(item, Mapping):
-                raise TypeError("cancelled response output item must be an object")
-            if set(item) != _OUTPUT_ITEM_KEYS:
-                raise ValueError("cancelled response output item has an invalid authority shape")
+            item = self._validate_output_item_authority_shape(
+                output[0], context="cancelled response"
+            )
+            if set(item) - {"object"} != _OUTPUT_ITEM_KEYS:
+                raise ValueError(
+                    "cancelled response output item has an invalid authority shape"
+                )
             if item.get("type") != "message":
                 raise ValueError("cancelled response output item type must be message")
             if item.get("role") != "assistant":

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -2409,6 +2409,239 @@ def test_requested_cancelled_done_maps_interruption_and_cleans_exact_response_st
     assert session._completed_responses == {"resp-1": "token-1"}
 
 
+def partial_cancelled_output_item(*, item_id="item-1", content=None):
+    return {
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "status": "incomplete",
+        "content": [] if content is None else content,
+    }
+
+
+_STATUS_DETAILS_ABSENT = object()
+
+
+@pytest.mark.parametrize(
+    "bad_output",
+    [
+        {},
+        [partial_cancelled_output_item(), partial_cancelled_output_item()],
+        [1],
+        [partial_cancelled_output_item(item_id="wrong-item")],
+        [{**partial_cancelled_output_item(), "type": "function_call"}],
+        [{**partial_cancelled_output_item(), "role": "user"}],
+        [{**partial_cancelled_output_item(), "status": "completed"}],
+        [{**partial_cancelled_output_item(), "response_id": "resp-2"}],
+        [{**partial_cancelled_output_item(), "content": {}}],
+        [
+            partial_cancelled_output_item(
+                content=[{"type": "output_audio"}, {"type": "output_audio"}]
+            )
+        ],
+        [partial_cancelled_output_item(content=[{"type": "output_text", "text": "no"}])],
+        [{**partial_cancelled_output_item(), "tool_calls": []}],
+    ],
+    ids=[
+        "non-list",
+        "multiple-items",
+        "nonmapping-item",
+        "wrong-item-id",
+        "wrong-item-type",
+        "wrong-role",
+        "wrong-status",
+        "conflicting-response-id",
+        "non-list-content",
+        "multiple-content-parts",
+        "nonaudio-content",
+        "structured-tool-authority",
+    ],
+)
+def test_cancelled_done_rejects_malformed_partial_output_before_direct_state_mutation(
+    bad_output,
+):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        session._map_event(
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            }
+        )
+        await session.cancel_response("resp-1")
+        event = cancelled_response_done_event("token-1", output=bad_output)
+        before = output_authority_state(session)
+        with pytest.raises((TypeError, ValueError)):
+            session._map_event(event)
+        assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "status_details",
+    [
+        [],
+        {"type": "failed", "reason": "client_cancelled"},
+        {"type": "incomplete", "reason": "client_cancelled"},
+        {"type": "completed", "reason": "client_cancelled"},
+        {"type": "cancelled", "reason": "max_output_tokens"},
+        {"type": "cancelled", "reason": "content_filter"},
+        {"type": "cancelled", "reason": "client_cancelled", "unknown": None},
+        {"type": True, "reason": "client_cancelled"},
+        {"type": "cancelled", "reason": 1},
+        {"type": "cancelled", "reason": "client_cancelled", "error": "failed"},
+    ],
+    ids=[
+        "nonmapping",
+        "failed-type",
+        "incomplete-type",
+        "completed-type",
+        "max-token-reason",
+        "content-filter-reason",
+        "unknown-key",
+        "coercive-type",
+        "coercive-reason",
+        "non-null-error",
+    ],
+)
+def test_cancelled_done_rejects_contradictory_status_details_before_direct_state_mutation(
+    status_details,
+):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        await session.cancel_response("resp-1")
+        event = cancelled_response_done_event("token-1")
+        event["response"]["status_details"] = status_details
+        before = output_authority_state(session)
+        with pytest.raises((TypeError, ValueError)):
+            session._map_event(event)
+        assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("output_marker", "status_details_marker"),
+    [
+        (None, _STATUS_DETAILS_ABSENT),
+        ([], None),
+        ([partial_cancelled_output_item()], _STATUS_DETAILS_ABSENT),
+        (
+            [partial_cancelled_output_item(content=[{"type": "output_audio"}])],
+            {"type": "cancelled", "reason": "client_cancelled"},
+        ),
+        ([], {"type": "cancelled", "reason": "turn_detected"}),
+        (
+            [],
+            {"type": "cancelled", "reason": "client_cancelled", "error": None},
+        ),
+    ],
+    ids=[
+        "absent-output-and-details",
+        "empty-output-and-null-details",
+        "empty-partial-item",
+        "partial-audio-and-client-cancelled",
+        "turn-detected",
+        "explicit-null-error",
+    ],
+)
+def test_cancelled_done_accepts_only_narrow_partial_terminal_shapes(
+    output_marker, status_details_marker
+):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        session._map_event(
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            }
+        )
+        await session.cancel_response("resp-1")
+        event = cancelled_response_done_event("token-1", output=output_marker or [])
+        if output_marker is None:
+            del event["response"]["output"]
+        if status_details_marker is not _STATUS_DETAILS_ABSENT:
+            event["response"]["status_details"] = status_details_marker
+        return session._map_event(event)
+
+    assert asyncio.run(scenario()) == Interruption(
+        response_id="resp-1", turn_id="turn-41"
+    )
+
+
+def test_cancelled_done_without_bound_item_rejects_nonempty_output_without_minting_authority():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        await session.cancel_response("resp-1")
+        before = output_authority_state(session)
+        with pytest.raises(ValueError):
+            session._map_event(
+                cancelled_response_done_event(
+                    "token-1", output=[partial_cancelled_output_item()]
+                )
+            )
+        assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+def test_cancelled_done_wrong_item_id_event_pump_fails_without_interruption_and_cleans_state():
+    correlation = "token-1"
+    harness = Harness(
+        [
+            cancelled_response_done_event(
+                correlation,
+                output=[partial_cancelled_output_item(item_id="wrong-item")],
+            ),
+        ]
+    )
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, correlation)
+        session._map_event(
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            }
+        )
+        await session.cancel_response("resp-1")
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert not any(isinstance(event, Interruption) for event in received)
+    assert harness.wire.closed is True
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._cancelling_responses
+
+
 @pytest.mark.parametrize("mutation", ["unsolicited", "wrong-correlation", "authority"])
 def test_cancelled_done_rejects_unsolicited_wrong_metadata_and_structured_authority(mutation):
     harness = Harness()

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -1829,6 +1829,107 @@ def test_valid_live_output_lifecycle_completes_exactly_once_and_cleans_terminal_
     assert not session._completed_responses
 
 
+def test_documented_realtime_item_object_completes_full_output_lifecycle_exactly_once():
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    events = valid_output_lifecycle_events(correlation)
+    for event in events:
+        if event["type"] in {
+            "response.output_item.added",
+            "response.output_item.done",
+            "conversation.item.done",
+        }:
+            event["item"]["object"] = "realtime.item"
+        elif event["type"] == "response.done":
+            event["response"]["output"][0]["object"] = "realtime.item"
+    harness = Harness([created, *events])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert sum(isinstance(event, ResponseCompleted) for event in received) == 1
+    assert not any(isinstance(event, Interruption) for event in received)
+    assert received[-1] == SessionClosed()
+    assert session._terminal is True
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._completed_responses
+
+
+@pytest.mark.parametrize(
+    ("object_value", "extra"),
+    [
+        (None, {}),
+        (True, {}),
+        ("realtime.item.wrong", {}),
+        ({"value": "realtime.item"}, {}),
+        ("realtime.item", {"unknown": None}),
+    ],
+    ids=["null", "bool", "wrong-string", "mapping", "extra-unknown-key"],
+)
+def test_output_item_object_variants_reject_before_lifecycle_state_mutation(
+    object_value, extra
+):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        item = {
+            "id": "item-1",
+            "type": "message",
+            "role": "assistant",
+            "status": "in_progress",
+            "content": [],
+            "object": object_value,
+            **extra,
+        }
+        before = output_authority_state(session)
+        with pytest.raises((TypeError, ValueError)):
+            session._map_event(
+                {
+                    "type": "response.output_item.added",
+                    "response_id": "resp-1",
+                    "item": item,
+                }
+            )
+        assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+def test_wrong_output_item_object_event_pump_fails_without_completion_or_interruption():
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    events = valid_output_lifecycle_events(correlation)
+    events[0]["item"]["object"] = "wrong"
+    harness = Harness([created, *events])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert not any(isinstance(event, Interruption) for event in received)
+    assert session._terminal is True
+    assert not session._active_responses
+    assert not session._completed_responses
+
+
 def test_live_proven_output_envelopes_accept_event_ids_and_indexes_once():
     correlation = "token-1"
     created = {
@@ -2419,6 +2520,75 @@ def partial_cancelled_output_item(*, item_id="item-1", content=None):
     }
 
 
+def test_cancelled_done_accepts_documented_realtime_item_object_direct_and_cleans_state():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        session._map_event(
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            }
+        )
+        await session.cancel_response("resp-1")
+        item = {**partial_cancelled_output_item(), "object": "realtime.item"}
+        interrupted = session._map_event(
+            cancelled_response_done_event("token-1", output=[item])
+        )
+        return session, interrupted
+
+    session, interrupted = asyncio.run(scenario())
+    assert interrupted == Interruption(response_id="resp-1", turn_id="turn-41")
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._audio_delta_items
+    assert not session._cancelling_responses
+    assert session._completed_responses == {"resp-1": "token-1"}
+
+
+def test_cancelled_done_accepts_documented_realtime_item_object_through_event_pump():
+    correlation = "token-1"
+    item = {
+        **partial_cancelled_output_item(
+            content=[{"type": "output_audio", "transcript": "partial"}]
+        ),
+        "object": "realtime.item",
+    }
+    harness = Harness([cancelled_response_done_event(correlation, output=[item])])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, correlation)
+        session._map_event(
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            }
+        )
+        await session.cancel_response("resp-1")
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert received.count(Interruption(response_id="resp-1", turn_id="turn-41")) == 1
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert received[-1] == SessionClosed()
+    assert session._terminal is True
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._cancelling_responses
+    assert not session._completed_responses
+
+
 _STATUS_DETAILS_ABSENT = object()
 
 
@@ -2482,6 +2652,79 @@ def test_cancelled_done_rejects_malformed_partial_output_before_direct_state_mut
         assert output_authority_state(session) == before
 
     asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("object_value", "extra"),
+    [
+        (None, {}),
+        (True, {}),
+        ("realtime.item.wrong", {}),
+        ({"value": "realtime.item"}, {}),
+        ("realtime.item", {"unknown": None}),
+    ],
+    ids=["null", "bool", "wrong-string", "mapping", "extra-unknown-key"],
+)
+def test_cancelled_done_rejects_item_object_variants_before_direct_state_mutation(
+    object_value, extra
+):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        session._map_event(
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            }
+        )
+        await session.cancel_response("resp-1")
+        item = {
+            **partial_cancelled_output_item(),
+            "object": object_value,
+            **extra,
+        }
+        before = output_authority_state(session)
+        with pytest.raises((TypeError, ValueError)):
+            session._map_event(
+                cancelled_response_done_event("token-1", output=[item])
+            )
+        assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+def test_wrong_cancelled_item_object_event_pump_fails_without_terminal_event():
+    correlation = "token-1"
+    item = {**partial_cancelled_output_item(), "object": "wrong"}
+    harness = Harness([cancelled_response_done_event(correlation, output=[item])])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, correlation)
+        session._map_event(
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            }
+        )
+        await session.cancel_response("resp-1")
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert not any(isinstance(event, Interruption) for event in received)
+    assert session._terminal is True
+    assert not session._active_responses
+    assert not session._completed_responses
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -16,7 +16,9 @@ pytest.importorskip(
     reason="Hermes core API-v2 is optional for standalone Talk",
 )
 from agent.realtime_voice_provider import (
+    InputSpeechStarted,
     InputTranscript,
+    Interruption,
     OutputAudio,
     OutputTranscript,
     RealtimeAudioFormat,
@@ -171,6 +173,23 @@ def response_done_event(
     }
 
 
+def cancelled_response_done_event(
+    correlation,
+    *,
+    response_id="resp-1",
+    output=None,
+):
+    return {
+        "type": "response.done",
+        "response": {
+            "id": response_id,
+            "status": "cancelled",
+            "metadata": {"correlation": correlation},
+            "output": [] if output is None else output,
+        },
+    }
+
+
 def complete_bound_response(
     session, correlation, *, response_id="resp-1", item_id="item-1", transcript="words"
 ):
@@ -292,6 +311,7 @@ def test_exact_api_v2_contract_and_fixed_capabilities():
             RealtimeCapability.EXPLICIT_RESPONSE,
             RealtimeCapability.RESPONSE_METADATA_ECHO,
             RealtimeCapability.OUTPUT_TRANSCRIPTION,
+            RealtimeCapability.RESPONSE_CANCELLATION,
         }
     )
 
@@ -1664,6 +1684,7 @@ def output_authority_state(session):
         set(session._conversation_item_done),
         dict(session._completed_responses),
         dict(session._consumed_correlations),
+        set(getattr(session, "_cancelling_responses", ())),
     )
 
 
@@ -1921,6 +1942,37 @@ def test_missing_task1_symbols_leave_legacy_input_only_contract_available(monkey
             }
         ) == legacy.CORE_CAPABILITIES
         assert legacy.SUPPORTED_OUTPUT_AUDIO_FORMAT is None
+    finally:
+        monkeypatch.undo()
+        importlib.reload(core_rt)
+
+
+def test_missing_task3a_symbols_preserve_task1_explicit_output_without_cancellation(monkeypatch):
+    contract = sys.modules["agent.realtime_voice_provider"]
+    shim = types.ModuleType(contract.__name__)
+    shim.__dict__.update(
+        {
+            name: value
+            for name, value in contract.__dict__.items()
+            if name not in {"InputSpeechStarted", "Interruption"}
+        }
+    )
+    agent_package = sys.modules["agent"]
+    monkeypatch.setitem(sys.modules, "agent.realtime_voice_provider", shim)
+    monkeypatch.setattr(agent_package, "realtime_voice_provider", shim)
+    legacy = importlib.reload(core_rt)
+    try:
+        assert legacy.core_provider_available() is True
+        assert legacy.explicit_output_available() is True
+        assert frozenset(
+            {
+                legacy.RealtimeCapability.INPUT_TRANSCRIPTION,
+                legacy.RealtimeCapability.INPUT_COMMIT_EVENTS,
+                legacy.RealtimeCapability.EXPLICIT_RESPONSE,
+                legacy.RealtimeCapability.RESPONSE_METADATA_ECHO,
+                legacy.RealtimeCapability.OUTPUT_TRANSCRIPTION,
+            }
+        ) == legacy.CORE_CAPABILITIES
     finally:
         monkeypatch.undo()
         importlib.reload(core_rt)
@@ -2209,3 +2261,216 @@ def test_provider_data_is_diagnostic_only_and_frozen():
     )
     assert isinstance(transcript.provider_data, Mapping)
     assert not transcript.provider_data
+
+
+def test_passive_speech_started_maps_exact_provider_identity_and_offset():
+    harness = Harness(
+        [{"type": "input_audio_buffer.speech_started", "item_id": "input-7", "audio_start_ms": 23}]
+    )
+
+    async def scenario():
+        session = await harness.provider().open_session(setup())
+        return [event async for event in session.events()]
+
+    received = asyncio.run(scenario())
+    assert received == [InputSpeechStarted(item_id="input-7", offset_ms=23), SessionClosed()]
+    assert not any(isinstance(event, Interruption) for event in received)
+
+
+@pytest.mark.parametrize(
+    "item_id,audio_start_ms",
+    [(True, 0), ("input", True), ("input", "0"), ("input", -1)],
+)
+def test_speech_started_rejects_coercive_or_negative_fields(item_id, audio_start_ms):
+    harness = Harness(
+        [
+            {
+                "type": "input_audio_buffer.speech_started",
+                "item_id": item_id,
+                "audio_start_ms": audio_start_ms,
+            }
+        ]
+    )
+
+    async def scenario():
+        session = await harness.provider().open_session(setup())
+        return [event async for event in session.events()]
+
+    received = asyncio.run(scenario())
+    assert len(received) == 1 and isinstance(received[0], SessionFailure)
+    assert harness.wire.closed is True
+
+
+def test_exact_response_cancel_payload_is_response_local_and_unique():
+    tokens = iter(("token-1", "token-2"))
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: next(tokens)).open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1", response_id="resp-1")
+        await session.start_response(
+            response_request(
+                assistant_message_id=42,
+                turn_marker="turn-42",
+                canonical_text="other",
+                content_digest=hashlib.sha256(b"other").hexdigest(),
+            )
+        )
+        bind_response(session, "token-2", response_id="resp-2")
+        await session.cancel_response("resp-1")
+        await session.cancel_response("resp-2")
+        return session
+
+    session = asyncio.run(scenario())
+    cancellations = [
+        message for message in harness.wire.sent if message["type"] == "response.cancel"
+    ]
+    payloads_without_event_ids = [
+        {key: value for key, value in message.items() if key != "event_id"}
+        for message in cancellations
+    ]
+    assert payloads_without_event_ids == [
+        {"type": "response.cancel", "response_id": "resp-1"},
+        {"type": "response.cancel", "response_id": "resp-2"},
+    ]
+    assert all(message["event_id"].startswith("evt-") for message in cancellations)
+    assert cancellations[0]["event_id"] != cancellations[1]["event_id"]
+    assert session._cancelling_responses == {"resp-1", "resp-2"}
+
+
+def test_cancel_rejects_unknown_duplicate_and_completed_before_wire_send():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        with pytest.raises(ValueError, match=r"active|bound"):
+            await session._cancel_response("unknown")
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        await session.cancel_response("resp-1")
+        with pytest.raises(ValueError, match="already"):
+            await session.cancel_response("resp-1")
+        session._map_event(cancelled_response_done_event("token-1"))
+        with pytest.raises(ValueError, match=r"already|active|completed"):
+            await session._cancel_response("resp-1")
+
+    asyncio.run(scenario())
+    assert [message["type"] for message in harness.wire.sent].count("response.cancel") == 1
+
+
+def test_cancel_send_failure_releases_reservation_and_remains_terminally_visible():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        harness.wire.send_error = core_rt.OpenAIWireError("cancel exploded")
+        with pytest.raises(core_rt.OpenAIWireError, match="cancel exploded"):
+            await session.cancel_response("resp-1")
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert not session._cancelling_responses
+    assert received == [
+        SessionFailure(
+            code="response_cancellation_failed",
+            message="response cancellation provider send failed",
+        )
+    ]
+
+
+def test_requested_cancelled_done_maps_interruption_and_cleans_exact_response_state():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        session._map_event(
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            }
+        )
+        await session.cancel_response("resp-1")
+        return session, session._map_event(cancelled_response_done_event("token-1"))
+
+    session, interrupted = asyncio.run(scenario())
+    assert interrupted == Interruption(response_id="resp-1", turn_id="turn-41")
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._audio_delta_items
+    assert not session._cancelling_responses
+    assert session._completed_responses == {"resp-1": "token-1"}
+
+
+@pytest.mark.parametrize("mutation", ["unsolicited", "wrong-correlation", "authority"])
+def test_cancelled_done_rejects_unsolicited_wrong_metadata_and_structured_authority(mutation):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        event = cancelled_response_done_event("token-1")
+        if mutation != "unsolicited":
+            await session.cancel_response("resp-1")
+        if mutation == "wrong-correlation":
+            event["response"]["metadata"] = {"correlation": "wrong"}
+        elif mutation == "authority":
+            event["response"]["output"] = [{"nested": {"function_call": {}}}]
+        before = output_authority_state(session)
+        with pytest.raises(ValueError):
+            session._map_event(event)
+        assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+def test_cancel_then_strict_completed_race_emits_completion_and_clears_cancel_state():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        await session.cancel_response("resp-1")
+        return session, complete_bound_response(session, "token-1")
+
+    session, completed = asyncio.run(scenario())
+    assert completed == ResponseCompleted(response_id="resp-1", turn_id="turn-41")
+    assert not session._cancelling_responses
+
+
+def test_cancelled_terminal_is_tombstoned_and_terminate_clears_cancellation_state():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        await session.cancel_response("resp-1")
+        done = cancelled_response_done_event("token-1")
+        session._map_event(done)
+        with pytest.raises(ValueError, match="replayed"):
+            session._map_event(done)
+        with pytest.raises(ValueError, match="unbound"):
+            session._map_event(
+                {
+                    "type": "response.output_audio.delta",
+                    "response_id": "resp-1",
+                    "item_id": "item-1",
+                    "delta": "cGNt",
+                }
+            )
+        await session.close()
+        return session
+
+    session = asyncio.run(scenario())
+    assert not session._cancelling_responses
+    assert not session._completed_responses


### PR DESCRIPTION
## Summary
- surface passive provider input-speech-start events without granting interruption authority
- send exact response-local OpenAI `response.cancel` requests behind an additive capability
- validate cancelled terminals, partial audio-only authority, and cancel-vs-complete races fail-closed

## Stack
- stacked on Talk PR #27
- requires Agent Task 3A commit `ab28071fd0a3907d61ee9fc4005392e9c2175b23`

## Verification
- Agent-backed Talk: 1,015 passed, 1 skipped
- standalone Talk: 827 passed, 7 skipped
- final spec/authority: PASS
- final quality/security/concurrency: APPROVED
- Ruff, py_compile, and diff checks passed

No install, activation, restart, or live canary is included.