### PR TITLE
feat(talk): ship native realtime Hermes orchestrator

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -123,7 +123,8 @@ def _register_talk_command(ctx) -> None:
     kwargs = {
         "handler": _talk_command,
         "description": (
-            "Start limited legacy voice (join) or canonical parity voice (core join); "
+            "Start provider-owned voice with canonical Hermes tools (join), or the "
+            "canonical core voice lane (core join); "
             "gateway also supports leave and status"
         ),
         "args_hint": "[join|core join|leave|status]",
@@ -181,6 +182,13 @@ def _talk_command(raw_args: str = "", invocation=None) -> str:
             return f"Canonical core voice was refused by the host ({type(exc).__name__})."
         return talk_discord.start_core_session(factory)
     if sub in {"", "join"}:
+        capture = getattr(invocation, "capture_realtime_execution_attachment", None)
+        if callable(capture):
+            try:
+                attachment = capture()
+            except Exception as exc:  # noqa: BLE001 - capability refusal is speakable
+                return f"Provider-owned voice was refused by the host ({type(exc).__name__})."
+            return talk_discord.start_session(host_execution_attachment=attachment)
         return talk_discord.start_session()
     return talk_discord.JOIN_USAGE
 

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -113,16 +113,12 @@ def _tool_definitions(tools: list[dict]) -> tuple[talk_realtime.ToolDefinition, 
 
     return tuple(
         talk_realtime.ToolDefinition(
-            name=str(tool.get("name") or ""),
-            description=str(tool.get("description") or ""),
-            parameters=(
-                tool.get("parameters")
-                if isinstance(tool.get("parameters"), dict)
-                else {}
-            ),
+            name=tool["name"],
+            description=tool["description"],
+            parameters=tool["parameters"],
         )
         for tool in tools
-        if tool.get("type") == "function"
+        if tool.get("type", "function") == "function"
     )
 
 
@@ -205,6 +201,11 @@ TOOL_SESSION_QUEUE_SIZE = 1
 TOOL_CLEANUP_WAIT_S = 6.0
 MAX_SPEAKER_DISPLAY_NAME_CHARS = 256
 _TOOL_COORDINATOR_STOP = object()
+_HOST_TOOL_BATCH = object()
+
+HOST_TOOL_ARGUMENT_ERROR = (
+    "The tool call arguments were not a valid JSON object, so the tool was not run."
+)
 
 
 class SpeakerPacketLane:
@@ -303,6 +304,10 @@ class ToolResponseCoordinator:
         self.closed = False
         self.failed = False
         self.provider_neutral = provider_neutral
+        self.max_pending = max_pending
+        self.host_batch_mode = callable(getattr(relay, "handle_tool_batch_async", None))
+        self._host_events: list[tuple[int, dict]] = []
+        self._host_batch_id: str | None = None
         self._stop_requested = False
         self._stopped = asyncio.Event()
         self._continuation = self._default_continuation()
@@ -340,6 +345,14 @@ class ToolResponseCoordinator:
             # Mixed/missing attribution in one response can continue talking,
             # but its continuation must carry no authorization binding.
             self._continuation = self._default_continuation()
+        if self.host_batch_mode:
+            if len(self._host_events) >= self.max_pending + 1:
+                self.outputs[position] = self.relay.tool_queue_full_commands(event)
+                return False
+            if self._host_batch_id is None:
+                self._host_batch_id = f"talkbatch{uuid.uuid4().hex}"
+            self._host_events.append((position, event))
+            return True
         try:
             self.queue.put_nowait((position, event))
         except asyncio.QueueFull:
@@ -355,6 +368,13 @@ class ToolResponseCoordinator:
         if not self.outputs:
             return
         self.closed = True
+        if self.host_batch_mode:
+            positioned_events = tuple(self._host_events)
+            self._host_events = []
+            self.queue.put_nowait(
+                (_HOST_TOOL_BATCH, positioned_events, self._host_batch_id)
+            )
+            return
         await self._flush_if_ready()
 
     async def _flush_if_ready(self) -> None:
@@ -383,6 +403,7 @@ class ToolResponseCoordinator:
             self.outputs = []
             self.closed = False
             self._continuation = self._default_continuation()
+            self._host_batch_id = None
 
     async def run(self) -> None:
         try:
@@ -391,6 +412,18 @@ class ToolResponseCoordinator:
                 try:
                     if item is _TOOL_COORDINATOR_STOP:
                         return
+                    if item[0] is _HOST_TOOL_BATCH:
+                        _marker, positioned_events, batch_id = item
+                        results = await self.relay.handle_tool_batch_async(
+                            tuple(event for _position, event in positioned_events),
+                            batch_id,
+                        )
+                        for (position, _event), result in zip(
+                            positioned_events, results, strict=True
+                        ):
+                            self.outputs[position] = result
+                        await self._flush_if_ready()
+                        continue
                     position, event = item
                     self.outputs[position] = await (
                         self.relay.handle_tool_call_async(event)
@@ -440,6 +473,61 @@ class ToolResponseCoordinator:
                             discard(event)
                 finally:
                     self.queue.task_done()
+
+
+class HostExecutionRelay:
+    """Translate one provider response's calls into one canonical host batch."""
+
+    def __init__(self, attachment) -> None:
+        self.attachment = attachment
+
+    @staticmethod
+    def _output(call_id: str, output: str) -> list[talk_realtime.RealtimeCommand]:
+        return [talk_realtime.SubmitToolResult(call_id=call_id, output=output)]
+
+    def tool_queue_full_commands(self, event: dict) -> list[talk_realtime.RealtimeCommand]:
+        return self._output(
+            event["call_id"],
+            "The canonical host tool queue is full, so this tool was not run.",
+        )
+
+    async def handle_tool_batch_async(
+        self, events: tuple[dict, ...], batch_id: str
+    ) -> list[list[talk_realtime.RealtimeCommand]]:
+        outputs: list[list[talk_realtime.RealtimeCommand] | None] = [None] * len(events)
+        permits = []
+        permitted_positions = []
+        for position, event in enumerate(events):
+            try:
+                arguments = json.loads(event["arguments"])
+            except (TypeError, ValueError, json.JSONDecodeError):
+                arguments = None
+            response_id = event.get("response_id")
+            item_id = event.get("item_id")
+            if type(arguments) is not dict or not response_id or not item_id:
+                outputs[position] = self._output(
+                    event["call_id"], HOST_TOOL_ARGUMENT_ERROR
+                )
+                continue
+            permits.append(
+                self.attachment.mint_tool_call_permit(
+                    response_id=response_id,
+                    item_id=item_id,
+                    call_id=event["call_id"],
+                    batch_id=batch_id,
+                    tool_name=event["name"],
+                    arguments=arguments,
+                )
+            )
+            permitted_positions.append(position)
+
+        if permits:
+            results = await self.attachment.execute_tool_batch(tuple(permits))
+            by_call_id = {result["call_id"]: result["output"] for result in results}
+            for position in permitted_positions:
+                call_id = events[position]["call_id"]
+                outputs[position] = self._output(call_id, by_call_id[call_id])
+        return [output or [] for output in outputs]
 
 
 async def pump_announcements(
@@ -653,7 +741,10 @@ def _neutral_response_command(message: dict) -> talk_realtime.StartResponse:
 
 
 async def run_talk_session(
-    audio: object | None = None, *, session_factory=None
+    audio: object | None = None,
+    *,
+    session_factory=None,
+    host_execution_attachment=None,
 ) -> int:
     """Run one voice session. Returns a process exit code.
 
@@ -672,11 +763,24 @@ async def run_talk_session(
         voice = talk_config.talk_voice()
     except (talk_config.TalkConfigError, talk_auth.TalkAuthError) as exc:
         print(f"talk: {exc}", file=sys.stderr)
+        if host_execution_attachment is not None:
+            host_execution_attachment.close()
         return 1
 
-    tools = talk_tools.default_talk_tools()
+    try:
+        tools = (
+            host_execution_attachment.tool_definitions()
+            if host_execution_attachment is not None
+            else talk_tools.default_talk_tools()
+        )
+    except Exception as exc:  # noqa: BLE001 - host attachment startup boundary
+        print(f"talk: host tool setup failed: {type(exc).__name__}", file=sys.stderr)
+        host_execution_attachment.close()
+        return 1
     instructions = talk_identity.build_instructions(
-        talk_host.host().identity_sections(), tools=tools
+        talk_host.host().identity_sections(),
+        tools=tools,
+        host_execution=host_execution_attachment is not None,
     )
 
     # Find out NOW whether the api_server lane is up. The verdict is needed by
@@ -702,6 +806,8 @@ async def run_talk_session(
         audio.start()
     except talk_audio.TalkAudioError as exc:
         print(f"talk: {exc}", file=sys.stderr)
+        if host_execution_attachment is not None:
+            host_execution_attachment.close()
         return 1
 
     setup = talk_realtime.SessionSetup(
@@ -761,6 +867,8 @@ async def run_talk_session(
         audio.stop()
         capture.finish()
         talk_transcript.sweep_transcripts(hermes_home)
+        if host_execution_attachment is not None:
+            host_execution_attachment.close()
         raise
     except Exception as exc:  # noqa: BLE001 — provider startup is a voice boundary
         print(f"talk: {exc}", file=sys.stderr)
@@ -774,6 +882,8 @@ async def run_talk_session(
         audio.stop()
         capture.finish()
         talk_transcript.sweep_transcripts(hermes_home)
+        if host_execution_attachment is not None:
+            host_execution_attachment.close()
         return 1
 
     try:
@@ -843,7 +953,11 @@ async def run_talk_session(
                     return
 
         tool_coordinator = ToolResponseCoordinator(
-            relay,
+            (
+                HostExecutionRelay(host_execution_attachment)
+                if host_execution_attachment is not None
+                else relay
+            ),
             send_outgoing,
             max_pending=TOOL_SESSION_QUEUE_SIZE,
             provider_neutral=True,
@@ -897,6 +1011,7 @@ async def run_talk_session(
                     tool_event = {
                         "call_id": event.call_id,
                         "response_id": event.response_id,
+                        "item_id": event.item_id,
                         "name": event.name,
                         "arguments": event.arguments,
                     }
@@ -1055,6 +1170,8 @@ async def run_talk_session(
             audio.stop()
             capture.finish()
             talk_transcript.sweep_transcripts(hermes_home)
+            if host_execution_attachment is not None:
+                host_execution_attachment.close()
 
     return result
 

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -28,6 +28,7 @@ except ImportError:  # pragma: no cover - flat-module fallback
 
 _CORE_IMPORT_ERROR: BaseException | None = None
 try:
+    from agent import realtime_voice_provider as _core_api
     from agent.realtime_voice_provider import (
         REALTIME_VOICE_PROVIDER_API_VERSION,
         InputTranscript,
@@ -72,6 +73,29 @@ try:
 except Exception as exc:  # noqa: BLE001 - optional core must never poison legacy imports
     _CORE_IMPORT_ERROR = exc
 
+_EXPLICIT_RESPONSE_SYMBOL_NAMES = (
+    "RealtimeInputAudioFormat",
+    "RealtimeOutputAudioFormat",
+    "RealtimeResponseRequest",
+    "ResponseStarted",
+    "OutputAudio",
+    "OutputTranscript",
+    "ResponseCompleted",
+)
+_CANCELLATION_SYMBOL_NAMES = ("InputSpeechStarted", "Interruption")
+_EXPLICIT_RESPONSE_SURFACE_AVAILABLE = _CORE_IMPORT_ERROR is None and all(
+    isinstance(getattr(_core_api, name, None), type)
+    for name in _EXPLICIT_RESPONSE_SYMBOL_NAMES
+)
+_RESPONSE_CANCELLATION_SURFACE_AVAILABLE = (
+    _CORE_IMPORT_ERROR is None
+    and all(
+        isinstance(getattr(_core_api, name, None), type)
+        for name in _CANCELLATION_SYMBOL_NAMES
+    )
+    and hasattr(RealtimeCapability, "RESPONSE_CANCELLATION")
+)
+
 DEFAULT_INPUT_LEDGER_CAPACITY = 1024
 MAX_IDENTIFIER_LENGTH = 512
 MAX_TRANSCRIPT_LENGTH = 1_000_000
@@ -104,6 +128,26 @@ if _CORE_IMPORT_ERROR is None:
     SUPPORTED_AUDIO_FORMAT = RealtimeAudioFormat(
         mime_type="audio/pcm", sample_rate_hz=24_000, channels=1
     )
+    if _EXPLICIT_RESPONSE_SURFACE_AVAILABLE:
+        SUPPORTED_INPUT_AUDIO_FORMAT = _core_api.RealtimeInputAudioFormat(
+            mime_type="audio/pcm",
+            sample_rate_hz=24_000,
+            channels=1,
+            sample_encoding="pcm_s16le",
+            sample_width_bytes=2,
+            endianness="little",
+        )
+        SUPPORTED_OUTPUT_AUDIO_FORMAT = _core_api.RealtimeOutputAudioFormat(
+            mime_type="audio/pcm",
+            sample_rate_hz=24_000,
+            channels=1,
+            sample_encoding="pcm_s16le",
+            sample_width_bytes=2,
+            endianness="little",
+        )
+    else:
+        SUPPORTED_INPUT_AUDIO_FORMAT = None
+        SUPPORTED_OUTPUT_AUDIO_FORMAT = None
     CORE_CAPABILITIES = frozenset(
         {
             RealtimeCapability.INPUT_TRANSCRIPTION,
@@ -162,17 +206,27 @@ if _CORE_IMPORT_ERROR is None:
             raise TypeError("setup must be a RealtimeVoiceSetup")
         if setup.tools:
             raise ValueError("the input-only core provider does not accept tools")
-        if setup.audio is not None and setup.audio != SUPPORTED_AUDIO_FORMAT:
+        input_audio = getattr(setup, "input_audio", None)
+        output_audio = getattr(setup, "output_audio", None)
+        if input_audio is None and output_audio is None:
+            input_audio = setup.audio
+            output_audio = setup.audio
+        if input_audio is not None and input_audio not in {
+            SUPPORTED_AUDIO_FORMAT,
+            SUPPORTED_INPUT_AUDIO_FORMAT,
+        }:
             raise ValueError("the input-only core provider requires audio/pcm at 24000 Hz mono")
+        if output_audio is not None and output_audio not in {
+            SUPPORTED_AUDIO_FORMAT,
+            SUPPORTED_OUTPUT_AUDIO_FORMAT,
+        }:
+            raise ValueError("the input-only core provider requires audio/pcm at 24000 Hz mono")
+        if getattr(setup, "automatic_response", False) is not False:
+            raise ValueError("automatic_response must remain exactly false in the core lane")
         options = setup.provider_options
-        unknown = set(options) - {"automatic_response", "capabilities"}
+        unknown = set(options) - {"capabilities"}
         if unknown:
             raise ValueError(f"unsupported provider option: {sorted(unknown)[0]}")
-        automatic_response = options.get("automatic_response", False)
-        if not isinstance(automatic_response, bool):
-            raise TypeError("automatic_response must be boolean")
-        if automatic_response:
-            raise ValueError("automatic_response must remain false in the core lane")
         if "capabilities" in options:
             _requested_capabilities(options["capabilities"])
 
@@ -469,6 +523,8 @@ if _CORE_IMPORT_ERROR is None:
 
 else:
     SUPPORTED_AUDIO_FORMAT = None
+    SUPPORTED_INPUT_AUDIO_FORMAT = None
+    SUPPORTED_OUTPUT_AUDIO_FORMAT = None
     CORE_CAPABILITIES = frozenset()
     TalkOpenAIRealtimeProvider = None
 
@@ -478,6 +534,8 @@ __all__ = [
     "DEFAULT_INPUT_LEDGER_CAPACITY",
     "PROVIDER_NAME",
     "SUPPORTED_AUDIO_FORMAT",
+    "SUPPORTED_INPUT_AUDIO_FORMAT",
+    "SUPPORTED_OUTPUT_AUDIO_FORMAT",
     "OpenAIWireEOF",
     "OpenAIWireError",
     "TalkOpenAIRealtimeProvider",

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -1,4 +1,4 @@
-"""Defensive Hermes core API-v2 input-only OpenAI Realtime adapter.
+"""Defensive Hermes core API-v2 OpenAI Realtime adapter.
 
 The optional core boundary is deliberately contained in this module.  Legacy
 Talk never imports Hermes core through its OpenAI transport, and this module
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from collections.abc import AsyncIterator, Callable, Mapping
+import binascii
+import secrets
+from collections import OrderedDict
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 try:
@@ -19,16 +23,23 @@ try:
         OpenAIWireEOF,
         OpenAIWireError,
         _OpenAIWireSession,
+        build_core_response_create,
     )
 except ImportError:  # pragma: no cover - flat-module fallback
     import talk_auth
     import talk_config
     import talk_wire
-    from talk_openai_realtime import OpenAIWireEOF, OpenAIWireError, _OpenAIWireSession
+    from talk_openai_realtime import (
+        OpenAIWireEOF,
+        OpenAIWireError,
+        _OpenAIWireSession,
+        build_core_response_create,
+    )
 
 _CORE_IMPORT_ERROR: BaseException | None = None
+_EXPLICIT_OUTPUT_AVAILABLE = False
 try:
-    from agent import realtime_voice_provider as _core_api
+    from agent import realtime_voice_provider as _core_contract
     from agent.realtime_voice_provider import (
         REALTIME_VOICE_PROVIDER_API_VERSION,
         InputTranscript,
@@ -70,31 +81,57 @@ try:
     ):
         if not isinstance(enum_type, type) or any(not hasattr(enum_type, name) for name in names):
             raise ImportError("Hermes realtime voice API-v2 enum shape is incompatible")
+    try:
+        RealtimeInputAudioFormat = _core_contract.RealtimeInputAudioFormat
+        RealtimeOutputAudioFormat = _core_contract.RealtimeOutputAudioFormat
+        RealtimeResponseRequest = _core_contract.RealtimeResponseRequest
+        ResponseStarted = _core_contract.ResponseStarted
+        OutputAudio = _core_contract.OutputAudio
+        OutputTranscript = _core_contract.OutputTranscript
+        ResponseCompleted = _core_contract.ResponseCompleted
+        _EXPLICIT_OUTPUT_AVAILABLE = all(
+            isinstance(symbol, type)
+            for symbol in (
+                RealtimeInputAudioFormat,
+                RealtimeOutputAudioFormat,
+                RealtimeResponseRequest,
+                ResponseStarted,
+                OutputAudio,
+                OutputTranscript,
+                ResponseCompleted,
+            )
+        ) and all(
+            hasattr(RealtimeCapability, name)
+            for name in (
+                "EXPLICIT_RESPONSE",
+                "RESPONSE_METADATA_ECHO",
+                "OUTPUT_TRANSCRIPTION",
+            )
+        )
+    except (AttributeError, ImportError):
+        _EXPLICIT_OUTPUT_AVAILABLE = False
 except Exception as exc:  # noqa: BLE001 - optional core must never poison legacy imports
     _CORE_IMPORT_ERROR = exc
 
-_EXPLICIT_RESPONSE_SYMBOL_NAMES = (
-    "RealtimeInputAudioFormat",
-    "RealtimeOutputAudioFormat",
-    "RealtimeResponseRequest",
-    "ResponseStarted",
-    "OutputAudio",
-    "OutputTranscript",
-    "ResponseCompleted",
-)
-_CANCELLATION_SYMBOL_NAMES = ("InputSpeechStarted", "Interruption")
+# Compatibility diagnostics intentionally distinguish the detected data surface
+# from the complete production capability (which also requires enum claims and
+# the concrete mapper/hook implemented below).
 _EXPLICIT_RESPONSE_SURFACE_AVAILABLE = _CORE_IMPORT_ERROR is None and all(
-    isinstance(getattr(_core_api, name, None), type)
-    for name in _EXPLICIT_RESPONSE_SYMBOL_NAMES
-)
-_RESPONSE_CANCELLATION_SURFACE_AVAILABLE = (
-    _CORE_IMPORT_ERROR is None
-    and all(
-        isinstance(getattr(_core_api, name, None), type)
-        for name in _CANCELLATION_SYMBOL_NAMES
+    isinstance(getattr(_core_contract, name, None), type)
+    for name in (
+        "RealtimeInputAudioFormat",
+        "RealtimeOutputAudioFormat",
+        "RealtimeResponseRequest",
+        "ResponseStarted",
+        "OutputAudio",
+        "OutputTranscript",
+        "ResponseCompleted",
     )
-    and hasattr(RealtimeCapability, "RESPONSE_CANCELLATION")
 )
+_RESPONSE_CANCELLATION_SURFACE_AVAILABLE = _CORE_IMPORT_ERROR is None and all(
+    isinstance(getattr(_core_contract, name, None), type)
+    for name in ("InputSpeechStarted", "Interruption")
+) and hasattr(RealtimeCapability, "RESPONSE_CANCELLATION")
 
 DEFAULT_INPUT_LEDGER_CAPACITY = 1024
 MAX_IDENTIFIER_LENGTH = 512
@@ -106,6 +143,12 @@ def core_provider_available() -> bool:
     """Return only whether the exact optional Hermes core API-v2 is importable."""
 
     return _CORE_IMPORT_ERROR is None
+
+
+def explicit_output_available() -> bool:
+    """Return whether the installed API-v2 exposes native explicit output."""
+
+    return _CORE_IMPORT_ERROR is None and _EXPLICIT_OUTPUT_AVAILABLE
 
 
 def core_provider_diagnostic() -> dict[str, bool]:
@@ -128,8 +171,8 @@ if _CORE_IMPORT_ERROR is None:
     SUPPORTED_AUDIO_FORMAT = RealtimeAudioFormat(
         mime_type="audio/pcm", sample_rate_hz=24_000, channels=1
     )
-    if _EXPLICIT_RESPONSE_SURFACE_AVAILABLE:
-        SUPPORTED_INPUT_AUDIO_FORMAT = _core_api.RealtimeInputAudioFormat(
+    SUPPORTED_OUTPUT_AUDIO_FORMAT = (
+        RealtimeOutputAudioFormat(
             mime_type="audio/pcm",
             sample_rate_hz=24_000,
             channels=1,
@@ -137,7 +180,11 @@ if _CORE_IMPORT_ERROR is None:
             sample_width_bytes=2,
             endianness="little",
         )
-        SUPPORTED_OUTPUT_AUDIO_FORMAT = _core_api.RealtimeOutputAudioFormat(
+        if _EXPLICIT_OUTPUT_AVAILABLE
+        else None
+    )
+    SUPPORTED_INPUT_AUDIO_FORMAT = (
+        RealtimeInputAudioFormat(
             mime_type="audio/pcm",
             sample_rate_hz=24_000,
             channels=1,
@@ -145,15 +192,84 @@ if _CORE_IMPORT_ERROR is None:
             sample_width_bytes=2,
             endianness="little",
         )
-    else:
-        SUPPORTED_INPUT_AUDIO_FORMAT = None
-        SUPPORTED_OUTPUT_AUDIO_FORMAT = None
+        if _EXPLICIT_OUTPUT_AVAILABLE
+        else None
+    )
     CORE_CAPABILITIES = frozenset(
+        {RealtimeCapability.INPUT_TRANSCRIPTION, RealtimeCapability.INPUT_COMMIT_EVENTS}
+        | (
+            {
+                RealtimeCapability.EXPLICIT_RESPONSE,
+                RealtimeCapability.RESPONSE_METADATA_ECHO,
+                RealtimeCapability.OUTPUT_TRANSCRIPTION,
+            }
+            if _EXPLICIT_OUTPUT_AVAILABLE
+            else set()
+        )
+    )
+    _OUTPUT_ITEM_KEYS = frozenset({"id", "type", "role", "status", "content"})
+    _OUTPUT_ITEM_ALLOWED_KEYS = _OUTPUT_ITEM_KEYS | {"object"}
+    _OUTPUT_AUDIO_PART_KEYS = frozenset({"type", "transcript"})
+    _OUTPUT_EVENT_TYPES = frozenset(
         {
-            RealtimeCapability.INPUT_TRANSCRIPTION,
-            RealtimeCapability.INPUT_COMMIT_EVENTS,
+            "response.created",
+            "response.output_item.added",
+            "response.output_item.done",
+            "response.content_part.added",
+            "response.content_part.done",
+            "response.output_audio.delta",
+            "response.output_audio.done",
+            "response.output_audio_transcript.delta",
+            "response.output_audio_transcript.done",
+            "conversation.item.done",
+            "response.done",
         }
     )
+    _FORBIDDEN_OUTPUT_AUTHORITY_KEYS = frozenset(
+        {
+            "tool_calls",
+            "function_call",
+            "function",
+            "tool",
+            "tools",
+            "tool_choice",
+            "call_id",
+            "name",
+            "arguments",
+            "function_call_output",
+        }
+    )
+    _FORBIDDEN_OUTPUT_AUTHORITY_TYPES = frozenset(
+        {"function_call", "function_call_output", "tool", "tool_call"}
+    )
+
+    def _validate_output_event_authority(value: Any) -> None:
+        if isinstance(value, Mapping):
+            forbidden = _FORBIDDEN_OUTPUT_AUTHORITY_KEYS.intersection(value)
+            if forbidden:
+                raise ValueError(
+                    f"output event has forbidden structured authority: {sorted(forbidden)[0]}"
+                )
+            discriminator = value.get("type")
+            if (
+                isinstance(discriminator, str)
+                and discriminator in _FORBIDDEN_OUTPUT_AUTHORITY_TYPES
+            ):
+                raise ValueError(
+                    f"output event has forbidden structured authority type: {discriminator}"
+                )
+            for nested in value.values():
+                _validate_output_event_authority(nested)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            for nested in value:
+                _validate_output_event_authority(nested)
+
+    @dataclass(frozen=True, slots=True)
+    class _ResponseBinding:
+        durable_session_id: str
+        assistant_message_id: int
+        turn_marker: str
+        content_digest: str
 
     def _validate_identifier(value: Any, field_name: str) -> str:
         if (
@@ -206,27 +322,30 @@ if _CORE_IMPORT_ERROR is None:
             raise TypeError("setup must be a RealtimeVoiceSetup")
         if setup.tools:
             raise ValueError("the input-only core provider does not accept tools")
-        input_audio = getattr(setup, "input_audio", None)
-        output_audio = getattr(setup, "output_audio", None)
-        if input_audio is None and output_audio is None:
-            input_audio = setup.audio
-            output_audio = setup.audio
-        if input_audio is not None and input_audio not in {
-            SUPPORTED_AUDIO_FORMAT,
-            SUPPORTED_INPUT_AUDIO_FORMAT,
-        }:
+        if setup.audio is not None and setup.audio != SUPPORTED_AUDIO_FORMAT:
             raise ValueError("the input-only core provider requires audio/pcm at 24000 Hz mono")
-        if output_audio is not None and output_audio not in {
-            SUPPORTED_AUDIO_FORMAT,
-            SUPPORTED_OUTPUT_AUDIO_FORMAT,
-        }:
-            raise ValueError("the input-only core provider requires audio/pcm at 24000 Hz mono")
-        if getattr(setup, "automatic_response", False) is not False:
-            raise ValueError("automatic_response must remain exactly false in the core lane")
+        if _EXPLICIT_OUTPUT_AVAILABLE:
+            if (
+                setup.input_audio is not None
+                and setup.input_audio != SUPPORTED_INPUT_AUDIO_FORMAT
+            ):
+                raise ValueError("the core provider requires exact 24kHz mono PCM input audio")
+            if (
+                setup.output_audio is not None
+                and setup.output_audio != SUPPORTED_OUTPUT_AUDIO_FORMAT
+            ):
+                raise ValueError("the core provider requires exact 24kHz mono PCM output audio")
+            if setup.automatic_response:
+                raise ValueError("automatic_response must remain false in the core lane")
         options = setup.provider_options
-        unknown = set(options) - {"capabilities"}
+        unknown = set(options) - {"automatic_response", "capabilities"}
         if unknown:
             raise ValueError(f"unsupported provider option: {sorted(unknown)[0]}")
+        automatic_response = options.get("automatic_response", False)
+        if not isinstance(automatic_response, bool):
+            raise TypeError("automatic_response must be boolean")
+        if automatic_response:
+            raise ValueError("automatic_response must remain false in the core lane")
         if "capabilities" in options:
             _requested_capabilities(options["capabilities"])
 
@@ -250,11 +369,32 @@ if _CORE_IMPORT_ERROR is None:
             wire,
             audio_format: RealtimeAudioFormat,
             ledger_capacity: int,
+            voice: str,
+            response_ledger_capacity: int,
+            token_factory: Callable[[], str],
         ) -> None:
             super().__init__(CORE_CAPABILITIES)
             self._wire = wire
             self._audio_format = audio_format
             self._ledger_capacity = ledger_capacity
+            self._voice = voice
+            self._response_ledger_capacity = response_ledger_capacity
+            self._token_factory = token_factory
+            self._response_lock = asyncio.Lock()
+            self._pending_responses: dict[str, _ResponseBinding] = {}
+            self._active_responses: dict[str, tuple[str, _ResponseBinding]] = {}
+            self._response_items: dict[str, str] = {}
+            self._item_responses: dict[str, str] = {}
+            self._final_output_transcripts: dict[tuple[str, str], str] = {}
+            self._audio_delta_items: set[tuple[str, str]] = set()
+            self._audio_done_items: set[tuple[str, str]] = set()
+            self._output_item_added: set[tuple[str, str]] = set()
+            self._content_part_added: set[tuple[str, str]] = set()
+            self._content_part_done: set[tuple[str, str]] = set()
+            self._output_item_done: set[tuple[str, str]] = set()
+            self._conversation_item_done: set[tuple[str, str]] = set()
+            self._completed_responses: OrderedDict[str, str] = OrderedDict()
+            self._consumed_correlations: OrderedDict[str, None] = OrderedDict()
             self._input_ledger: dict[str, str | None] = {}
             self._provider_session_id: str | None = None
             self._terminal = False
@@ -307,6 +447,49 @@ if _CORE_IMPORT_ERROR is None:
             del batch_id, results
             raise RuntimeError("the input-only core provider does not accept tool results")
 
+        async def _start_response(self, request) -> None:
+            if request.output_audio_format != SUPPORTED_OUTPUT_AUDIO_FORMAT:
+                raise ValueError("explicit response output audio format is unsupported")
+            correlation = _validate_identifier(self._token_factory(), "correlation token")
+            binding = _ResponseBinding(
+                durable_session_id=request.durable_session_id,
+                assistant_message_id=request.assistant_message_id,
+                turn_marker=request.turn_marker,
+                content_digest=request.content_digest,
+            )
+            async with self._response_lock:
+                active_correlations = {
+                    active_correlation
+                    for active_correlation, _binding in self._active_responses.values()
+                }
+                if (
+                    correlation in self._pending_responses
+                    or correlation in self._consumed_correlations
+                    or correlation in active_correlations
+                ):
+                    raise ValueError("correlation token was already used")
+                accepted_responses = (
+                    len(self._pending_responses)
+                    + len(self._active_responses)
+                    + len(self._completed_responses)
+                )
+                if accepted_responses >= self._response_ledger_capacity:
+                    raise ValueError("response lifetime capacity exhausted")
+                self._pending_responses[correlation] = binding
+            message = build_core_response_create(
+                canonical_text=request.canonical_text,
+                correlation=correlation,
+                voice=self._voice,
+                event_id=f"evt-{secrets.token_urlsafe(24)}",
+            )
+            try:
+                await self._send_wire(message)
+            except BaseException:
+                async with self._response_lock:
+                    if self._pending_responses.get(correlation) == binding:
+                        del self._pending_responses[correlation]
+                raise
+
         def _input_transcript(self, event: Mapping[str, Any], *, final: bool) -> InputTranscript:
             explicit_finality = event.get("final")
             if "final" in event and not isinstance(explicit_finality, bool):
@@ -330,10 +513,198 @@ if _CORE_IMPORT_ERROR is None:
                 provenance=TranscriptProvenance.OPERATOR_INPUT,
             )
 
+        @staticmethod
+        def _response_metadata(response: Mapping[str, Any]) -> str:
+            metadata = response.get("metadata")
+            if not isinstance(metadata, Mapping) or set(metadata) != {"correlation"}:
+                raise ValueError("response metadata must contain only the correlation token")
+            return _validate_identifier(metadata.get("correlation"), "correlation token")
+
+        def _bind_response_created(self, event: Mapping[str, Any]):
+            response = event.get("response")
+            if not isinstance(response, Mapping):
+                raise TypeError("response.created requires a response object")
+            response_id = _validate_identifier(response.get("id"), "response_id")
+            if response_id in self._active_responses or response_id in self._completed_responses:
+                raise ValueError("duplicate or conflicting provider response_id")
+            correlation = self._response_metadata(response)
+            if correlation in self._consumed_correlations:
+                raise ValueError("replayed correlation token")
+            binding = self._pending_responses.get(correlation)
+            if binding is None:
+                raise ValueError("unknown or unsolicited correlation token")
+            accepted_responses = (
+                len(self._pending_responses)
+                + len(self._active_responses)
+                + len(self._completed_responses)
+            )
+            if accepted_responses > self._response_ledger_capacity:
+                raise ValueError("response lifetime capacity exhausted")
+            if len(self._consumed_correlations) >= self._response_ledger_capacity:
+                raise ValueError("consumed correlation capacity exhausted")
+            del self._pending_responses[correlation]
+            self._consumed_correlations[correlation] = None
+            self._active_responses[response_id] = (correlation, binding)
+            return ResponseStarted(response_id=response_id, turn_id=binding.turn_marker)
+
+        def _validate_active_response(
+            self, event: Mapping[str, Any]
+        ) -> tuple[str, str, _ResponseBinding, str]:
+            response_id = _validate_identifier(event.get("response_id"), "response_id")
+            active = self._active_responses.get(response_id)
+            if active is None:
+                raise ValueError("output event references an unbound response")
+            item_id = _validate_identifier(event.get("item_id"), "item_id")
+            known_item = self._response_items.get(response_id)
+            known_response = self._item_responses.get(item_id)
+            if known_item is not None and known_item != item_id:
+                raise ValueError("output item identity changed for response")
+            if known_response is not None and known_response != response_id:
+                raise ValueError("output item is already bound to another response")
+            return response_id, active[0], active[1], item_id
+
+        def _active_response(self, event: Mapping[str, Any]) -> tuple[str, _ResponseBinding, str]:
+            response_id, correlation, binding, item_id = self._validate_active_response(event)
+            self._response_items[response_id] = item_id
+            self._item_responses[item_id] = response_id
+            return correlation, binding, item_id
+
+        def _validate_output_audio_part(
+            self,
+            part: Any,
+            *,
+            response_id: str,
+            item_id: str,
+            context: str,
+        ) -> Mapping[str, Any]:
+            if not isinstance(part, Mapping):
+                raise TypeError(f"{context} requires an output_audio part object")
+            if not set(part).issubset(_OUTPUT_AUDIO_PART_KEYS):
+                raise ValueError(f"{context} output_audio part has an invalid authority shape")
+            if part.get("type") != "output_audio":
+                raise ValueError(f"{context} content type must be output_audio")
+            if "transcript" in part:
+                transcript = _validate_text(part["transcript"], final=True)
+                terminal = self._final_output_transcripts.get((response_id, item_id))
+                if terminal is not None and transcript != terminal:
+                    raise ValueError(f"{context} transcript conflicts with final text")
+            return part
+
+        def _validate_output_item_shape(
+            self,
+            item: Any,
+            *,
+            response_id: str,
+            stage: str,
+        ) -> tuple[str, Mapping[str, Any] | None]:
+            if not isinstance(item, Mapping):
+                raise TypeError(f"{stage} requires an output item object")
+            if not set(item).issubset(_OUTPUT_ITEM_ALLOWED_KEYS):
+                raise ValueError(f"{stage} output item has an invalid authority shape")
+            if "object" in item and (
+                type(item["object"]) is not str or item["object"] != "realtime.item"
+            ):
+                raise ValueError(f"{stage} output item object must be realtime.item")
+            if item.get("type") != "message":
+                raise ValueError(f"{stage} output item type must be message")
+            if item.get("role") != "assistant":
+                raise ValueError(f"{stage} output item role must be assistant")
+            item_id = _validate_identifier(item.get("id"), "output item_id")
+            status = item.get("status")
+            if stage == "response.output_item.added":
+                if status is not None and status != "in_progress":
+                    raise ValueError("added output item status must be in_progress")
+            elif status is not None and status != "completed":
+                raise ValueError(f"{stage} output item status must be completed")
+            if "content" not in item:
+                raise ValueError(f"{stage} output item content is required")
+            content = item["content"]
+            if not isinstance(content, (list, tuple)):
+                raise TypeError(f"{stage} output item content must be a sequence")
+            if stage == "response.output_item.added" and not content:
+                return item_id, None
+            if len(content) != 1:
+                raise ValueError(f"{stage} output item content must contain exactly one part")
+            part = self._validate_output_audio_part(
+                content[0],
+                response_id=response_id,
+                item_id=item_id,
+                context=stage,
+            )
+            return item_id, part
+
+        @staticmethod
+        def _note_lifecycle_stage(
+            observed: set[tuple[str, str]], key: tuple[str, str], event_type: str
+        ) -> None:
+            if key in observed:
+                raise ValueError(f"{event_type} was replayed")
+            observed.add(key)
+
+        def _complete_response(self, event: Mapping[str, Any]):
+            response = event.get("response")
+            if not isinstance(response, Mapping):
+                raise TypeError("response.done requires a response object")
+            response_id = _validate_identifier(response.get("id"), "response_id")
+            if response_id in self._completed_responses:
+                raise ValueError("response completion was replayed")
+            active = self._active_responses.get(response_id)
+            if active is None:
+                raise ValueError("completion references an unbound response")
+            correlation, binding = active
+            if self._response_metadata(response) != correlation:
+                raise ValueError("response completion correlation mismatch")
+            if response.get("status") != "completed":
+                raise ValueError("response status must be completed")
+            if "output" not in response:
+                raise ValueError("response output is required")
+            output = response["output"]
+            if not isinstance(output, (list, tuple)):
+                raise TypeError("response output must be a sequence")
+            if not output:
+                raise ValueError("response output must be nonempty")
+            if len(output) != 1:
+                raise ValueError("response output must contain exactly one item")
+            item = output[0]
+            output_item_id, _part = self._validate_output_item_shape(
+                item,
+                response_id=response_id,
+                stage="response.done",
+            )
+            known_item_id = self._response_items.get(response_id)
+            if known_item_id is None or output_item_id != known_item_id:
+                raise ValueError("response completion output item identity changed")
+            stream_key = (response_id, output_item_id)
+            final_transcript = self._final_output_transcripts.get(stream_key)
+            if final_transcript is None:
+                raise ValueError("response completion requires transcript done")
+            if stream_key not in self._audio_delta_items:
+                raise ValueError("response completion requires audio delta")
+            if stream_key not in self._audio_done_items:
+                raise ValueError("response completion requires audio done")
+            if len(self._completed_responses) >= self._response_ledger_capacity:
+                raise ValueError("completed response capacity exhausted")
+            del self._active_responses[response_id]
+            item_id = self._response_items.pop(response_id, None)
+            if item_id is not None:
+                self._item_responses.pop(item_id, None)
+                self._final_output_transcripts.pop((response_id, item_id), None)
+                self._audio_delta_items.discard((response_id, item_id))
+                self._audio_done_items.discard((response_id, item_id))
+                self._output_item_added.discard((response_id, item_id))
+                self._content_part_added.discard((response_id, item_id))
+                self._content_part_done.discard((response_id, item_id))
+                self._output_item_done.discard((response_id, item_id))
+                self._conversation_item_done.discard((response_id, item_id))
+            self._completed_responses[response_id] = correlation
+            return ResponseCompleted(response_id=response_id, turn_id=binding.turn_marker)
+
         def _map_event(self, event: Mapping[str, Any]):
             event_type = event.get("type")
             if not isinstance(event_type, str) or not event_type:
                 raise ValueError("provider event type must be a nonblank string")
+            if event_type in _OUTPUT_EVENT_TYPES:
+                _validate_output_event_authority(event)
             if event_type == "session.created":
                 session = event.get("session")
                 session_id = _validate_identifier(
@@ -355,6 +726,134 @@ if _CORE_IMPORT_ERROR is None:
                 return self._input_transcript(event, final=False)
             if event_type == "conversation.item.input_audio_transcription.completed":
                 return self._input_transcript(event, final=True)
+            if event_type == "response.created":
+                return self._bind_response_created(event)
+            if event_type == "response.output_audio.delta":
+                delta = event.get("delta")
+                if not isinstance(delta, str) or not delta:
+                    raise ValueError("output audio delta must be nonempty base64 text")
+                try:
+                    data = base64.b64decode(delta, validate=True)
+                except (binascii.Error, ValueError, TypeError) as exc:
+                    raise ValueError("output audio delta is malformed base64") from exc
+                if not data:
+                    raise ValueError("output audio delta decoded to empty data")
+                response_id, _correlation, binding, item_id = (
+                    self._validate_active_response(event)
+                )
+                self._response_items[response_id] = item_id
+                self._item_responses[item_id] = response_id
+                self._audio_delta_items.add((response_id, item_id))
+                return OutputAudio(
+                    data=data,
+                    item_id=item_id,
+                    response_id=response_id,
+                    turn_id=binding.turn_marker,
+                )
+            if event_type in {
+                "response.output_audio_transcript.delta",
+                "response.output_audio_transcript.done",
+            }:
+                final = event_type.endswith(".done")
+                text = _validate_text(
+                    event.get("transcript" if final else "delta"), final=final
+                )
+                response_id, _correlation, binding, item_id = (
+                    self._validate_active_response(event)
+                )
+                transcript_key = (response_id, item_id)
+                terminal_text = self._final_output_transcripts.get(transcript_key)
+                if terminal_text is not None:
+                    if not final:
+                        raise ValueError("output transcript is already terminal")
+                    if terminal_text == text:
+                        raise ValueError("output transcript terminal event was replayed")
+                    raise ValueError("conflicting terminal output transcript")
+                self._response_items[response_id] = item_id
+                self._item_responses[item_id] = response_id
+                if final:
+                    self._final_output_transcripts[transcript_key] = text
+                return OutputTranscript(
+                    item_id=item_id,
+                    response_id=response_id,
+                    turn_id=binding.turn_marker,
+                    text=text,
+                    final=final,
+                )
+            if event_type == "response.done":
+                return self._complete_response(event)
+            if "function_call" in event_type:
+                raise ValueError(f"function/tool output is forbidden: {event_type}")
+            if event_type == "response.output_audio.done":
+                response_id, _correlation, _binding, item_id = (
+                    self._validate_active_response(event)
+                )
+                stream_key = (response_id, item_id)
+                if stream_key in self._audio_done_items:
+                    raise ValueError("output audio done event was replayed")
+                self._response_items[response_id] = item_id
+                self._item_responses[item_id] = response_id
+                self._audio_done_items.add(stream_key)
+                return None
+            if event_type in {"response.output_item.added", "response.output_item.done"}:
+                response_id = _validate_identifier(event.get("response_id"), "response_id")
+                item_id, _part = self._validate_output_item_shape(
+                    event.get("item"),
+                    response_id=response_id,
+                    stage=event_type,
+                )
+                normalized = dict(event)
+                normalized["item_id"] = item_id
+                response_id, _correlation, _binding, item_id = self._validate_active_response(
+                    normalized
+                )
+                observed = (
+                    self._output_item_added
+                    if event_type.endswith(".added")
+                    else self._output_item_done
+                )
+                self._note_lifecycle_stage(observed, (response_id, item_id), event_type)
+                self._response_items[response_id] = item_id
+                self._item_responses[item_id] = response_id
+                return None
+            if event_type in {"response.content_part.added", "response.content_part.done"}:
+                response_id, _correlation, _binding, item_id = self._validate_active_response(event)
+                self._validate_output_audio_part(
+                    event.get("part"),
+                    response_id=response_id,
+                    item_id=item_id,
+                    context=event_type,
+                )
+                observed = (
+                    self._content_part_added
+                    if event_type.endswith(".added")
+                    else self._content_part_done
+                )
+                self._note_lifecycle_stage(observed, (response_id, item_id), event_type)
+                self._response_items[response_id] = item_id
+                self._item_responses[item_id] = response_id
+                return None
+            if event_type == "conversation.item.done":
+                item = event.get("item")
+                if not isinstance(item, Mapping):
+                    raise TypeError("conversation.item.done requires an item object")
+                item_id = _validate_identifier(item.get("id"), "item_id")
+                response_id = self._item_responses.get(item_id)
+                if response_id is None or response_id not in self._active_responses:
+                    raise ValueError("conversation item is not bound to an active response")
+                validated_item_id, _part = self._validate_output_item_shape(
+                    item,
+                    response_id=response_id,
+                    stage=event_type,
+                )
+                if validated_item_id != item_id:
+                    raise ValueError("conversation output item identity changed")
+                self._note_lifecycle_stage(
+                    self._conversation_item_done,
+                    (response_id, item_id),
+                    event_type,
+                )
+                return None
             if event_type == "error":
                 error = event.get("error")
                 detail = error.get("message") if isinstance(error, Mapping) else error
@@ -382,8 +881,24 @@ if _CORE_IMPORT_ERROR is None:
 
         async def _terminate(self) -> None:
             self._terminal = True
-            await self._wire.close()
-            self._input_ledger.clear()
+            try:
+                await self._wire.close()
+            finally:
+                self._input_ledger.clear()
+                self._pending_responses.clear()
+                self._active_responses.clear()
+                self._response_items.clear()
+                self._item_responses.clear()
+                self._final_output_transcripts.clear()
+                self._audio_delta_items.clear()
+                self._audio_done_items.clear()
+                self._output_item_added.clear()
+                self._content_part_added.clear()
+                self._content_part_done.clear()
+                self._output_item_done.clear()
+                self._conversation_item_done.clear()
+                self._completed_responses.clear()
+                self._consumed_correlations.clear()
 
         def _take_send_failure(self) -> Exception | None:
             failure, self._pending_send_failure = self._pending_send_failure, None
@@ -457,6 +972,8 @@ if _CORE_IMPORT_ERROR is None:
             auth_resolver: Callable[[], Any] = talk_auth.resolve_auth,
             wire_factory: Callable[..., Any] = _OpenAIWireSession,
             ledger_capacity: int = DEFAULT_INPUT_LEDGER_CAPACITY,
+            response_ledger_capacity: int = 1024,
+            token_factory: Callable[[], str] = lambda: secrets.token_urlsafe(32),
         ) -> None:
             if isinstance(ledger_capacity, bool) or not isinstance(ledger_capacity, int):
                 raise TypeError("ledger_capacity must be a positive integer")
@@ -465,6 +982,16 @@ if _CORE_IMPORT_ERROR is None:
             self._auth_resolver = auth_resolver
             self._wire_factory = wire_factory
             self._ledger_capacity = ledger_capacity
+            if (
+                isinstance(response_ledger_capacity, bool)
+                or not isinstance(response_ledger_capacity, int)
+                or response_ledger_capacity <= 0
+            ):
+                raise ValueError("response_ledger_capacity must be a positive integer")
+            if not callable(token_factory):
+                raise TypeError("token_factory must be callable")
+            self._response_ledger_capacity = response_ledger_capacity
+            self._token_factory = token_factory
 
         @property
         def name(self) -> str:
@@ -472,6 +999,8 @@ if _CORE_IMPORT_ERROR is None:
 
         @property
         def display_name(self) -> str:
+            if _EXPLICIT_OUTPUT_AVAILABLE:
+                return "Hermes Talk OpenAI Realtime (native explicit output)"
             return "Hermes Talk OpenAI Realtime (input only)"
 
         def is_available(self) -> bool:
@@ -486,7 +1015,13 @@ if _CORE_IMPORT_ERROR is None:
             return bool(model and auth.get("configured"))
 
         def list_models(self):
-            return ({"id": talk_config.talk_model(), "input_only": True},)
+            return (
+                {
+                    "id": talk_config.talk_model(),
+                    "input_only": not _EXPLICIT_OUTPUT_AVAILABLE,
+                    "native_explicit_output": _EXPLICIT_OUTPUT_AVAILABLE,
+                },
+            )
 
         def list_voices(self):
             return tuple({"id": voice} for voice in talk_config.OPENAI_REALTIME_VOICES)
@@ -519,6 +1054,9 @@ if _CORE_IMPORT_ERROR is None:
                 wire=wire,
                 audio_format=SUPPORTED_AUDIO_FORMAT,
                 ledger_capacity=self._ledger_capacity,
+                voice=voice,
+                response_ledger_capacity=self._response_ledger_capacity,
+                token_factory=self._token_factory,
             )
 
 else:
@@ -541,4 +1079,5 @@ __all__ = [
     "TalkOpenAIRealtimeProvider",
     "core_provider_available",
     "core_provider_diagnostic",
+    "explicit_output_available",
 ]

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -412,6 +412,7 @@ if _CORE_IMPORT_ERROR is None:
             self._provider_session_id: str | None = None
             self._terminal = False
             self._pending_send_failure: Exception | None = None
+            self._enforce_output_lifecycle = False
 
         def _reserve_input(self, item_id: Any) -> str:
             item_id = _validate_identifier(item_id, "item_id")
@@ -659,7 +660,15 @@ if _CORE_IMPORT_ERROR is None:
         ) -> None:
             if key not in self._response_lifecycle:
                 if event_type != _REQUIRED_OUTPUT_LIFECYCLE[0]:
-                    return
+                    if (
+                        not self._enforce_output_lifecycle
+                        or key[0] not in self._active_responses
+                    ):
+                        return
+                    raise ValueError(
+                        "output lifecycle is out of order: expected "
+                        f"{_REQUIRED_OUTPUT_LIFECYCLE[0]}, got {event_type}"
+                    )
                 self._response_lifecycle[key] = 1
                 return
             stage = self._response_lifecycle[key]
@@ -771,6 +780,10 @@ if _CORE_IMPORT_ERROR is None:
             if event_type == "response.created":
                 return self._bind_response_created(event)
             if event_type == "response.output_audio.delta":
+                response_id, _correlation, binding, item_id = (
+                    self._validate_active_response(event)
+                )
+                self._advance_lifecycle_stage((response_id, item_id), event_type)
                 delta = event.get("delta")
                 if not isinstance(delta, str) or not delta:
                     raise ValueError("output audio delta must be nonempty base64 text")
@@ -780,10 +793,6 @@ if _CORE_IMPORT_ERROR is None:
                     raise ValueError("output audio delta is malformed base64") from exc
                 if not data:
                     raise ValueError("output audio delta decoded to empty data")
-                response_id, _correlation, binding, item_id = (
-                    self._validate_active_response(event)
-                )
-                self._advance_lifecycle_stage((response_id, item_id), event_type)
                 self._response_items[response_id] = item_id
                 self._item_responses[item_id] = response_id
                 self._audio_delta_items.add((response_id, item_id))
@@ -965,6 +974,7 @@ if _CORE_IMPORT_ERROR is None:
                 )
                 return
             try:
+                self._enforce_output_lifecycle = True
                 while True:
                     wire_event = await self._wire.__anext__()
                     mapped = self._map_event(wire_event)

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -245,6 +245,19 @@ if _CORE_IMPORT_ERROR is None:
             "response.done",
         }
     )
+    _AUTHORITY_VALIDATED_EVENT_TYPES = _OUTPUT_EVENT_TYPES | frozenset(
+        {
+            "session.created",
+            "session.updated",
+            "input_audio_buffer.speech_started",
+            "input_audio_buffer.speech_stopped",
+            "input_audio_buffer.committed",
+            "conversation.item.input_audio_transcription.delta",
+            "conversation.item.input_audio_transcription.completed",
+            "rate_limits.updated",
+            "error",
+        }
+    )
     _REQUIRED_OUTPUT_LIFECYCLE = (
         "response.output_item.added",
         "response.content_part.added",
@@ -419,6 +432,7 @@ if _CORE_IMPORT_ERROR is None:
             self._final_output_transcripts: dict[tuple[str, str], str] = {}
             self._audio_delta_items: set[tuple[str, str]] = set()
             self._audio_done_items: set[tuple[str, str]] = set()
+            self._audio_byte_carries: dict[tuple[str, str], bytes] = {}
             self._output_item_added: set[tuple[str, str]] = set()
             self._content_part_added: set[tuple[str, str]] = set()
             self._content_part_done: set[tuple[str, str]] = set()
@@ -465,17 +479,20 @@ if _CORE_IMPORT_ERROR is None:
             try:
                 await self._wire.send_json((message,))
             except Exception as exc:
-                if self._pending_send_failure is None:
-                    self._pending_send_failure = exc
-                try:
-                    await self._wire.close()
-                except Exception as close_exc:  # noqa: BLE001 - retain cleanup class
-                    if self._pending_send_failure is exc:
-                        self._pending_send_failure = RuntimeError(
-                            f"{type(exc).__name__}: {exc}; cleanup failed: "
-                            f"{type(close_exc).__name__}"
-                        )
+                await self._record_send_failure(exc)
                 raise
+
+        async def _record_send_failure(self, exc: Exception) -> None:
+            if self._pending_send_failure is None:
+                self._pending_send_failure = exc
+            try:
+                await self._wire.close()
+            except Exception as close_exc:  # noqa: BLE001 - retain cleanup class
+                if self._pending_send_failure is exc:
+                    self._pending_send_failure = RuntimeError(
+                        f"{type(exc).__name__}: {exc}; cleanup failed: "
+                        f"{type(close_exc).__name__}"
+                    )
 
         async def _submit_tool_results(self, batch_id, results) -> None:
             del batch_id, results
@@ -528,20 +545,35 @@ if _CORE_IMPORT_ERROR is None:
             async with self._response_lock:
                 if response_id in self._completed_responses:
                     raise ValueError("response is already terminal")
-                if response_id not in self._active_responses:
+                active = self._active_responses.get(response_id)
+                if active is None:
                     raise ValueError("cancellation references an unbound response")
                 if response_id in self._cancelling_responses:
                     raise ValueError("response cancellation is already pending")
                 if len(self._cancelling_responses) >= self._response_ledger_capacity:
                     raise ValueError("response cancellation capacity exhausted")
+                correlation, _binding = active
                 self._cancelling_responses.add(response_id)
             try:
-                await self._send_wire(
-                    build_core_response_cancel(
-                        response_id=response_id,
-                        event_id=f"evt-{secrets.token_urlsafe(24)}",
+                await self._wire.send_json(
+                    (
+                        build_core_response_cancel(
+                            response_id=response_id,
+                            event_id=f"evt-{secrets.token_urlsafe(24)}",
+                        ),
                     )
                 )
+            except Exception as exc:
+                async with self._response_lock:
+                    terminal_won = (
+                        self._completed_responses.get(response_id) == correlation
+                    )
+                    if not terminal_won:
+                        self._cancelling_responses.discard(response_id)
+                if terminal_won:
+                    return
+                await self._record_send_failure(exc)
+                raise
             except BaseException:
                 async with self._response_lock:
                     self._cancelling_responses.discard(response_id)
@@ -717,6 +749,12 @@ if _CORE_IMPORT_ERROR is None:
             stage = self._response_lifecycle[key]
             if stage >= len(_REQUIRED_OUTPUT_LIFECYCLE):
                 raise ValueError(f"{event_type} was replayed")
+            if (
+                event_type == "response.output_audio.delta"
+                and stage
+                == _REQUIRED_OUTPUT_LIFECYCLE.index("response.output_audio.delta") + 1
+            ):
+                return
             expected = _REQUIRED_OUTPUT_LIFECYCLE[stage]
             if event_type != expected:
                 raise ValueError(
@@ -784,6 +822,7 @@ if _CORE_IMPORT_ERROR is None:
                 self._final_output_transcripts.pop((response_id, item_id), None)
                 self._audio_delta_items.discard((response_id, item_id))
                 self._audio_done_items.discard((response_id, item_id))
+                self._audio_byte_carries.pop((response_id, item_id), None)
                 self._output_item_added.discard((response_id, item_id))
                 self._content_part_added.discard((response_id, item_id))
                 self._content_part_done.discard((response_id, item_id))
@@ -871,6 +910,7 @@ if _CORE_IMPORT_ERROR is None:
                 self._final_output_transcripts.pop(key, None)
                 self._audio_delta_items.discard(key)
                 self._audio_done_items.discard(key)
+                self._audio_byte_carries.pop(key, None)
                 self._output_item_added.discard(key)
                 self._content_part_added.discard(key)
                 self._content_part_done.discard(key)
@@ -885,7 +925,7 @@ if _CORE_IMPORT_ERROR is None:
             event_type = event.get("type")
             if not isinstance(event_type, str) or not event_type:
                 raise ValueError("provider event type must be a nonblank string")
-            if event_type in _OUTPUT_EVENT_TYPES:
+            if event_type in _AUTHORITY_VALIDATED_EVENT_TYPES:
                 _validate_output_event_authority(event)
             if event_type == "session.created":
                 session = event.get("session")
@@ -905,7 +945,6 @@ if _CORE_IMPORT_ERROR is None:
                 self._reserve_input(event.get("item_id"))
                 return None
             if event_type == "input_audio_buffer.speech_started":
-                _validate_output_event_authority(event)
                 item_id = event.get("item_id")
                 if type(item_id) is not str:
                     raise TypeError("speech-start item_id must be an exact str")
@@ -916,6 +955,8 @@ if _CORE_IMPORT_ERROR is None:
                 if audio_start_ms < 0:
                     raise ValueError("audio_start_ms must be nonnegative")
                 return InputSpeechStarted(item_id=item_id, audio_start_ms=audio_start_ms)
+            if event_type in {"input_audio_buffer.speech_stopped", "rate_limits.updated"}:
+                return None
             if event_type == "conversation.item.input_audio_transcription.delta":
                 return self._input_transcript(event, final=False)
             if event_type == "conversation.item.input_audio_transcription.completed":
@@ -926,7 +967,6 @@ if _CORE_IMPORT_ERROR is None:
                 response_id, _correlation, binding, item_id = (
                     self._validate_active_response(event)
                 )
-                self._advance_lifecycle_stage((response_id, item_id), event_type)
                 delta = event.get("delta")
                 if not isinstance(delta, str) or not delta:
                     raise ValueError("output audio delta must be nonempty base64 text")
@@ -936,11 +976,29 @@ if _CORE_IMPORT_ERROR is None:
                     raise ValueError("output audio delta is malformed base64") from exc
                 if not data:
                     raise ValueError("output audio delta decoded to empty data")
+                stream_key = (response_id, item_id)
+                buffered = self._audio_byte_carries.get(stream_key, b"") + data
+                complete_length = len(buffered) - (len(buffered) % 2)
+                complete_data = buffered[:complete_length]
+                next_carry = buffered[complete_length:]
+                if (
+                    next_carry
+                    and stream_key not in self._audio_byte_carries
+                    and len(self._audio_byte_carries) >= self._response_ledger_capacity
+                ):
+                    raise ValueError("output audio carry capacity exhausted")
+                self._advance_lifecycle_stage(stream_key, event_type)
                 self._response_items[response_id] = item_id
                 self._item_responses[item_id] = response_id
-                self._audio_delta_items.add((response_id, item_id))
+                self._audio_delta_items.add(stream_key)
+                if next_carry:
+                    self._audio_byte_carries[stream_key] = next_carry
+                else:
+                    self._audio_byte_carries.pop(stream_key, None)
+                if not complete_data:
+                    return None
                 return OutputAudio(
-                    data=data,
+                    data=complete_data,
                     item_id=item_id,
                     response_id=response_id,
                     turn_id=binding.turn_marker,
@@ -990,6 +1048,8 @@ if _CORE_IMPORT_ERROR is None:
                 stream_key = (response_id, item_id)
                 if stream_key in self._audio_done_items:
                     raise ValueError("output audio done event was replayed")
+                if stream_key in self._audio_byte_carries:
+                    raise ValueError("output audio ended with an incomplete PCM16LE sample")
                 self._advance_lifecycle_stage(stream_key, event_type)
                 self._response_items[response_id] = item_id
                 self._item_responses[item_id] = response_id
@@ -1095,6 +1155,7 @@ if _CORE_IMPORT_ERROR is None:
                 self._final_output_transcripts.clear()
                 self._audio_delta_items.clear()
                 self._audio_done_items.clear()
+                self._audio_byte_carries.clear()
                 self._output_item_added.clear()
                 self._content_part_added.clear()
                 self._content_part_done.clear()

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -24,6 +24,7 @@ try:
         OpenAIWireEOF,
         OpenAIWireError,
         _OpenAIWireSession,
+        build_core_response_cancel,
         build_core_response_create,
     )
 except ImportError:  # pragma: no cover - flat-module fallback
@@ -34,6 +35,7 @@ except ImportError:  # pragma: no cover - flat-module fallback
         OpenAIWireEOF,
         OpenAIWireError,
         _OpenAIWireSession,
+        build_core_response_cancel,
         build_core_response_create,
     )
 
@@ -90,6 +92,8 @@ try:
         OutputAudio = _core_contract.OutputAudio
         OutputTranscript = _core_contract.OutputTranscript
         ResponseCompleted = _core_contract.ResponseCompleted
+        InputSpeechStarted = _core_contract.InputSpeechStarted
+        Interruption = _core_contract.Interruption
         _EXPLICIT_OUTPUT_AVAILABLE = all(
             isinstance(symbol, type)
             for symbol in (
@@ -109,8 +113,18 @@ try:
                 "OUTPUT_TRANSCRIPTION",
             )
         )
+        _RESPONSE_CANCELLATION_AVAILABLE = (
+            _EXPLICIT_OUTPUT_AVAILABLE
+            and all(isinstance(symbol, type) for symbol in (InputSpeechStarted, Interruption))
+            and hasattr(RealtimeCapability, "RESPONSE_CANCELLATION")
+            and callable(getattr(RealtimeVoiceSession, "cancel_response", None))
+            and getattr(RealtimeVoiceSession, "_CAPABILITY_HOOKS", {}).get(
+                RealtimeCapability.RESPONSE_CANCELLATION
+            ) == "_cancel_response"
+        )
     except (AttributeError, ImportError):
         _EXPLICIT_OUTPUT_AVAILABLE = False
+        _RESPONSE_CANCELLATION_AVAILABLE = False
 except Exception as exc:  # noqa: BLE001 - optional core must never poison legacy imports
     _CORE_IMPORT_ERROR = exc
 
@@ -205,6 +219,11 @@ if _CORE_IMPORT_ERROR is None:
                 RealtimeCapability.OUTPUT_TRANSCRIPTION,
             }
             if _EXPLICIT_OUTPUT_AVAILABLE
+            else set()
+        )
+        | (
+            {RealtimeCapability.RESPONSE_CANCELLATION}
+            if _RESPONSE_CANCELLATION_AVAILABLE
             else set()
         )
     )
@@ -408,6 +427,7 @@ if _CORE_IMPORT_ERROR is None:
             self._response_lifecycle: dict[tuple[str, str], int] = {}
             self._completed_responses: OrderedDict[str, str] = OrderedDict()
             self._consumed_correlations: OrderedDict[str, None] = OrderedDict()
+            self._cancelling_responses: set[str] = set()
             self._input_ledger: dict[str, str | None] = {}
             self._provider_session_id: str | None = None
             self._terminal = False
@@ -502,6 +522,29 @@ if _CORE_IMPORT_ERROR is None:
                 async with self._response_lock:
                     if self._pending_responses.get(correlation) == binding:
                         del self._pending_responses[correlation]
+                raise
+
+        async def _cancel_response(self, response_id: str) -> None:
+            async with self._response_lock:
+                if response_id in self._completed_responses:
+                    raise ValueError("response is already terminal")
+                if response_id not in self._active_responses:
+                    raise ValueError("cancellation references an unbound response")
+                if response_id in self._cancelling_responses:
+                    raise ValueError("response cancellation is already pending")
+                if len(self._cancelling_responses) >= self._response_ledger_capacity:
+                    raise ValueError("response cancellation capacity exhausted")
+                self._cancelling_responses.add(response_id)
+            try:
+                await self._send_wire(
+                    build_core_response_cancel(
+                        response_id=response_id,
+                        event_id=f"evt-{secrets.token_urlsafe(24)}",
+                    )
+                )
+            except BaseException:
+                async with self._response_lock:
+                    self._cancelling_responses.discard(response_id)
                 raise
 
         def _input_transcript(self, event: Mapping[str, Any], *, final: bool) -> InputTranscript:
@@ -748,7 +791,95 @@ if _CORE_IMPORT_ERROR is None:
                 self._conversation_item_done.discard((response_id, item_id))
                 self._response_lifecycle.pop((response_id, item_id), None)
             self._completed_responses[response_id] = correlation
+            self._cancelling_responses.discard(response_id)
             return ResponseCompleted(response_id=response_id, turn_id=binding.turn_marker)
+
+        def _cancelled_response(self, event: Mapping[str, Any]):
+            response = event.get("response")
+            if not isinstance(response, Mapping):
+                raise TypeError("response.done requires a response object")
+            response_id = _validate_identifier(response.get("id"), "response_id")
+            if response_id in self._completed_responses:
+                raise ValueError("response completion was replayed")
+            active = self._active_responses.get(response_id)
+            if active is None:
+                raise ValueError("cancellation completion references an unbound response")
+            if response_id not in self._cancelling_responses:
+                raise ValueError("unsolicited response cancellation terminal")
+            correlation, binding = active
+            if self._response_metadata(response) != correlation:
+                raise ValueError("response cancellation correlation mismatch")
+            if type(response.get("status")) is not str or response["status"] != "cancelled":
+                raise ValueError("response status must be cancelled")
+            details = response.get("status_details")
+            if details is not None:
+                if type(details) is not dict:
+                    raise TypeError("cancelled status_details must be an exact mapping")
+                if not set(details).issubset({"type", "reason", "error"}):
+                    raise ValueError("cancelled status_details has unknown keys")
+                if details.get("type") != "cancelled":
+                    raise ValueError("status_details type must be cancelled")
+                if details.get("reason") not in {"client_cancelled", "turn_detected"}:
+                    raise ValueError("status_details cancellation reason is invalid")
+                if details.get("error") is not None:
+                    raise ValueError("cancelled status_details error must be absent")
+            output = response.get("output", [])
+            if type(output) is not list:
+                raise TypeError("cancelled response output must be a sequence")
+            known_item_id = self._response_items.get(response_id)
+            if known_item_id is None:
+                if output:
+                    raise ValueError("cancelled response cannot mint an output item")
+            elif len(output) > 1:
+                raise ValueError("cancelled response output must contain at most one item")
+            elif output:
+                item = output[0]
+                if type(item) is not dict or not set(item).issubset(
+                    _OUTPUT_ITEM_ALLOWED_KEYS
+                ):
+                    raise ValueError(
+                        "cancelled response output item has an invalid authority shape"
+                    )
+                if "object" in item and (
+                    type(item["object"]) is not str
+                    or item["object"] != "realtime.item"
+                ):
+                    raise ValueError("cancelled response output item object must be realtime.item")
+                if item.get("type") != "message" or item.get("role") != "assistant":
+                    raise ValueError("cancelled response output item must be an assistant message")
+                if item.get("status") not in (None, "in_progress", "completed"):
+                    raise ValueError("cancelled response output item status is invalid")
+                item_id = _validate_identifier(item.get("id"), "output item_id")
+                content = item.get("content")
+                if type(content) is not list or len(content) != 1:
+                    raise ValueError("cancelled response output item must have one audio part")
+                self._validate_output_audio_part(
+                    content[0],
+                    response_id=response_id,
+                    item_id=item_id,
+                    context="response.cancelled",
+                )
+                if item_id != known_item_id:
+                    raise ValueError("cancelled response output item identity changed")
+            if len(self._completed_responses) >= self._response_ledger_capacity:
+                raise ValueError("completed response capacity exhausted")
+            del self._active_responses[response_id]
+            item_id = self._response_items.pop(response_id, None)
+            if item_id is not None:
+                self._item_responses.pop(item_id, None)
+                key = (response_id, item_id)
+                self._final_output_transcripts.pop(key, None)
+                self._audio_delta_items.discard(key)
+                self._audio_done_items.discard(key)
+                self._output_item_added.discard(key)
+                self._content_part_added.discard(key)
+                self._content_part_done.discard(key)
+                self._output_item_done.discard(key)
+                self._conversation_item_done.discard(key)
+                self._response_lifecycle.pop(key, None)
+            self._cancelling_responses.remove(response_id)
+            self._completed_responses[response_id] = correlation
+            return Interruption(response_id=response_id, turn_id=binding.turn_marker)
 
         def _map_event(self, event: Mapping[str, Any]):
             event_type = event.get("type")
@@ -773,6 +904,18 @@ if _CORE_IMPORT_ERROR is None:
             if event_type == "input_audio_buffer.committed":
                 self._reserve_input(event.get("item_id"))
                 return None
+            if event_type == "input_audio_buffer.speech_started":
+                _validate_output_event_authority(event)
+                item_id = event.get("item_id")
+                if type(item_id) is not str:
+                    raise TypeError("speech-start item_id must be an exact str")
+                item_id = _validate_identifier(item_id, "item_id")
+                audio_start_ms = event.get("audio_start_ms")
+                if type(audio_start_ms) is not int:
+                    raise TypeError("audio_start_ms must be an exact int")
+                if audio_start_ms < 0:
+                    raise ValueError("audio_start_ms must be nonnegative")
+                return InputSpeechStarted(item_id=item_id, audio_start_ms=audio_start_ms)
             if event_type == "conversation.item.input_audio_transcription.delta":
                 return self._input_transcript(event, final=False)
             if event_type == "conversation.item.input_audio_transcription.completed":
@@ -834,6 +977,9 @@ if _CORE_IMPORT_ERROR is None:
                     final=final,
                 )
             if event_type == "response.done":
+                response = event.get("response")
+                if isinstance(response, Mapping) and response.get("status") == "cancelled":
+                    return self._cancelled_response(event)
                 return self._complete_response(event)
             if "function_call" in event_type:
                 raise ValueError(f"function/tool output is forbidden: {event_type}")
@@ -957,6 +1103,7 @@ if _CORE_IMPORT_ERROR is None:
                 self._response_lifecycle.clear()
                 self._completed_responses.clear()
                 self._consumed_correlations.clear()
+                self._cancelling_responses.clear()
 
         def _take_send_failure(self) -> Exception | None:
             failure, self._pending_send_failure = self._pending_send_failure, None

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -13,7 +13,6 @@ import base64
 import binascii
 import contextlib
 import hashlib
-import re
 import secrets
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
@@ -154,14 +153,9 @@ DEFAULT_INPUT_LEDGER_CAPACITY = 1024
 MAX_IDENTIFIER_LENGTH = 512
 MAX_TRANSCRIPT_LENGTH = 1_000_000
 PROVIDER_NAME = "talk_openai_realtime"
-_PUBLIC_ERROR_SECRET = re.compile(
-    r"(?i)(?:bearer\s+[^\s,;]+|(?:password|api[_-]?key|token)\s*[=:]\s*[^\s,;]+|sk-[A-Za-z0-9_-]{8,})"
-)
-
-
-def _sanitize_public_error(exc: BaseException | str) -> str:
-    text = str(exc).strip() or "provider operation failed"
-    return _PUBLIC_ERROR_SECRET.sub("<redacted-secret>", text)
+_PROVIDER_SEND_FAILURE_MESSAGE = "provider send failed"
+_PROVIDER_PROTOCOL_FAILURE_MESSAGE = "provider protocol failure"
+_PROVIDER_EOF_MESSAGE = "provider connection closed unexpectedly"
 
 
 def core_provider_available() -> bool:
@@ -472,7 +466,7 @@ if _CORE_IMPORT_ERROR is None:
             self._input_ledger: dict[str, str | None] = {}
             self._provider_session_id: str | None = None
             self._terminal = False
-            self._pending_send_failure: str | None = None
+            self._pending_send_failure: bool | None = None
             self._enforce_output_lifecycle = False
 
         def _reserve_input(self, item_id: Any) -> str:
@@ -510,7 +504,8 @@ if _CORE_IMPORT_ERROR is None:
                 raise
 
         async def _record_send_failure(self, exc: Exception) -> None:
-            self._pending_send_failure = _sanitize_public_error(exc)
+            del exc
+            self._pending_send_failure = True
             with contextlib.suppress(Exception):
                 await self._wire.close()
 
@@ -1192,9 +1187,9 @@ if _CORE_IMPORT_ERROR is None:
                 self._consumed_correlations.clear()
                 self._cancelling_responses.clear()
 
-        def _take_send_failure(self) -> str | None:
+        def _take_send_failure(self) -> bool:
             failure, self._pending_send_failure = self._pending_send_failure, None
-            return failure
+            return failure is True
 
         async def _events(self) -> AsyncIterator[Any]:
             if self._terminal:
@@ -1204,7 +1199,7 @@ if _CORE_IMPORT_ERROR is None:
                 await self._terminate()
                 yield SessionFailure(
                     code="provider_send_failure",
-                    message=failure,
+                    message=_PROVIDER_SEND_FAILURE_MESSAGE,
                 )
                 return
             try:
@@ -1220,34 +1215,32 @@ if _CORE_IMPORT_ERROR is None:
                 if failure:
                     yield SessionFailure(
                         code="provider_send_failure",
-                        message=failure,
+                        message=_PROVIDER_SEND_FAILURE_MESSAGE,
                     )
                 elif exc.detail:
                     yield SessionFailure(
                         code="provider_eof",
-                        message=_sanitize_public_error(exc.detail),
+                        message=_PROVIDER_EOF_MESSAGE,
                     )
                 else:
                     yield SessionClosed()
             except asyncio.CancelledError:
                 await self._terminate()
                 raise
-            except Exception as exc:  # noqa: BLE001 - protocol errors converge here
+            except Exception:  # noqa: BLE001 - protocol errors converge here
                 failure = self._take_send_failure()
-                try:
+                with contextlib.suppress(Exception):
                     await self._terminate()
-                except Exception:  # noqa: BLE001 - public text is fixed and secret-safe
-                    message = "provider operation failed; cleanup failed"
-                else:
-                    message = _sanitize_public_error(exc)
                 failure_code = (
-                    "provider_send_failure"
-                    if failure is not None
-                    else "provider_protocol_failure"
+                    "provider_send_failure" if failure else "provider_protocol_failure"
                 )
                 yield SessionFailure(
                     code=failure_code,
-                    message=message,
+                    message=(
+                        _PROVIDER_SEND_FAILURE_MESSAGE
+                        if failure
+                        else _PROVIDER_PROTOCOL_FAILURE_MESSAGE
+                    ),
                 )
 
         async def _close(self) -> None:

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import contextlib
 import hashlib
+import re
 import secrets
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
@@ -152,6 +154,14 @@ DEFAULT_INPUT_LEDGER_CAPACITY = 1024
 MAX_IDENTIFIER_LENGTH = 512
 MAX_TRANSCRIPT_LENGTH = 1_000_000
 PROVIDER_NAME = "talk_openai_realtime"
+_PUBLIC_ERROR_SECRET = re.compile(
+    r"(?i)(?:bearer\s+[^\s,;]+|(?:password|api[_-]?key|token)\s*[=:]\s*[^\s,;]+|sk-[A-Za-z0-9_-]{8,})"
+)
+
+
+def _sanitize_public_error(exc: BaseException | str) -> str:
+    text = str(exc).strip() or "provider operation failed"
+    return _PUBLIC_ERROR_SECRET.sub("<redacted-secret>", text)
 
 
 def core_provider_available() -> bool:
@@ -286,27 +296,40 @@ if _CORE_IMPORT_ERROR is None:
     _FORBIDDEN_OUTPUT_AUTHORITY_TYPES = frozenset(
         {"function_call", "function_call_output", "tool", "tool_call"}
     )
+    MAX_AUTHORITY_VALIDATION_DEPTH = 66
+    MAX_AUTHORITY_VALIDATION_NODES = 4096
 
     def _validate_output_event_authority(value: Any) -> None:
-        if isinstance(value, Mapping):
-            forbidden = _FORBIDDEN_OUTPUT_AUTHORITY_KEYS.intersection(value)
-            if forbidden:
-                raise ValueError(
-                    f"output event has forbidden structured authority: {sorted(forbidden)[0]}"
-                )
-            discriminator = value.get("type")
-            if (
-                isinstance(discriminator, str)
-                and discriminator in _FORBIDDEN_OUTPUT_AUTHORITY_TYPES
+        pending = [(value, 0)]
+        visited = 0
+        while pending:
+            current, depth = pending.pop()
+            visited += 1
+            if visited > MAX_AUTHORITY_VALIDATION_NODES:
+                raise ValueError("output event authority node limit exceeded")
+            if depth > MAX_AUTHORITY_VALIDATION_DEPTH:
+                raise ValueError("output event authority depth limit exceeded")
+            if isinstance(current, Mapping):
+                forbidden = _FORBIDDEN_OUTPUT_AUTHORITY_KEYS.intersection(current)
+                if forbidden:
+                    raise ValueError(
+                        "output event has forbidden structured authority: "
+                        f"{sorted(forbidden)[0]}"
+                    )
+                discriminator = current.get("type")
+                if (
+                    isinstance(discriminator, str)
+                    and discriminator in _FORBIDDEN_OUTPUT_AUTHORITY_TYPES
+                ):
+                    raise ValueError(
+                        "output event has forbidden structured authority type: "
+                        f"{discriminator}"
+                    )
+                pending.extend((nested, depth + 1) for nested in current.values())
+            elif isinstance(current, Sequence) and not isinstance(
+                current, (str, bytes, bytearray)
             ):
-                raise ValueError(
-                    f"output event has forbidden structured authority type: {discriminator}"
-                )
-            for nested in value.values():
-                _validate_output_event_authority(nested)
-        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-            for nested in value:
-                _validate_output_event_authority(nested)
+                pending.extend((nested, depth + 1) for nested in current)
 
     @dataclass(frozen=True, slots=True)
     class _ResponseBinding:
@@ -442,10 +465,14 @@ if _CORE_IMPORT_ERROR is None:
             self._completed_responses: OrderedDict[str, str] = OrderedDict()
             self._consumed_correlations: OrderedDict[str, None] = OrderedDict()
             self._cancelling_responses: set[str] = set()
+            # Exact cancellation operations whose provider terminal won.  This
+            # authority outlives response/session ledgers only until that
+            # already-bounded retained operation settles.
+            self._terminal_cancel_supersessions: set[str] = set()
             self._input_ledger: dict[str, str | None] = {}
             self._provider_session_id: str | None = None
             self._terminal = False
-            self._pending_send_failure: Exception | None = None
+            self._pending_send_failure: str | None = None
             self._enforce_output_lifecycle = False
 
         def _reserve_input(self, item_id: Any) -> str:
@@ -483,16 +510,9 @@ if _CORE_IMPORT_ERROR is None:
                 raise
 
         async def _record_send_failure(self, exc: Exception) -> None:
-            if self._pending_send_failure is None:
-                self._pending_send_failure = exc
-            try:
+            self._pending_send_failure = _sanitize_public_error(exc)
+            with contextlib.suppress(Exception):
                 await self._wire.close()
-            except Exception as close_exc:  # noqa: BLE001 - retain cleanup class
-                if self._pending_send_failure is exc:
-                    self._pending_send_failure = RuntimeError(
-                        f"{type(exc).__name__}: {exc}; cleanup failed: "
-                        f"{type(close_exc).__name__}"
-                    )
 
         async def _submit_tool_results(self, batch_id, results) -> None:
             del batch_id, results
@@ -567,6 +587,7 @@ if _CORE_IMPORT_ERROR is None:
                 async with self._response_lock:
                     terminal_won = (
                         self._completed_responses.get(response_id) == correlation
+                        or response_id in self._terminal_cancel_supersessions
                     )
                     if not terminal_won:
                         self._cancelling_responses.discard(response_id)
@@ -578,6 +599,8 @@ if _CORE_IMPORT_ERROR is None:
                 async with self._response_lock:
                     self._cancelling_responses.discard(response_id)
                 raise
+            finally:
+                self._terminal_cancel_supersessions.discard(response_id)
 
         def _input_transcript(self, event: Mapping[str, Any], *, final: bool) -> InputTranscript:
             explicit_finality = event.get("final")
@@ -919,6 +942,8 @@ if _CORE_IMPORT_ERROR is None:
                 self._response_lifecycle.pop(key, None)
             self._cancelling_responses.remove(response_id)
             self._completed_responses[response_id] = correlation
+            if response_id in self._in_flight_response_cancellations:
+                self._terminal_cancel_supersessions.add(response_id)
             return Interruption(response_id=response_id, turn_id=binding.turn_marker)
 
         def _map_event(self, event: Mapping[str, Any]):
@@ -1147,6 +1172,7 @@ if _CORE_IMPORT_ERROR is None:
             try:
                 await self._wire.close()
             finally:
+                self._pending_send_failure = None
                 self._input_ledger.clear()
                 self._pending_responses.clear()
                 self._active_responses.clear()
@@ -1166,7 +1192,7 @@ if _CORE_IMPORT_ERROR is None:
                 self._consumed_correlations.clear()
                 self._cancelling_responses.clear()
 
-        def _take_send_failure(self) -> Exception | None:
+        def _take_send_failure(self) -> str | None:
             failure, self._pending_send_failure = self._pending_send_failure, None
             return failure
 
@@ -1174,11 +1200,11 @@ if _CORE_IMPORT_ERROR is None:
             if self._terminal:
                 return
             failure = self._take_send_failure()
-            if failure is not None:
+            if failure:
                 await self._terminate()
                 yield SessionFailure(
                     code="provider_send_failure",
-                    message=f"{type(failure).__name__}: {failure}",
+                    message=failure,
                 )
                 return
             try:
@@ -1191,13 +1217,16 @@ if _CORE_IMPORT_ERROR is None:
             except OpenAIWireEOF as exc:
                 failure = self._take_send_failure()
                 await self._terminate()
-                if failure is not None:
+                if failure:
                     yield SessionFailure(
                         code="provider_send_failure",
-                        message=f"{type(failure).__name__}: {failure}",
+                        message=failure,
                     )
                 elif exc.detail:
-                    yield SessionFailure(code="provider_eof", message=exc.detail)
+                    yield SessionFailure(
+                        code="provider_eof",
+                        message=_sanitize_public_error(exc.detail),
+                    )
                 else:
                     yield SessionClosed()
             except asyncio.CancelledError:
@@ -1205,15 +1234,12 @@ if _CORE_IMPORT_ERROR is None:
                 raise
             except Exception as exc:  # noqa: BLE001 - protocol errors converge here
                 failure = self._take_send_failure()
-                root = failure or exc
                 try:
                     await self._terminate()
-                except Exception as close_exc:  # noqa: BLE001 - report cleanup class only
-                    message = (
-                        f"{type(root).__name__}: {root}; cleanup failed: {type(close_exc).__name__}"
-                    )
+                except Exception:  # noqa: BLE001 - public text is fixed and secret-safe
+                    message = "provider operation failed; cleanup failed"
                 else:
-                    message = f"{type(root).__name__}: {root}"
+                    message = _sanitize_public_error(exc)
                 failure_code = (
                     "provider_send_failure"
                     if failure is not None

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import hashlib
 import secrets
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Callable, Mapping, Sequence
@@ -225,6 +226,17 @@ if _CORE_IMPORT_ERROR is None:
             "response.done",
         }
     )
+    _REQUIRED_OUTPUT_LIFECYCLE = (
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_audio.delta",
+        "response.output_audio_transcript.delta",
+        "response.output_audio.done",
+        "response.output_audio_transcript.done",
+        "response.content_part.done",
+        "response.output_item.done",
+        "conversation.item.done",
+    )
     _FORBIDDEN_OUTPUT_AUTHORITY_KEYS = frozenset(
         {
             "tool_calls",
@@ -393,6 +405,7 @@ if _CORE_IMPORT_ERROR is None:
             self._content_part_done: set[tuple[str, str]] = set()
             self._output_item_done: set[tuple[str, str]] = set()
             self._conversation_item_done: set[tuple[str, str]] = set()
+            self._response_lifecycle: dict[tuple[str, str], int] = {}
             self._completed_responses: OrderedDict[str, str] = OrderedDict()
             self._consumed_correlations: OrderedDict[str, None] = OrderedDict()
             self._input_ledger: dict[str, str | None] = {}
@@ -641,6 +654,24 @@ if _CORE_IMPORT_ERROR is None:
                 raise ValueError(f"{event_type} was replayed")
             observed.add(key)
 
+        def _advance_lifecycle_stage(
+            self, key: tuple[str, str], event_type: str
+        ) -> None:
+            if key not in self._response_lifecycle:
+                if event_type != _REQUIRED_OUTPUT_LIFECYCLE[0]:
+                    return
+                self._response_lifecycle[key] = 1
+                return
+            stage = self._response_lifecycle[key]
+            if stage >= len(_REQUIRED_OUTPUT_LIFECYCLE):
+                raise ValueError(f"{event_type} was replayed")
+            expected = _REQUIRED_OUTPUT_LIFECYCLE[stage]
+            if event_type != expected:
+                raise ValueError(
+                    f"output lifecycle is out of order: expected {expected}, got {event_type}"
+                )
+            self._response_lifecycle[key] = stage + 1
+
         def _complete_response(self, event: Mapping[str, Any]):
             response = event.get("response")
             if not isinstance(response, Mapping):
@@ -682,6 +713,16 @@ if _CORE_IMPORT_ERROR is None:
                 raise ValueError("response completion requires audio delta")
             if stream_key not in self._audio_done_items:
                 raise ValueError("response completion requires audio done")
+            try:
+                final_digest = hashlib.sha256(final_transcript.encode("utf-8")).hexdigest()
+            except UnicodeEncodeError as exc:
+                raise ValueError("response terminal transcript is not valid UTF-8") from exc
+            if final_digest != binding.content_digest:
+                raise ValueError("response terminal transcript digest mismatch")
+            if self._response_lifecycle.get(stream_key) != len(
+                _REQUIRED_OUTPUT_LIFECYCLE
+            ):
+                raise ValueError("response completion requires complete output lifecycle")
             if len(self._completed_responses) >= self._response_ledger_capacity:
                 raise ValueError("completed response capacity exhausted")
             del self._active_responses[response_id]
@@ -696,6 +737,7 @@ if _CORE_IMPORT_ERROR is None:
                 self._content_part_done.discard((response_id, item_id))
                 self._output_item_done.discard((response_id, item_id))
                 self._conversation_item_done.discard((response_id, item_id))
+                self._response_lifecycle.pop((response_id, item_id), None)
             self._completed_responses[response_id] = correlation
             return ResponseCompleted(response_id=response_id, turn_id=binding.turn_marker)
 
@@ -741,6 +783,7 @@ if _CORE_IMPORT_ERROR is None:
                 response_id, _correlation, binding, item_id = (
                     self._validate_active_response(event)
                 )
+                self._advance_lifecycle_stage((response_id, item_id), event_type)
                 self._response_items[response_id] = item_id
                 self._item_responses[item_id] = response_id
                 self._audio_delta_items.add((response_id, item_id))
@@ -769,6 +812,7 @@ if _CORE_IMPORT_ERROR is None:
                     if terminal_text == text:
                         raise ValueError("output transcript terminal event was replayed")
                     raise ValueError("conflicting terminal output transcript")
+                self._advance_lifecycle_stage(transcript_key, event_type)
                 self._response_items[response_id] = item_id
                 self._item_responses[item_id] = response_id
                 if final:
@@ -791,6 +835,7 @@ if _CORE_IMPORT_ERROR is None:
                 stream_key = (response_id, item_id)
                 if stream_key in self._audio_done_items:
                     raise ValueError("output audio done event was replayed")
+                self._advance_lifecycle_stage(stream_key, event_type)
                 self._response_items[response_id] = item_id
                 self._item_responses[item_id] = response_id
                 self._audio_done_items.add(stream_key)
@@ -807,6 +852,7 @@ if _CORE_IMPORT_ERROR is None:
                 response_id, _correlation, _binding, item_id = self._validate_active_response(
                     normalized
                 )
+                self._advance_lifecycle_stage((response_id, item_id), event_type)
                 observed = (
                     self._output_item_added
                     if event_type.endswith(".added")
@@ -824,6 +870,7 @@ if _CORE_IMPORT_ERROR is None:
                     item_id=item_id,
                     context=event_type,
                 )
+                self._advance_lifecycle_stage((response_id, item_id), event_type)
                 observed = (
                     self._content_part_added
                     if event_type.endswith(".added")
@@ -848,6 +895,7 @@ if _CORE_IMPORT_ERROR is None:
                 )
                 if validated_item_id != item_id:
                     raise ValueError("conversation output item identity changed")
+                self._advance_lifecycle_stage((response_id, item_id), event_type)
                 self._note_lifecycle_stage(
                     self._conversation_item_done,
                     (response_id, item_id),
@@ -897,6 +945,7 @@ if _CORE_IMPORT_ERROR is None:
                 self._content_part_done.clear()
                 self._output_item_done.clear()
                 self._conversation_item_done.clear()
+                self._response_lifecycle.clear()
                 self._completed_responses.clear()
                 self._consumed_correlations.clear()
 

--- a/talk_core_session.py
+++ b/talk_core_session.py
@@ -28,8 +28,8 @@ def build_core_setup():
         instructions="",
         tools=(),
         audio=talk_core_realtime.SUPPORTED_AUDIO_FORMAT,
+        automatic_response=False,
         provider_options={
-            "automatic_response": False,
             "capabilities": (
                 "input_transcription",
                 "input_commit_events",

--- a/talk_core_session.py
+++ b/talk_core_session.py
@@ -22,12 +22,19 @@ def build_core_setup():
 
     if not talk_core_realtime.core_provider_available():
         raise RuntimeError("Hermes realtime voice API-v2 is unavailable")
+    typed_audio = {}
+    if talk_core_realtime.SUPPORTED_INPUT_AUDIO_FORMAT is not None:
+        typed_audio = {
+            "input_audio": talk_core_realtime.SUPPORTED_INPUT_AUDIO_FORMAT,
+            "output_audio": talk_core_realtime.SUPPORTED_OUTPUT_AUDIO_FORMAT,
+        }
     return talk_core_realtime.RealtimeVoiceSetup(
         model=talk_config.talk_model(),
         voice=talk_config.talk_voice(),
         instructions="",
         tools=(),
         audio=talk_core_realtime.SUPPORTED_AUDIO_FORMAT,
+        **typed_audio,
         automatic_response=False,
         provider_options={
             "capabilities": (

--- a/talk_discord.py
+++ b/talk_discord.py
@@ -1153,6 +1153,11 @@ def session_status() -> str:
                 "say `talk leave` to stop."
             )
         return f"Canonical core voice is starting on server {guild_id} — say `talk leave` to stop."
+    if mode == "provider-host-tools":
+        return (
+            f"Provider-owned Realtime voice with canonical Hermes tools is live on server "
+            f"{guild_id}. Say `talk leave` to stop."
+        )
     return (
         f"Limited legacy provider-owned voice is live on server {guild_id}. "
         "Use `/talk core join` for full canonical Hermes parity; say `talk leave` to stop."
@@ -1325,7 +1330,9 @@ def start_core_session(factory: object, guild_id: int | None = None) -> str:
     )
 
 
-def start_session(guild_id: int | None = None) -> str:
+def start_session(
+    guild_id: int | None = None, *, host_execution_attachment=None
+) -> str:
     """Start a realtime session on the host's voice connection.
 
     Returns the sentence to speak back. Requires a running event loop —
@@ -1445,14 +1452,25 @@ def start_session(guild_id: int | None = None) -> str:
         _LAST_FAILURE_GENERATION = None
         _SESSION_GENERATION += 1
         generation = _SESSION_GENERATION
-        task = loop.create_task(talk_cli.run_talk_session(audio=audio))
+        if host_execution_attachment is None:
+            session = talk_cli.run_talk_session(audio=audio)
+        else:
+            session = talk_cli.run_talk_session(
+                audio=audio,
+                host_execution_attachment=host_execution_attachment,
+            )
+        task = loop.create_task(session)
         task.add_done_callback(_done)
         _SESSION.update(
             {
                 "task": task,
                 "guild_id": bridge["guild_id"],
                 "audio": audio,
-                "mode": "legacy",
+                "mode": (
+                    "provider-host-tools"
+                    if host_execution_attachment is not None
+                    else "legacy"
+                ),
                 "generation": generation,
             }
         )
@@ -1461,6 +1479,11 @@ def start_session(guild_id: int | None = None) -> str:
     # still has to mint, open a socket, and take the channel, and any of
     # those can refuse. Overclaiming here would be the one thing this
     # plugin refuses to do anywhere else.
+    if host_execution_attachment is not None:
+        return (
+            "Starting provider-owned Realtime voice with canonical Hermes tools; say "
+            "`talk status` to check or `talk leave` to stop."
+        )
     return (
         "Starting limited legacy provider-owned voice. Use `/talk core join` for full "
         "canonical Hermes parity; say `talk status` to check or `talk leave` to stop."

--- a/talk_identity.py
+++ b/talk_identity.py
@@ -72,6 +72,7 @@ VOICE_PREAMBLE = (
 )
 
 _TOOLS_MARKER = "Advertised legacy tools:"
+_HOST_TOOLS_MARKER = "Canonical Hermes host tools:"
 _TRANSCRIPT_CONTRACT = (
     "This limited legacy provider-owned call keeps a temporary local transcript while live. "
     "It is handed off after the call closes for durable-memory review; it is not a live "
@@ -79,9 +80,15 @@ _TRANSCRIPT_CONTRACT = (
     "whether capture occurred. Canonical core-session persistence is separate; users "
     "who need full Hermes parity should use /talk core join."
 )
+_HOST_TRANSCRIPT_CONTRACT = (
+    "This provider-owned Realtime call executes tools through the canonical Hermes host. "
+    "Ordinary speech and native PCM remain provider-owned; they are never routed through "
+    "a second canonical Hermes inference turn. The temporary live transcript is handed off "
+    "after the call closes for durable-memory review."
+)
 
 
-def _tool_contract(tools: list[dict] | None) -> str:
+def _tool_contract(tools: list[dict] | None, *, host_execution: bool = False) -> str:
     """Render the exact schema names supplied to the provider session."""
 
     names = [
@@ -90,13 +97,15 @@ def _tool_contract(tools: list[dict] | None) -> str:
         if isinstance(tool, dict) and isinstance(tool.get("name"), str)
     ]
     rendered = ", ".join(names) if names else "none"
-    return f"{_TOOLS_MARKER} {rendered}. Do not claim or simulate tools outside this list."
+    marker = _HOST_TOOLS_MARKER if host_execution else _TOOLS_MARKER
+    return f"{marker} {rendered}. Do not claim or simulate tools outside this list."
 
 
 def advertised_tool_names(instructions: str) -> tuple[str, ...]:
     """Read back the machine-checkable tool-name claim from built instructions."""
 
-    match = re.search(rf"{re.escape(_TOOLS_MARKER)} ([^.]+)\.", instructions)
+    markers = f"(?:{re.escape(_TOOLS_MARKER)}|{re.escape(_HOST_TOOLS_MARKER)})"
+    match = re.search(rf"{markers} ([^.]+)\.", instructions)
     if match is None or match.group(1) == "none":
         return ()
     return tuple(name.strip() for name in match.group(1).split(",") if name.strip())
@@ -123,7 +132,10 @@ def current_moment() -> str:
 
 
 def build_instructions(
-    host_sections: dict[str, str] | None, *, tools: list[dict] | None = None
+    host_sections: dict[str, str] | None,
+    *,
+    tools: list[dict] | None = None,
+    host_execution: bool = False,
 ) -> str:
     """Assemble the Realtime session prompt.
 
@@ -152,7 +164,10 @@ def build_instructions(
     # perishable thing in the prompt, and a session with no host sections at
     # all should still be able to say what day it is.
     sections.append(current_moment())
-    contracts = [_tool_contract(tools), _TRANSCRIPT_CONTRACT]
+    contracts = [
+        _tool_contract(tools, host_execution=host_execution),
+        _HOST_TRANSCRIPT_CONTRACT if host_execution else _TRANSCRIPT_CONTRACT,
+    ]
     return VOICE_PREAMBLE + "\n\n" + "\n\n".join([*contracts, *sections])
 
 

--- a/talk_openai_realtime.py
+++ b/talk_openai_realtime.py
@@ -247,6 +247,7 @@ def decode_event(event: dict[str, Any]) -> rt.RealtimeEvent | None:
                 name=event.get("name"),
                 arguments=event.get("arguments") if isinstance(event.get("arguments"), str) else "",
                 response_id=event.get("response_id"),
+                item_id=event.get("item_id"),
             )
         if event_type == "response.done":
             response = _mapping(event.get("response"))

--- a/talk_openai_realtime.py
+++ b/talk_openai_realtime.py
@@ -56,6 +56,45 @@ def build_session_update(setup: rt.SessionSetup) -> dict[str, Any]:
     }
 
 
+CORE_RENDER_VERBATIM_INSTRUCTION = (
+    "Render the sole user input as speech verbatim. Speak every character's "
+    "words and punctuation naturally, but add, remove, or paraphrase nothing. "
+    "Do not preface or explain."
+)
+
+
+def build_core_response_create(
+    *, canonical_text: str, correlation: str, voice: str, event_id: str
+) -> dict[str, Any]:
+    """Build the exact explicit canonical response for the Hermes core lane."""
+
+    return {
+        "type": "response.create",
+        "event_id": event_id,
+        "response": {
+            "conversation": "none",
+            "metadata": {"correlation": correlation},
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": canonical_text}],
+                }
+            ],
+            "instructions": CORE_RENDER_VERBATIM_INSTRUCTION,
+            "output_modalities": ["audio"],
+            "audio": {
+                "output": {
+                    "voice": voice,
+                    "format": {"type": "audio/pcm", "rate": 24_000},
+                }
+            },
+            "tools": [],
+            "tool_choice": "none",
+        },
+    }
+
+
 def encode_command(command: rt.RealtimeCommand) -> dict[str, Any]:
     """Map one provider-neutral command to OpenAI wire JSON."""
 

--- a/talk_openai_realtime.py
+++ b/talk_openai_realtime.py
@@ -95,6 +95,16 @@ def build_core_response_create(
     }
 
 
+def build_core_response_cancel(*, response_id: str, event_id: str) -> dict[str, Any]:
+    """Build one exact response-local cancellation for the Hermes core lane."""
+
+    return {
+        "type": "response.cancel",
+        "event_id": event_id,
+        "response_id": response_id,
+    }
+
+
 def encode_command(command: rt.RealtimeCommand) -> dict[str, Any]:
     """Map one provider-neutral command to OpenAI wire JSON."""
 

--- a/talk_openai_realtime.py
+++ b/talk_openai_realtime.py
@@ -286,8 +286,8 @@ class _OpenAIWireSession:
         aiohttp_module=None,
         mint_session: Callable[..., Any] | None = None,
     ) -> None:
-        self.auth_token = auth_token
-        self.auth_source = auth_source
+        self._auth_token: str | None = auth_token
+        self._auth_source: str | None = auth_source
         self._aiohttp = aiohttp_module
         self._mint_session = mint_session or self._mint
         self._stack: AsyncExitStack | None = None
@@ -298,10 +298,18 @@ class _OpenAIWireSession:
         self._close_task: asyncio.Task[None] | None = None
         self._close_failure: BaseException | None = None
         self._closed = False
+        self._connect_started = False
+
+    def _clear_raw_credentials(self) -> None:
+        self._auth_token = None
+        self._auth_source = None
 
     def _mint(self, **configuration):
+        auth_token = self._auth_token
+        if auth_token is None:
+            raise OpenAIWireError("Realtime wire credentials are unavailable")
         return talk_wire.mint_ephemeral_session(
-            auth_token=self.auth_token,
+            auth_token=auth_token,
             model=configuration["model"],
             voice=configuration["voice"],
             instructions=configuration["instructions"],
@@ -319,17 +327,21 @@ class _OpenAIWireSession:
         automatic_response: bool,
         session_update: dict[str, Any],
     ) -> None:
-        if self._stack is not None or self._closed:
+        if self._connect_started or self._closed:
             raise OpenAIWireError("Realtime wire connect may only run once")
+        self._connect_started = True
         stack = AsyncExitStack()
         try:
-            descriptor = self._mint_session(
-                model=model,
-                voice=voice,
-                instructions=instructions,
-                tools=tools,
-                automatic_response=automatic_response,
-            )
+            try:
+                descriptor = self._mint_session(
+                    model=model,
+                    voice=voice,
+                    instructions=instructions,
+                    tools=tools,
+                    automatic_response=automatic_response,
+                )
+            finally:
+                self._clear_raw_credentials()
             aiohttp = self._aiohttp or _import_aiohttp()
             http = await stack.enter_async_context(aiohttp.ClientSession())
             ws = await stack.enter_async_context(
@@ -345,6 +357,7 @@ class _OpenAIWireSession:
             self._iterator = ws.__aiter__()
             await self.send_json((session_update,))
         except BaseException:
+            self._clear_raw_credentials()
             self._stack = None
             await stack.aclose()
             raise
@@ -417,6 +430,7 @@ class _OpenAIWireSession:
             return wire_event
 
     async def _close_once(self) -> None:
+        self._clear_raw_credentials()
         stack, self._stack = self._stack, None
         if stack is not None:
             try:

--- a/talk_realtime.py
+++ b/talk_realtime.py
@@ -163,11 +163,13 @@ class FunctionCall(RealtimeEvent):
     name: str
     arguments: str
     response_id: str | None = None
+    item_id: str | None = None
 
     def __post_init__(self) -> None:
         _identifier(self.call_id, "call_id")
         _identifier(self.name, "name")
         _identifier(self.response_id, "response_id", optional=True)
+        _identifier(self.item_id, "item_id", optional=True)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -13,8 +13,9 @@ pytest.importorskip(
 )
 from agent.realtime_voice_provider import (
     InputTranscript,
-    RealtimeAudioFormat,
     RealtimeCapability,
+    RealtimeInputAudioFormat,
+    RealtimeOutputAudioFormat,
     RealtimeTool,
     RealtimeVoiceSetup,
     SessionClosed,
@@ -87,7 +88,9 @@ def setup(**changes):
         "model": "gpt-realtime-test",
         "voice": "cedar",
         "instructions": "transcribe only",
-        "audio": core_rt.SUPPORTED_AUDIO_FORMAT,
+        "input_audio": core_rt.SUPPORTED_INPUT_AUDIO_FORMAT,
+        "output_audio": core_rt.SUPPORTED_OUTPUT_AUDIO_FORMAT,
+        "automatic_response": False,
     }
     values.update(changes)
     return RealtimeVoiceSetup(**values)
@@ -155,10 +158,18 @@ def test_passive_diagnostic_distinguishes_contract_from_provider_readiness(monke
         setup(
             tools=(RealtimeTool(name="forbidden", description="must stay inert", parameters={}),)
         ),
-        setup(provider_options={"automatic_response": True}),
+        setup(automatic_response=True),
         setup(provider_options={"capabilities": ["tool_calling"]}),
-        setup(audio=RealtimeAudioFormat("audio/pcm", 16_000, 1)),
-        setup(audio=RealtimeAudioFormat("audio/wav", 24_000, 1)),
+        setup(
+            input_audio=RealtimeInputAudioFormat(
+                "audio/pcm", 16_000, 1, "pcm_s16le", 2, "little"
+            )
+        ),
+        setup(
+            output_audio=RealtimeOutputAudioFormat(
+                "audio/pcm", 16_000, 1, "pcm_s16le", 2, "little"
+            )
+        ),
     ],
 )
 def test_unsupported_setup_is_rejected_before_credentials_or_network(bad_setup):
@@ -194,6 +205,28 @@ def test_core_connect_disables_response_in_update_and_sends_only_input_commands(
         {"type": "input_audio_buffer.commit"},
     ]
     assert harness.wire.closed is True
+
+
+def test_typed_setup_fields_are_exact_and_legacy_audio_remains_compatible():
+    assert RealtimeInputAudioFormat(
+        "audio/pcm", 24_000, 1, "pcm_s16le", 2, "little"
+    ) == core_rt.SUPPORTED_INPUT_AUDIO_FORMAT
+    assert RealtimeOutputAudioFormat(
+        "audio/pcm", 24_000, 1, "pcm_s16le", 2, "little"
+    ) == core_rt.SUPPORTED_OUTPUT_AUDIO_FORMAT
+
+    async def scenario():
+        typed = Harness()
+        session = await typed.provider().open_session(setup())
+        await session.close()
+
+        legacy = Harness()
+        session = await legacy.provider().open_session(
+            setup(input_audio=None, output_audio=None, audio=core_rt.SUPPORTED_AUDIO_FORMAT)
+        )
+        await session.close()
+
+    asyncio.run(scenario())
 
 
 def test_send_failure_closes_and_remains_visible_as_one_terminal_event():

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -217,7 +217,7 @@ def valid_output_lifecycle_events(
             "type": "response.output_audio.delta",
             "response_id": response_id,
             "item_id": item_id,
-            "delta": "cGNt",
+            "delta": "cGNtAA==",
         },
         {
             "type": "response.output_audio_transcript.delta",
@@ -408,7 +408,7 @@ def test_bound_response_maps_started_audio_transcript_and_completed():
             "type": "response.output_audio.delta",
             "response_id": "resp-1",
             "item_id": "item-out-1",
-            "delta": "cGNt",
+            "delta": "cGNtAA==",
         },
         {
             "type": "response.output_audio_transcript.delta",
@@ -484,7 +484,7 @@ def test_bound_response_maps_started_audio_transcript_and_completed():
     assert received[:-1] == [
         ResponseStarted(response_id="resp-1", turn_id="turn-41"),
         OutputAudio(
-            data=b"pcm", item_id="item-out-1", response_id="resp-1", turn_id="turn-41"
+            data=b"pcm\x00", item_id="item-out-1", response_id="resp-1", turn_id="turn-41"
         ),
         OutputTranscript(
             item_id="item-out-1",
@@ -506,6 +506,114 @@ def test_bound_response_maps_started_audio_transcript_and_completed():
     assert not session._pending_responses
     assert not session._active_responses
     assert not session._completed_responses
+
+
+def test_pcm16le_arbitrary_chunks_use_exact_one_byte_carry_and_clean_terminals():
+    async def open_bound_session():
+        harness = Harness()
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        session._enforce_output_lifecycle = True
+        lifecycle = valid_output_lifecycle_events(
+            "token-1", transcript="Exact words, exactly."
+        )
+        session._map_event(lifecycle[0])
+        session._map_event(lifecycle[1])
+        return harness, session, lifecycle
+
+    def audio_delta(data, *, response_id="resp-1", item_id="item-1"):
+        encoded = {
+            b"\x01": "AQ==",
+            b"\x02\x03\x04": "AgME",
+            b"\x05": "BQ==",
+            b"\x06": "Bg==",
+            b"\x07": "Bw==",
+        }[data]
+        return {
+            "type": "response.output_audio.delta",
+            "response_id": response_id,
+            "item_id": item_id,
+            "delta": encoded,
+        }
+
+    async def scenario():
+        _harness, session, lifecycle = await open_bound_session()
+        assert session._map_event(audio_delta(b"\x01")) is None
+        assert session._audio_byte_carries == {("resp-1", "item-1"): b"\x01"}
+        assert max(map(len, session._audio_byte_carries.values())) == 1
+
+        before_wrong_id = dict(session._audio_byte_carries)
+        with pytest.raises(ValueError, match="identity"):
+            session._map_event(audio_delta(b"\x07", item_id="item-wrong"))
+        assert session._audio_byte_carries == before_wrong_id
+
+        reconstructed = session._map_event(audio_delta(b"\x02\x03\x04"))
+        assert reconstructed == OutputAudio(
+            data=b"\x01\x02\x03\x04",
+            item_id="item-1",
+            response_id="resp-1",
+            turn_id="turn-41",
+        )
+        assert not session._audio_byte_carries
+
+        assert session._map_event(audio_delta(b"\x05")) is None
+        before_odd_done = (
+            dict(session._audio_byte_carries),
+            set(session._audio_done_items),
+            dict(session._response_lifecycle),
+        )
+        with pytest.raises(ValueError, match="incomplete PCM16LE sample"):
+            session._map_event(lifecycle[4])
+        assert (
+            dict(session._audio_byte_carries),
+            set(session._audio_done_items),
+            dict(session._response_lifecycle),
+        ) == before_odd_done
+
+        assert session._map_event(audio_delta(b"\x06")) == OutputAudio(
+            data=b"\x05\x06",
+            item_id="item-1",
+            response_id="resp-1",
+            turn_id="turn-41",
+        )
+        session._map_event(lifecycle[3])
+        assert session._map_event(lifecycle[4]) is None
+        with pytest.raises(ValueError, match="replayed"):
+            session._map_event(lifecycle[4])
+        for event in lifecycle[5:-1]:
+            session._map_event(event)
+        assert session._map_event(lifecycle[-1]) == ResponseCompleted(
+            response_id="resp-1", turn_id="turn-41"
+        )
+        assert not session._audio_byte_carries
+
+        _cancel_harness, cancel_session, _cancel_lifecycle = await open_bound_session()
+        assert cancel_session._map_event(audio_delta(b"\x07")) is None
+        await cancel_session.cancel_response("resp-1")
+        assert cancel_session._map_event(
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "resp-1",
+                    "status": "cancelled",
+                    "metadata": {"correlation": "token-1"},
+                    "output": [],
+                    "status_details": {
+                        "type": "cancelled",
+                        "reason": "client_cancelled",
+                    },
+                },
+            }
+        ) == Interruption(response_id="resp-1", turn_id="turn-41")
+        assert not cancel_session._audio_byte_carries
+
+        _close_harness, close_session, _close_lifecycle = await open_bound_session()
+        assert close_session._map_event(audio_delta(b"\x07")) is None
+        await close_session.close()
+        assert not close_session._audio_byte_carries
+
+    asyncio.run(scenario())
 
 
 @pytest.mark.parametrize(
@@ -948,7 +1056,7 @@ def test_response_done_rejects_non_exact_audio_only_schema_without_consuming_act
                 "type": "response.output_audio.delta",
                 "response_id": "resp-1",
                 "item_id": "item-1",
-                "delta": "cGNt",
+                "delta": "cGNtAA==",
             },
             {
                 "type": "response.output_audio_transcript.done",
@@ -1001,7 +1109,7 @@ def test_response_done_requires_observed_audio_and_transcript_terminals(omitted)
                 "type": "response.output_audio.delta",
                 "response_id": "resp-1",
                 "item_id": "item-1",
-                "delta": "cGNt",
+                "delta": "cGNtAA==",
             },
             "audio_done": {
                 "type": "response.output_audio.done",
@@ -1667,6 +1775,7 @@ def output_authority_state(session):
         dict(session._final_output_transcripts),
         set(session._audio_delta_items),
         set(session._audio_done_items),
+        dict(session._audio_byte_carries),
         set(session._output_item_added),
         set(session._content_part_added),
         set(session._content_part_done),
@@ -1743,6 +1852,134 @@ def test_recursive_output_authority_discriminator_is_rejected(discriminator):
                 }
             )
         assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+def test_recursive_authority_covers_every_recognized_nonoutput_family_atomically():
+    forbidden_events = [
+        {
+            "type": "session.created",
+            "session": {
+                "id": "session-1",
+                "metadata": {"left": [{"nested": {"tools": []}}]},
+            },
+        },
+        {
+            "type": "session.updated",
+            "session": {"metadata": {"right": {"nested": [{"type": "tool_call"}]}}},
+        },
+        {
+            "type": "input_audio_buffer.speech_started",
+            "item_id": "input-1",
+            "audio_start_ms": 7,
+            "provider": [{"left": {"function_call": {}}}],
+        },
+        {
+            "type": "input_audio_buffer.speech_stopped",
+            "item_id": "input-1",
+            "audio_end_ms": 11,
+            "provider": {"right": [{"arguments": "{}"}]},
+        },
+        {
+            "type": "input_audio_buffer.committed",
+            "item_id": "input-1",
+            "metadata": {"left": [{"nested": {"call_id": "call-1"}}]},
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "input-1",
+            "delta": "hel",
+            "diagnostic": {"right": [{"nested": {"tool_choice": "none"}}]},
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "input-1",
+            "transcript": "hello",
+            "diagnostic": [{"left": {"type": "function_call_output"}}],
+        },
+        {
+            "type": "rate_limits.updated",
+            "rate_limits": [{"name": "requests", "metadata": {"right": {"name": "tool"}}}],
+        },
+        {
+            "type": "error",
+            "error": {
+                "message": "provider error",
+                "metadata": {"left": [{"function": {}}]},
+            },
+        },
+    ]
+
+    def state(session):
+        return (
+            session._provider_session_id,
+            dict(session._input_ledger),
+            output_authority_state(session),
+        )
+
+    async def scenario():
+        for bad_event in forbidden_events:
+            harness = Harness()
+            session = await harness.provider().open_session(setup())
+            before = state(session)
+            with pytest.raises(ValueError, match="authority"):
+                session._map_event(bad_event)
+            assert state(session) == before
+            await session.close()
+
+        harness = Harness()
+        session = await harness.provider().open_session(setup())
+        assert session._map_event(
+            {
+                "type": "session.created",
+                "session": {
+                    "id": "session-1",
+                    "metadata": {"left": [{"classification": "tools-disabled"}]},
+                },
+            }
+        ) == SessionReady(session_id="session-1")
+        assert session._map_event(
+            {
+                "type": "input_audio_buffer.committed",
+                "item_id": "input-1",
+                "metadata": {"right": [{"classification": "operator-audio"}]},
+            }
+        ) is None
+        transcript = session._map_event(
+            {
+                "type": "conversation.item.input_audio_transcription.completed",
+                "item_id": "input-1",
+                "transcript": "hello",
+                "diagnostic": {"left": [{"classification": "legitimate"}]},
+            }
+        )
+        assert transcript == InputTranscript(
+            item_id="input-1",
+            turn_id="input-1",
+            text="hello",
+            final=True,
+            role=TranscriptRole.OPERATOR,
+            provenance=TranscriptProvenance.OPERATOR_INPUT,
+        )
+        before_unknown = state(session)
+        assert session._map_event(
+            {
+                "type": "vendor.future_diagnostic",
+                "metadata": {"nested": [{"tools": []}, {"type": "tool_call"}]},
+            }
+        ) is None
+        assert state(session) == before_unknown
+        with pytest.raises(core_rt.OpenAIWireError, match="legitimate provider error"):
+            session._map_event(
+                {
+                    "type": "error",
+                    "error": {
+                        "message": "legitimate provider error",
+                        "metadata": {"classification": "diagnostic-only"},
+                    },
+                }
+            )
 
     asyncio.run(scenario())
 
@@ -1921,7 +2158,7 @@ def test_response_done_requires_every_live_output_lifecycle_stage(omitted_type):
     assert session._terminal is True
     assert not session._response_lifecycle
     assert output_authority_state(session) == (
-        {}, {}, {}, {}, {}, set(), set(), set(), set(), set(), set(), set(), {}, {}
+        {}, {}, {}, {}, {}, set(), set(), {}, set(), set(), set(), set(), set(), {}, {}
     )
 
 
@@ -2348,6 +2585,114 @@ def test_cancel_response_exact_authority_and_empty_cancelled_terminal():
     assert not session._active_responses
     assert not session._cancelling_responses
     assert session._completed_responses == {"resp-1": "token-1"}
+
+
+def test_cancel_send_and_provider_terminal_are_linearized_in_both_race_orders():
+    class RacingCancelWire(FakeWire):
+        def __init__(self):
+            super().__init__()
+            self.incoming = asyncio.Queue()
+            self.cancel_send_started = asyncio.Event()
+            self.release_cancel_send = asyncio.Event()
+
+        async def send_json(self, messages):
+            messages = tuple(messages)
+            self.sent.extend(messages)
+            if messages[0]["type"] == "response.cancel":
+                self.cancel_send_started.set()
+                await self.release_cancel_send.wait()
+                raise RuntimeError("cancel send exploded")
+
+        async def __anext__(self):
+            event = await self.incoming.get()
+            if event is None:
+                raise core_rt.OpenAIWireEOF("")
+            return event
+
+        async def close(self):
+            if not self.closed:
+                self.closed = True
+                self.incoming.put_nowait(None)
+
+    cancelled = {
+        "type": "response.done",
+        "response": {
+            "id": "resp-1",
+            "status": "cancelled",
+            "metadata": {"correlation": "token-1"},
+            "output": [],
+            "status_details": {
+                "type": "cancelled",
+                "reason": "client_cancelled",
+            },
+        },
+    }
+
+    async def terminal_wins():
+        harness = Harness()
+        harness.wire = RacingCancelWire()
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        stream = session.events()
+        harness.wire.incoming.put_nowait(
+            {
+                "type": "response.created",
+                "response": {"id": "resp-1", "metadata": {"correlation": "token-1"}},
+            }
+        )
+        assert await anext(stream) == ResponseStarted(response_id="resp-1", turn_id="turn-41")
+
+        waiter = asyncio.create_task(session.cancel_response("resp-1"))
+        await harness.wire.cancel_send_started.wait()
+        harness.wire.incoming.put_nowait(cancelled)
+        assert await anext(stream) == Interruption(response_id="resp-1", turn_id="turn-41")
+        harness.wire.release_cancel_send.set()
+        await waiter
+
+        harness.wire.incoming.put_nowait(None)
+        assert await anext(stream) == SessionClosed()
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+        await asyncio.sleep(0)
+        assert session._pending_send_failure is None
+        assert session._completed_responses == {}
+        assert not session._active_responses
+        assert not session._cancelling_responses
+        assert not session._in_flight_response_cancellations
+        assert not session._response_cancellation_tasks
+
+    async def send_failure_wins():
+        harness = Harness()
+        harness.wire = RacingCancelWire()
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        stream = session.events()
+        pump = asyncio.create_task(_collect_async(stream))
+
+        waiter = asyncio.create_task(session.cancel_response("resp-1"))
+        await harness.wire.cancel_send_started.wait()
+        harness.wire.release_cancel_send.set()
+        with pytest.raises(RuntimeError, match="cancel send exploded"):
+            await waiter
+        harness.wire.incoming.put_nowait(cancelled)
+        received = await pump
+        await asyncio.sleep(0)
+
+        assert len(received) == 1
+        assert isinstance(received[0], SessionFailure)
+        assert received[0].code == "cancellation_failed"
+        assert session._terminal_failure is received[0]
+        assert not session._active_responses
+        assert not session._cancelling_responses
+        assert not session._in_flight_response_cancellations
+        assert not session._response_cancellation_tasks
+
+    async def _collect_async(stream):
+        return [event async for event in stream]
+
+    asyncio.run(terminal_wins())
+    asyncio.run(send_failure_wins())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -172,36 +172,22 @@ def response_done_event(
 
 
 def complete_bound_response(
-    session, correlation, *, response_id="resp-1", item_id="item-1", transcript="words"
+    session,
+    correlation,
+    *,
+    response_id="resp-1",
+    item_id="item-1",
+    transcript="Exact words, exactly.",
 ):
-    for event in (
-        {
-            "type": "response.output_audio.delta",
-            "response_id": response_id,
-            "item_id": item_id,
-            "delta": "cGNt",
-        },
-        {
-            "type": "response.output_audio_transcript.done",
-            "response_id": response_id,
-            "item_id": item_id,
-            "transcript": transcript,
-        },
-        {
-            "type": "response.output_audio.done",
-            "response_id": response_id,
-            "item_id": item_id,
-        },
-    ):
-        session._map_event(event)
-    return session._map_event(
-        response_done_event(
-            correlation,
-            response_id=response_id,
-            item_id=item_id,
-            transcript=transcript,
-        )
+    events = valid_output_lifecycle_events(
+        correlation,
+        response_id=response_id,
+        item_id=item_id,
+        transcript=transcript,
     )
+    for event in events[:-1]:
+        session._map_event(event)
+    return session._map_event(events[-1])
 
 
 def valid_output_lifecycle_events(
@@ -238,15 +224,15 @@ def valid_output_lifecycle_events(
             "delta": transcript[:1],
         },
         {
+            "type": "response.output_audio.done",
+            "response_id": response_id,
+            "item_id": item_id,
+        },
+        {
             "type": "response.output_audio_transcript.done",
             "response_id": response_id,
             "item_id": item_id,
             "transcript": transcript,
-        },
-        {
-            "type": "response.output_audio.done",
-            "response_id": response_id,
-            "item_id": item_id,
         },
         {
             "type": "response.content_part.done",
@@ -428,15 +414,15 @@ def test_bound_response_maps_started_audio_transcript_and_completed():
             "delta": "Exact ",
         },
         {
+            "type": "response.output_audio.done",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+        },
+        {
             "type": "response.output_audio_transcript.done",
             "response_id": "resp-1",
             "item_id": "item-out-1",
             "transcript": "Exact words, exactly.",
-        },
-        {
-            "type": "response.output_audio.done",
-            "response_id": "resp-1",
-            "item_id": "item-out-1",
         },
         {
             "type": "response.content_part.done",
@@ -1040,7 +1026,7 @@ def test_response_done_requires_observed_audio_and_transcript_terminals(omitted)
 
 def test_response_done_accepts_documented_realtime_item_object():
     correlation = "token-1"
-    events = valid_output_lifecycle_events(correlation)
+    events = valid_output_lifecycle_events(correlation, transcript="Exact words, exactly.")
     events[-1]["response"]["output"][0]["object"] = "realtime.item"
     harness = Harness(
         [
@@ -1808,13 +1794,142 @@ def test_response_done_extra_authority_fails_event_pump_and_cleans_terminal_stat
     assert not session._completed_responses
 
 
+def test_terminal_transcript_digest_mismatch_fails_closed_and_clears_all_response_state():
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    harness = Harness(
+        [
+            created,
+            *valid_output_lifecycle_events(
+                correlation, transcript="DIFFERENT WORDS"
+            ),
+        ]
+    )
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request(canonical_text="Exact words, exactly."))
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    failures = [event for event in received if isinstance(event, SessionFailure)]
+    assert len(failures) == 1
+    assert failures[0].code == "provider_protocol_failure"
+    assert "digest" in failures[0].message
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert harness.wire.closed is True
+    assert session._terminal is True
+    assert not session._pending_responses
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._final_output_transcripts
+    assert not session._audio_delta_items
+    assert not session._audio_done_items
+    assert not session._output_item_added
+    assert not session._content_part_added
+    assert not session._content_part_done
+    assert not session._output_item_done
+    assert not session._conversation_item_done
+    assert not session._response_lifecycle
+    assert not session._completed_responses
+    assert not session._consumed_correlations
+
+
+@pytest.mark.parametrize(
+    "omitted_type",
+    [
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_audio.delta",
+        "response.output_audio_transcript.delta",
+        "response.output_audio.done",
+        "response.output_audio_transcript.done",
+        "response.content_part.done",
+        "response.output_item.done",
+        "conversation.item.done",
+    ],
+)
+def test_response_done_requires_every_live_output_lifecycle_stage(omitted_type):
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    lifecycle = valid_output_lifecycle_events(
+        correlation, transcript="Exact words, exactly."
+    )
+    events = [event for event in lifecycle[:-1] if event["type"] != omitted_type]
+    harness = Harness([created, *events, lifecycle[-1]])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert sum(isinstance(event, SessionFailure) for event in received) == 1
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert harness.wire.closed is True
+    assert session._terminal is True
+    assert not session._response_lifecycle
+    assert output_authority_state(session) == (
+        {}, {}, {}, {}, {}, set(), set(), set(), set(), set(), set(), set(), {}, {}
+    )
+
+
+@pytest.mark.parametrize(
+    ("earlier_type", "later_type"),
+    [
+        ("response.output_item.added", "response.content_part.added"),
+        ("response.content_part.added", "response.output_audio.delta"),
+        ("response.output_audio.done", "response.output_audio_transcript.done"),
+        ("response.content_part.done", "response.output_item.done"),
+        ("response.output_item.done", "conversation.item.done"),
+    ],
+)
+def test_live_output_lifecycle_rejects_out_of_order_stages(earlier_type, later_type):
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    lifecycle = valid_output_lifecycle_events(
+        correlation, transcript="Exact words, exactly."
+    )
+    positions = {event["type"]: index for index, event in enumerate(lifecycle)}
+    first, second = positions[earlier_type], positions[later_type]
+    lifecycle[first], lifecycle[second] = lifecycle[second], lifecycle[first]
+    harness = Harness([created, *lifecycle])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return [event async for event in session.events()]
+
+    received = asyncio.run(scenario())
+    assert sum(isinstance(event, SessionFailure) for event in received) == 1
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert harness.wire.closed is True
+
+
 def test_valid_live_output_lifecycle_completes_exactly_once_and_cleans_terminal_state():
     correlation = "token-1"
     created = {
         "type": "response.created",
         "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
     }
-    harness = Harness([created, *valid_output_lifecycle_events(correlation)])
+    harness = Harness(
+        [
+            created,
+            *valid_output_lifecycle_events(
+                correlation, transcript="Exact words, exactly."
+            ),
+        ]
+    )
 
     async def scenario():
         session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
@@ -1828,6 +1943,7 @@ def test_valid_live_output_lifecycle_completes_exactly_once_and_cleans_terminal_
     assert not session._active_responses
     assert not session._response_items
     assert not session._item_responses
+    assert not session._response_lifecycle
     assert not session._completed_responses
 
 
@@ -1838,7 +1954,7 @@ def test_live_proven_output_envelopes_accept_event_ids_and_indexes_once():
         "event_id": "evt-created",
         "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
     }
-    events = valid_output_lifecycle_events(correlation)
+    events = valid_output_lifecycle_events(correlation, transcript="Exact words, exactly.")
     for index, event in enumerate(events):
         event["event_id"] = f"evt-{index}"
         if event["type"].startswith("response."):

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -16,7 +16,9 @@ pytest.importorskip(
     reason="Hermes core API-v2 is optional for standalone Talk",
 )
 from agent.realtime_voice_provider import (
+    InputSpeechStarted,
     InputTranscript,
+    Interruption,
     OutputAudio,
     OutputTranscript,
     RealtimeAudioFormat,
@@ -278,6 +280,7 @@ def test_exact_api_v2_contract_and_fixed_capabilities():
             RealtimeCapability.EXPLICIT_RESPONSE,
             RealtimeCapability.RESPONSE_METADATA_ECHO,
             RealtimeCapability.OUTPUT_TRANSCRIPTION,
+            RealtimeCapability.RESPONSE_CANCELLATION,
         }
     )
 
@@ -2278,6 +2281,73 @@ def test_exact_input_item_identity_maps_partial_and_final_operator_transcripts()
     assert received[-1] == SessionClosed()
     assert harness.wire.closed is True
     assert not session._input_ledger
+
+
+def test_passive_speech_start_maps_exact_primitives_without_sending():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider().open_session(setup())
+        mapped = session._map_event(
+            {
+                "type": "input_audio_buffer.speech_started",
+                "item_id": "input-1",
+                "audio_start_ms": 7,
+            }
+        )
+        assert harness.wire.sent == []
+        for item_id, offset in (("", 0), ("input", True), ("input", 1.0), ("input", -1)):
+            with pytest.raises((TypeError, ValueError)):
+                session._map_event(
+                    {
+                        "type": "input_audio_buffer.speech_started",
+                        "item_id": item_id,
+                        "audio_start_ms": offset,
+                    }
+                )
+        return mapped
+
+    assert asyncio.run(scenario()) == InputSpeechStarted(
+        item_id="input-1", audio_start_ms=7
+    )
+
+
+def test_cancel_response_exact_authority_and_empty_cancelled_terminal():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        await session.cancel_response("resp-1")
+        with pytest.raises(ValueError):
+            await session.cancel_response("resp-1")
+        terminal = session._map_event(
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "resp-1",
+                    "status": "cancelled",
+                    "metadata": {"correlation": "token-1"},
+                    "output": [],
+                    "status_details": {
+                        "type": "cancelled",
+                        "reason": "client_cancelled",
+                    },
+                },
+            }
+        )
+        return session, terminal
+
+    session, terminal = asyncio.run(scenario())
+    cancel = harness.wire.sent[-1]
+    assert cancel["type"] == "response.cancel"
+    assert cancel["response_id"] == "resp-1"
+    assert cancel["event_id"].startswith("evt-")
+    assert terminal == Interruption(response_id="resp-1", turn_id="turn-41")
+    assert not session._active_responses
+    assert not session._cancelling_responses
+    assert session._completed_responses == {"resp-1": "token-1"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -2476,6 +2476,77 @@ def test_send_failure_remains_visible_when_event_pump_is_already_waiting():
     assert "concurrent send exploded" in events[0].message
 
 
+@pytest.mark.parametrize(
+    "operation,marker",
+    [
+        ("send_audio", "Bearer sentinel-send-secret"),
+        ("start_response", "password=sentinel-response-secret"),
+    ],
+)
+def test_failure_paths_redact_credentials_and_release_raw_exceptions(operation, marker):
+    harness = Harness()
+    harness.wire.send_error = core_rt.OpenAIWireError(f"provider rejected {marker}")
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        with pytest.raises(core_rt.OpenAIWireError):
+            if operation == "send_audio":
+                await session.send_audio(b"pcm")
+            else:
+                await session.start_response(response_request())
+        events = [event async for event in session.events()]
+        await asyncio.sleep(0)
+        return session, events
+
+    session, events = asyncio.run(scenario())
+    assert len(events) == 1
+    assert isinstance(events[0], SessionFailure)
+    assert events[0].code in {"provider_send_failure", "explicit_response_failed"}
+    assert marker not in repr(events)
+    assert marker not in repr(vars(session))
+    assert session._pending_send_failure is None
+    assert session._terminal is True
+    assert harness.wire.closed is True
+    assert not session._response_send_tasks
+    assert not session._detached_close_tasks
+
+
+def test_authority_validator_has_controlled_depth_and_node_budgets():
+    def nested(depth, leaf):
+        value = leaf
+        for _ in range(depth):
+            value = {"metadata": [value]}
+        return value
+
+    accepted = {"type": "session.updated", "metadata": nested(32, {"safe": True})}
+    core_rt._validate_output_event_authority(accepted)
+
+    forbidden = {"type": "session.updated", "metadata": nested(32, {"tool": "blocked"})}
+    with pytest.raises(ValueError, match="forbidden structured authority"):
+        core_rt._validate_output_event_authority(forbidden)
+
+    excessive = {"type": "session.updated", "metadata": nested(33, {"safe": True})}
+    with pytest.raises(ValueError, match="depth") as depth_error:
+        core_rt._validate_output_event_authority(excessive)
+    assert not isinstance(depth_error.value, RecursionError)
+
+    fanout = {"type": "session.updated", "metadata": [{"safe": True}] * 4097}
+    with pytest.raises(ValueError, match="node"):
+        core_rt._validate_output_event_authority(fanout)
+
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider().open_session(setup())
+        before = session._provider_session_id
+        with pytest.raises(ValueError, match="depth"):
+            session._map_event(excessive)
+        return session, before
+
+    session, before = asyncio.run(scenario())
+    assert session._provider_session_id == before is None
+
+
 def test_exact_input_item_identity_maps_partial_and_final_operator_transcripts():
     events = [
         {"type": "session.created", "session": {"id": "session-1"}},
@@ -2693,6 +2764,78 @@ def test_cancel_send_and_provider_terminal_are_linearized_in_both_race_orders():
 
     asyncio.run(terminal_wins())
     asyncio.run(send_failure_wins())
+
+
+def test_eof_cleanup_does_not_revoke_terminal_supersession_of_late_cancel_failure():
+    class RetainedCancelWire(FakeWire):
+        def __init__(self):
+            super().__init__()
+            self.incoming = asyncio.Queue()
+            self.cancel_started = asyncio.Event()
+            self.release_cancel = asyncio.Event()
+
+        async def send_json(self, messages):
+            messages = tuple(messages)
+            self.sent.extend(messages)
+            if messages[0]["type"] == "response.cancel":
+                self.cancel_started.set()
+                await self.release_cancel.wait()
+                raise RuntimeError("late cancel secret-free failure")
+
+        async def __anext__(self):
+            event = await self.incoming.get()
+            if event is None:
+                raise core_rt.OpenAIWireEOF("")
+            return event
+
+        async def close(self):
+            if not self.closed:
+                self.closed = True
+                self.incoming.put_nowait(None)
+
+    async def scenario():
+        harness = Harness()
+        harness.wire = RetainedCancelWire()
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        stream = session.events()
+        harness.wire.incoming.put_nowait(
+            {
+                "type": "response.created",
+                "response": {"id": "resp-1", "metadata": {"correlation": "token-1"}},
+            }
+        )
+        assert await anext(stream) == ResponseStarted(response_id="resp-1", turn_id="turn-41")
+        waiter = asyncio.create_task(session.cancel_response("resp-1"))
+        await harness.wire.cancel_started.wait()
+        harness.wire.incoming.put_nowait(
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "resp-1",
+                    "status": "cancelled",
+                    "metadata": {"correlation": "token-1"},
+                    "output": [],
+                    "status_details": {"type": "cancelled", "reason": "client_cancelled"},
+                },
+            }
+        )
+        assert await anext(stream) == Interruption(response_id="resp-1", turn_id="turn-41")
+        harness.wire.incoming.put_nowait(None)
+        assert await anext(stream) == SessionClosed()
+        with pytest.raises(StopAsyncIteration):
+            await anext(stream)
+        harness.wire.release_cancel.set()
+        await waiter
+        await asyncio.sleep(0)
+        assert session._terminal_failure is None
+        assert session._pending_send_failure is None
+        assert not session._terminal_cancel_supersessions
+        assert not session._in_flight_response_cancellations
+        assert not session._response_cancellation_tasks
+        assert not session._detached_close_tasks
+
+    asyncio.run(scenario())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import importlib
+import sys
+import types
 from collections.abc import Mapping
 
 import pytest
@@ -13,11 +17,17 @@ pytest.importorskip(
 )
 from agent.realtime_voice_provider import (
     InputTranscript,
+    OutputAudio,
+    OutputTranscript,
+    RealtimeAudioFormat,
     RealtimeCapability,
     RealtimeInputAudioFormat,
     RealtimeOutputAudioFormat,
+    RealtimeResponseRequest,
     RealtimeTool,
     RealtimeVoiceSetup,
+    ResponseCompleted,
+    ResponseStarted,
     SessionClosed,
     SessionFailure,
     SessionReady,
@@ -75,11 +85,18 @@ class Harness:
         self.wire_calls += 1
         return self.wire
 
-    def provider(self, *, ledger_capacity=1024):
+    def provider(
+        self, *, ledger_capacity=1024, token_factory=None, response_ledger_capacity=1024
+    ):
+        kwargs = {}
+        if token_factory is not None:
+            kwargs["token_factory"] = token_factory
         return core_rt.TalkOpenAIRealtimeProvider(
             auth_resolver=self.resolve_auth,
             wire_factory=self.wire_factory,
             ledger_capacity=ledger_capacity,
+            response_ledger_capacity=response_ledger_capacity,
+            **kwargs,
         )
 
 
@@ -88,12 +105,25 @@ def setup(**changes):
         "model": "gpt-realtime-test",
         "voice": "cedar",
         "instructions": "transcribe only",
-        "input_audio": core_rt.SUPPORTED_INPUT_AUDIO_FORMAT,
-        "output_audio": core_rt.SUPPORTED_OUTPUT_AUDIO_FORMAT,
-        "automatic_response": False,
+        "audio": core_rt.SUPPORTED_AUDIO_FORMAT,
     }
     values.update(changes)
     return RealtimeVoiceSetup(**values)
+
+
+def response_request(**changes):
+    text = changes.pop("canonical_text", "Exact words, exactly.")
+    values = {
+        "durable_session_id": "durable-1",
+        "assistant_message_id": 41,
+        "turn_marker": "turn-41",
+        "canonical_text": text,
+        "content_digest": hashlib.sha256(text.encode()).hexdigest(),
+        "output_audio_format": core_rt.SUPPORTED_OUTPUT_AUDIO_FORMAT,
+        "allow_tools": False,
+    }
+    values.update(changes)
+    return RealtimeResponseRequest(**values)
 
 
 def collect(session):
@@ -103,11 +133,165 @@ def collect(session):
     return asyncio.run(scenario())
 
 
+def bind_response(session, correlation, *, response_id="resp-1"):
+    return session._map_event(
+        {
+            "type": "response.created",
+            "response": {"id": response_id, "metadata": {"correlation": correlation}},
+        }
+    )
+
+
+def response_done_event(
+    correlation,
+    *,
+    response_id="resp-1",
+    item_id="item-1",
+    transcript="words",
+    output=None,
+):
+    if output is None:
+        output = [
+            {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": transcript}],
+            }
+        ]
+    return {
+        "type": "response.done",
+        "response": {
+            "id": response_id,
+            "status": "completed",
+            "metadata": {"correlation": correlation},
+            "output": output,
+        },
+    }
+
+
+def complete_bound_response(
+    session, correlation, *, response_id="resp-1", item_id="item-1", transcript="words"
+):
+    for event in (
+        {
+            "type": "response.output_audio.delta",
+            "response_id": response_id,
+            "item_id": item_id,
+            "delta": "cGNt",
+        },
+        {
+            "type": "response.output_audio_transcript.done",
+            "response_id": response_id,
+            "item_id": item_id,
+            "transcript": transcript,
+        },
+        {
+            "type": "response.output_audio.done",
+            "response_id": response_id,
+            "item_id": item_id,
+        },
+    ):
+        session._map_event(event)
+    return session._map_event(
+        response_done_event(
+            correlation,
+            response_id=response_id,
+            item_id=item_id,
+            transcript=transcript,
+        )
+    )
+
+
+def valid_output_lifecycle_events(
+    correlation="token-1", *, response_id="resp-1", item_id="item-1", transcript="words"
+):
+    return [
+        {
+            "type": "response.output_item.added",
+            "response_id": response_id,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "in_progress",
+                "content": [],
+            },
+        },
+        {
+            "type": "response.content_part.added",
+            "response_id": response_id,
+            "item_id": item_id,
+            "part": {"type": "output_audio"},
+        },
+        {
+            "type": "response.output_audio.delta",
+            "response_id": response_id,
+            "item_id": item_id,
+            "delta": "cGNt",
+        },
+        {
+            "type": "response.output_audio_transcript.delta",
+            "response_id": response_id,
+            "item_id": item_id,
+            "delta": transcript[:1],
+        },
+        {
+            "type": "response.output_audio_transcript.done",
+            "response_id": response_id,
+            "item_id": item_id,
+            "transcript": transcript,
+        },
+        {
+            "type": "response.output_audio.done",
+            "response_id": response_id,
+            "item_id": item_id,
+        },
+        {
+            "type": "response.content_part.done",
+            "response_id": response_id,
+            "item_id": item_id,
+            "part": {"type": "output_audio", "transcript": transcript},
+        },
+        {
+            "type": "response.output_item.done",
+            "response_id": response_id,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": transcript}],
+            },
+        },
+        {
+            "type": "conversation.item.done",
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": transcript}],
+            },
+        },
+        response_done_event(
+            correlation,
+            response_id=response_id,
+            item_id=item_id,
+            transcript=transcript,
+        ),
+    ]
+
+
 def test_exact_api_v2_contract_and_fixed_capabilities():
     expected = frozenset(
         {
             RealtimeCapability.INPUT_TRANSCRIPTION,
             RealtimeCapability.INPUT_COMMIT_EVENTS,
+            RealtimeCapability.EXPLICIT_RESPONSE,
+            RealtimeCapability.RESPONSE_METADATA_ECHO,
+            RealtimeCapability.OUTPUT_TRANSCRIPTION,
         }
     )
 
@@ -125,6 +309,1644 @@ def test_exact_api_v2_contract_and_fixed_capabilities():
             await session.close()
 
     asyncio.run(scenario())
+
+
+def test_explicit_output_format_is_exact_pcm_s16le():
+    assert RealtimeOutputAudioFormat(
+        mime_type="audio/pcm",
+        sample_rate_hz=24_000,
+        channels=1,
+        sample_encoding="pcm_s16le",
+        sample_width_bytes=2,
+        endianness="little",
+    ) == core_rt.SUPPORTED_OUTPUT_AUDIO_FORMAT
+
+
+def test_explicit_response_sends_exact_causally_opaque_no_tool_payload():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "opaque-token-1").open_session(
+            setup(output_audio=core_rt.SUPPORTED_OUTPUT_AUDIO_FORMAT)
+        )
+        await session.start_response(response_request())
+        await session.close()
+
+    asyncio.run(scenario())
+    message = harness.wire.sent[0]
+    assert message.pop("event_id").startswith("evt-")
+    assert message == {
+        "type": "response.create",
+        "response": {
+            "conversation": "none",
+            "metadata": {"correlation": "opaque-token-1"},
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Exact words, exactly."}],
+                }
+            ],
+            "instructions": (
+                "Render the sole user input as speech verbatim. Speak every character's "
+                "words and punctuation naturally, but add, remove, or paraphrase nothing. "
+                "Do not preface or explain."
+            ),
+            "output_modalities": ["audio"],
+            "audio": {
+                "output": {
+                    "voice": "cedar",
+                    "format": {"type": "audio/pcm", "rate": 24000},
+                }
+            },
+            "tools": [],
+            "tool_choice": "none",
+        },
+    }
+    assert not {
+        "durable_session_id",
+        "assistant_message_id",
+        "turn_marker",
+        "content_digest",
+    }.intersection(message["response"]["metadata"])
+
+
+def test_output_format_mismatch_is_rejected_before_provider_send():
+    harness = Harness()
+    wrong = RealtimeOutputAudioFormat(
+        mime_type="audio/pcm",
+        sample_rate_hz=16_000,
+        channels=1,
+        sample_encoding="pcm_s16le",
+        sample_width_bytes=2,
+        endianness="little",
+    )
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "unused").open_session(setup())
+        with pytest.raises(ValueError, match="output audio format"):
+            await session.start_response(response_request(output_audio_format=wrong))
+
+    asyncio.run(scenario())
+    assert harness.wire.sent == []
+
+
+def test_bound_response_maps_started_audio_transcript_and_completed():
+    correlation = "opaque-bound-token"
+    events = [
+        {
+            "type": "response.created",
+            "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+        },
+        {
+            "type": "response.output_item.added",
+            "response_id": "resp-1",
+            "item": {
+                "id": "item-out-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "in_progress",
+                "content": [],
+            },
+        },
+        {
+            "type": "response.content_part.added",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+            "part": {"type": "output_audio"},
+        },
+        {
+            "type": "response.output_audio.delta",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+            "delta": "cGNt",
+        },
+        {
+            "type": "response.output_audio_transcript.delta",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+            "delta": "Exact ",
+        },
+        {
+            "type": "response.output_audio_transcript.done",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+            "transcript": "Exact words, exactly.",
+        },
+        {
+            "type": "response.output_audio.done",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+        },
+        {
+            "type": "response.content_part.done",
+            "response_id": "resp-1",
+            "item_id": "item-out-1",
+            "part": {"type": "output_audio", "transcript": "Exact words, exactly."},
+        },
+        {
+            "type": "response.output_item.done",
+            "response_id": "resp-1",
+            "item": {
+                "id": "item-out-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": "Exact words, exactly."}],
+            },
+        },
+        {
+            "type": "conversation.item.done",
+            "item": {
+                "id": "item-out-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": "Exact words, exactly."}],
+            },
+        },
+        {
+            "type": "response.done",
+            "response": {
+                "id": "resp-1",
+                "status": "completed",
+                "metadata": {"correlation": correlation},
+                "output": [
+                    {
+                        "id": "item-out-1",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_audio", "transcript": "Exact words, exactly."}
+                        ],
+                    }
+                ],
+            },
+        },
+    ]
+    harness = Harness(events)
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert received[:-1] == [
+        ResponseStarted(response_id="resp-1", turn_id="turn-41"),
+        OutputAudio(
+            data=b"pcm", item_id="item-out-1", response_id="resp-1", turn_id="turn-41"
+        ),
+        OutputTranscript(
+            item_id="item-out-1",
+            response_id="resp-1",
+            turn_id="turn-41",
+            text="Exact ",
+            final=False,
+        ),
+        OutputTranscript(
+            item_id="item-out-1",
+            response_id="resp-1",
+            turn_id="turn-41",
+            text="Exact words, exactly.",
+            final=True,
+        ),
+        ResponseCompleted(response_id="resp-1", turn_id="turn-41"),
+    ]
+    assert received[-1] == SessionClosed()
+    assert not session._pending_responses
+    assert not session._active_responses
+    assert not session._completed_responses
+
+
+@pytest.mark.parametrize(
+    "bad_event,match",
+    [
+        (
+            {
+                "type": "response.created",
+                "response": {"id": "resp-1", "metadata": {"correlation": "unknown"}},
+            },
+            "correlation",
+        ),
+        (
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-wrong",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            },
+            "response",
+        ),
+        (
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "%%%",
+            },
+            "base64",
+        ),
+        (
+            {"type": "response.function_call_arguments.done", "response_id": "resp-1"},
+            "function",
+        ),
+        (
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "resp-1",
+                    "status": "failed",
+                    "metadata": {"correlation": "opaque-bad-token"},
+                },
+            },
+            "completed",
+        ),
+        (
+            {
+                "type": "response.done",
+                "response": {
+                    "id": "resp-1",
+                    "status": "completed",
+                    "metadata": {"correlation": "opaque-bad-token"},
+                    "output": [{"id": "wrong-item", "type": "message"}],
+                },
+            },
+            "item",
+        ),
+    ],
+)
+def test_explicit_output_protocol_violations_fail_closed(bad_event, match):
+    correlation = "opaque-bad-token"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    if bad_event["type"] == "response.created":
+        events = [bad_event]
+    elif match == "item":
+        events = [
+            created,
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            },
+            bad_event,
+        ]
+    else:
+        events = [created, bad_event]
+    harness = Harness(events)
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return [event async for event in session.events()]
+
+    received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert match in received[-1].message
+    assert harness.wire.closed is True
+
+
+def test_replayed_correlation_and_changed_item_identity_fail_closed():
+    correlation = "one-time-token"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    replay_events = [
+        created,
+        {
+            "type": "response.created",
+            "response": {"id": "resp-2", "metadata": {"correlation": correlation}},
+        },
+    ]
+    wrong_item_events = [
+        created,
+        {
+            "type": "response.output_audio.delta",
+            "response_id": "resp-1",
+            "item_id": "item-1",
+            "delta": "cGNt",
+        },
+        {
+            "type": "response.output_audio.delta",
+            "response_id": "resp-1",
+            "item_id": "item-2",
+            "delta": "cGNt",
+        },
+    ]
+    for events, match in ((replay_events, "replayed"), (wrong_item_events, "identity")):
+        harness = Harness(events)
+
+        async def scenario(harness=harness, correlation=correlation):
+            provider = harness.provider(token_factory=lambda: correlation)
+            session = await provider.open_session(setup())
+            await session.start_response(response_request())
+            return [event async for event in session.events()]
+
+        received = asyncio.run(scenario())
+        assert isinstance(received[-1], SessionFailure)
+        assert match in received[-1].message
+
+
+def test_exact_setup_formats_are_validated_before_credentials_or_network():
+    wrong_input = RealtimeInputAudioFormat(
+        mime_type="audio/pcm",
+        sample_rate_hz=16_000,
+        channels=1,
+        sample_encoding="pcm_s16le",
+        sample_width_bytes=2,
+        endianness="little",
+    )
+    wrong_output = RealtimeOutputAudioFormat(
+        mime_type="audio/pcm",
+        sample_rate_hz=24_000,
+        channels=2,
+        sample_encoding="pcm_s16le",
+        sample_width_bytes=2,
+        endianness="little",
+    )
+    for bad_setup in (setup(input_audio=wrong_input), setup(output_audio=wrong_output)):
+        harness = Harness()
+        with pytest.raises(ValueError, match="audio"):
+            asyncio.run(harness.provider().open_session(bad_setup))
+        assert harness.auth_calls == harness.wire_calls == 0
+
+
+def test_response_capacity_and_close_cleanup_are_fail_closed():
+    tokens = iter(("token-1", "token-2"))
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(
+            token_factory=lambda: next(tokens), response_ledger_capacity=1
+        ).open_session(setup())
+        await session.start_response(response_request())
+        with pytest.raises(ValueError, match="capacity"):
+            await session.start_response(
+                response_request(
+                    assistant_message_id=42,
+                    turn_marker="turn-42",
+                    content_digest=hashlib.sha256(b"other").hexdigest(),
+                    canonical_text="other",
+                )
+            )
+        await session.close()
+        return session
+
+    session = asyncio.run(scenario())
+    assert not session._pending_responses
+    assert not session._active_responses
+    assert not session._completed_responses
+    assert not session._consumed_correlations
+
+
+@pytest.mark.parametrize("saturated_stage", ["pending", "bound", "completed"])
+def test_response_lifetime_capacity_is_reserved_before_provider_send(saturated_stage):
+    tokens = iter(("token-1", "token-2"))
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(
+            token_factory=lambda: next(tokens), response_ledger_capacity=1
+        ).open_session(setup())
+        await session.start_response(response_request())
+        if saturated_stage != "pending":
+            bind_response(session, "token-1")
+        if saturated_stage == "completed":
+            complete_bound_response(session, "token-1")
+        with pytest.raises(ValueError, match="capacity"):
+            await session.start_response(
+                response_request(
+                    assistant_message_id=42,
+                    turn_marker="turn-42",
+                    canonical_text="other",
+                    content_digest=hashlib.sha256(b"other").hexdigest(),
+                )
+            )
+        return session
+
+    session = asyncio.run(scenario())
+    assert len(harness.wire.sent) == 1
+    assert "token-2" not in session._pending_responses
+
+
+def test_response_created_validation_is_atomic_and_preserves_pending_reservation():
+    tokens = iter(("token-1", "token-2"))
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(
+            token_factory=lambda: next(tokens), response_ledger_capacity=2
+        ).open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        await session.start_response(
+            response_request(
+                assistant_message_id=42,
+                turn_marker="turn-42",
+                canonical_text="other",
+                content_digest=hashlib.sha256(b"other").hexdigest(),
+            )
+        )
+        before = dict(session._pending_responses)
+        with pytest.raises(ValueError, match="duplicate"):
+            bind_response(session, "token-2", response_id="resp-1")
+        assert session._pending_responses == before
+        with pytest.raises(ValueError, match="metadata"):
+            session._map_event(
+                {
+                    "type": "response.created",
+                    "response": {
+                        "id": "resp-2",
+                        "metadata": {"correlation": "token-2", "extra": True},
+                    },
+                }
+            )
+        assert session._pending_responses == before
+        assert bind_response(session, "token-2", response_id="resp-2") == ResponseStarted(
+            response_id="resp-2", turn_id="turn-42"
+        )
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "late_event,match",
+    [
+        (
+            {
+                "type": "response.output_audio_transcript.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "later",
+            },
+            "terminal",
+        ),
+        (
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "words",
+            },
+            "replayed",
+        ),
+        (
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "changed",
+            },
+            "conflicting",
+        ),
+    ],
+)
+def test_output_transcript_finality_is_terminal_and_exact(late_event, match):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        final = session._map_event(
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "words",
+            }
+        )
+        with pytest.raises(ValueError, match=match):
+            session._map_event(late_event)
+        return session, final
+
+    session, final = asyncio.run(scenario())
+    assert final == OutputTranscript(
+        item_id="item-1",
+        response_id="resp-1",
+        turn_id="turn-41",
+        text="words",
+        final=True,
+    )
+    assert session._final_output_transcripts == {("resp-1", "item-1"): "words"}
+
+
+@pytest.mark.parametrize(
+    "output,match",
+    [
+        ([], "nonempty"),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+            ],
+            "exactly one",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "function_call",
+                    "role": "assistant",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                }
+            ],
+            "authority",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                }
+            ],
+            "assistant",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "words"}],
+                }
+            ],
+            "output_audio",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_audio", "transcript": "words"},
+                        {"type": "output_text", "text": "words"},
+                    ],
+                }
+            ],
+            "exactly one",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_audio",
+                            "transcript": "words",
+                            "function_call": {"name": "forbidden"},
+                        }
+                    ],
+                }
+            ],
+            "authority",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_audio", "transcript": "changed"}],
+                }
+            ],
+            "conflicts",
+        ),
+        (
+            [
+                {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                }
+            ],
+            "status",
+        ),
+        ({"id": "item-1"}, "sequence"),
+    ],
+)
+def test_response_done_rejects_non_exact_audio_only_schema_without_consuming_active(
+    output, match
+):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        for event in (
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            },
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "words",
+            },
+            {
+                "type": "response.output_audio.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+            },
+        ):
+            session._map_event(event)
+        event = response_done_event("token-1", output=output)
+        with pytest.raises((TypeError, ValueError), match=match):
+            session._map_event(event)
+        assert "resp-1" in session._active_responses
+        assert "resp-1" not in session._completed_responses
+
+    asyncio.run(scenario())
+
+
+def test_response_done_requires_output_member():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        event = response_done_event("token-1")
+        del event["response"]["output"]
+        with pytest.raises(ValueError, match="output"):
+            session._map_event(event)
+        assert "resp-1" in session._active_responses
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("omitted", ["audio_delta", "audio_done", "transcript_done"])
+def test_response_done_requires_observed_audio_and_transcript_terminals(omitted):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        events = {
+            "audio_delta": {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+            },
+            "audio_done": {
+                "type": "response.output_audio.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+            },
+            "transcript_done": {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "words",
+            },
+        }
+        for name, event in events.items():
+            if name != omitted:
+                session._map_event(event)
+        with pytest.raises(ValueError, match=omitted.replace("_", " ")):
+            session._map_event(response_done_event("token-1"))
+        assert "resp-1" in session._active_responses
+
+    asyncio.run(scenario())
+
+
+def test_response_done_accepts_documented_realtime_item_object():
+    correlation = "token-1"
+    events = valid_output_lifecycle_events(correlation)
+    events[-1]["response"]["output"][0]["object"] = "realtime.item"
+    harness = Harness(
+        [
+            {
+                "type": "response.created",
+                "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+            },
+            *events,
+        ]
+    )
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return [event async for event in session.events()]
+
+    received = asyncio.run(scenario())
+    assert sum(isinstance(event, ResponseCompleted) for event in received) == 1
+
+
+def test_response_done_accepts_proven_audio_only_shape_and_clears_stream_state():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        completed = complete_bound_response(session, "token-1")
+        return session, completed
+
+    session, completed = asyncio.run(scenario())
+    assert completed == ResponseCompleted(response_id="resp-1", turn_id="turn-41")
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._final_output_transcripts
+    assert not session._audio_delta_items
+    assert not session._audio_done_items
+
+
+@pytest.mark.parametrize(
+    ("prefix", "bad_event"),
+    [
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "tool",
+                    "status": "in_progress",
+                    "content": [],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "output_text",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "function_call",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                    "tool_calls": [],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                    "function": {"name": "forbidden"},
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                    "tool": {"name": "forbidden"},
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": {},
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [{"type": "output_text", "text": "forbidden"}],
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "response.output_item.done",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-wrong",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.done",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [],
+                },
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.output_item.done",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": {"type": "output_audio"},
+                },
+            },
+        ),
+        ([], {"type": "response.content_part.added", "response_id": "resp-1", "item_id": "item-1"}),
+        (
+            [],
+            {
+                "type": "response.content_part.added",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": "output_audio",
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.content_part.added",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {"type": "output_text", "text": "forbidden"},
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {"type": "function_call", "name": "forbidden"},
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {"type": "tool", "name": "forbidden"},
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-1",
+                "item_id": "item-wrong",
+                "part": {"type": "output_audio", "transcript": "words"},
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-wrong",
+                "item_id": "item-1",
+                "part": {"type": "output_audio", "transcript": "words"},
+            },
+        ),
+        (
+            [],
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {"type": "output_audio", "transcript": 7},
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "user",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "function_call",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "forbidden"}],
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                    "function_call": {"name": "forbidden"},
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                    "tool": {"name": "forbidden"},
+                },
+            },
+        ),
+        (
+            [valid_output_lifecycle_events()[0]],
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                    "tool_calls": [],
+                },
+            },
+        ),
+    ],
+)
+def test_contradictory_output_lifecycle_event_fails_before_sanitized_completion(prefix, bad_event):
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    harness = Harness([created, *prefix, bad_event, *valid_output_lifecycle_events(correlation)])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert harness.wire.closed is True
+    assert session._terminal is True
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"tool_calls": []},
+        {"function_call": {"name": "forbidden"}},
+        {"tool": {"name": "forbidden"}},
+        {"call_id": "call-forbidden"},
+        {"name": "forbidden", "arguments": "{}"},
+        {"content": [{"type": "output_audio", "transcript": "words", "tool": {}}]},
+    ],
+)
+def test_response_done_rejects_extra_authority_before_mutating_direct_state(extra):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        for event in valid_output_lifecycle_events()[:6]:
+            session._map_event(event)
+        output = response_done_event("token-1")["response"]["output"]
+        item = output[0]
+        if "content" in extra:
+            item["content"] = extra["content"]
+        else:
+            item.update(extra)
+        before = (
+            dict(session._active_responses),
+            dict(session._response_items),
+            dict(session._item_responses),
+            dict(session._final_output_transcripts),
+            set(session._audio_delta_items),
+            set(session._audio_done_items),
+            dict(session._completed_responses),
+        )
+        with pytest.raises((TypeError, ValueError)):
+            session._complete_response(response_done_event("token-1", output=output))
+        assert before == (
+            session._active_responses,
+            session._response_items,
+            session._item_responses,
+            session._final_output_transcripts,
+            session._audio_delta_items,
+            session._audio_done_items,
+            session._completed_responses,
+        )
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "bad_event",
+    [
+        {
+            "type": "response.content_part.done",
+            "response_id": "resp-1",
+            "item_id": "item-1",
+            "part": {"type": "output_audio", "transcript": "changed"},
+        },
+        {
+            "type": "response.output_item.done",
+            "response_id": "resp-1",
+            "item": {
+                "id": "item-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": "changed"}],
+            },
+        },
+        {
+            "type": "conversation.item.done",
+            "item": {
+                "id": "item-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_audio", "transcript": "changed"}],
+            },
+        },
+    ],
+)
+def test_final_lifecycle_transcript_must_match_terminal_text_before_mutation(bad_event):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        for event in valid_output_lifecycle_events()[:6]:
+            session._map_event(event)
+        before = (
+            dict(session._response_items),
+            dict(session._item_responses),
+            set(session._content_part_done),
+            set(session._output_item_done),
+            set(session._conversation_item_done),
+        )
+        with pytest.raises(ValueError, match="conflicts"):
+            session._map_event(bad_event)
+        assert before == (
+            session._response_items,
+            session._item_responses,
+            session._content_part_done,
+            session._output_item_done,
+            session._conversation_item_done,
+        )
+
+    asyncio.run(scenario())
+
+
+def output_envelope_authority_cases():
+    return [
+        pytest.param(
+            {
+                "type": "response.created",
+                "response": {
+                    "id": "resp-1",
+                    "metadata": {"correlation": "token-1"},
+                    "tool_calls": [],
+                },
+            },
+            ResponseStarted,
+            id="response-created-nested-tool-calls-empty",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_item.added",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "content": [],
+                },
+                "tools": [],
+            },
+            ResponseCompleted,
+            id="output-item-added-top-level-tools-empty",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_item.done",
+                "response_id": "resp-1",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                    "metadata": {"type": "tool_call"},
+                },
+                "function": {},
+            },
+            ResponseCompleted,
+            id="output-item-done-recursive-type-and-function-empty",
+        ),
+        pytest.param(
+            {
+                "type": "response.content_part.added",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {"type": "output_audio"},
+                "tool": {},
+            },
+            ResponseCompleted,
+            id="content-part-added-top-level-tool-empty",
+        ),
+        pytest.param(
+            {
+                "type": "response.content_part.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "part": {
+                    "type": "output_audio",
+                    "transcript": "words",
+                    "tool_choice": "none",
+                },
+            },
+            ResponseCompleted,
+            id="content-part-done-nested-tool-choice",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_audio.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "cGNt",
+                "function_call": {"name": "forbidden"},
+            },
+            OutputAudio,
+            id="output-audio-delta-function-call",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_audio.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "arguments": "{}",
+            },
+            ResponseCompleted,
+            id="output-audio-done-arguments-empty-object",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_audio_transcript.delta",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "delta": "w",
+                "call_id": "call-forbidden",
+            },
+            OutputTranscript,
+            id="output-transcript-delta-call-id",
+        ),
+        pytest.param(
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "item_id": "item-1",
+                "transcript": "words",
+                "function_call_output": "",
+            },
+            OutputTranscript,
+            id="output-transcript-done-function-call-output-empty",
+        ),
+        pytest.param(
+            {
+                "type": "conversation.item.done",
+                "item": {
+                    "id": "item-1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_audio", "transcript": "words"}],
+                },
+                "function_call": {},
+            },
+            ResponseCompleted,
+            id="conversation-item-done-top-level-function-call-empty",
+        ),
+        pytest.param(
+            {**response_done_event("token-1"), "name": "forbidden"},
+            ResponseCompleted,
+            id="response-done-top-level-name",
+        ),
+        pytest.param(
+            {
+                **response_done_event("token-1"),
+                "response": {
+                    **response_done_event("token-1")["response"],
+                    "tools": [],
+                },
+            },
+            ResponseCompleted,
+            id="response-done-nested-response-tools-empty",
+        ),
+    ]
+
+
+def output_authority_state(session):
+    return (
+        dict(session._pending_responses),
+        dict(session._active_responses),
+        dict(session._response_items),
+        dict(session._item_responses),
+        dict(session._final_output_transcripts),
+        set(session._audio_delta_items),
+        set(session._audio_done_items),
+        set(session._output_item_added),
+        set(session._content_part_added),
+        set(session._content_part_done),
+        set(session._output_item_done),
+        set(session._conversation_item_done),
+        dict(session._completed_responses),
+        dict(session._consumed_correlations),
+    )
+
+
+@pytest.mark.parametrize(("bad_event", "forbidden_output"), output_envelope_authority_cases())
+def test_every_output_event_envelope_authority_fails_before_emission(
+    bad_event, forbidden_output
+):
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    prefix = [] if bad_event["type"] == "response.created" else [created]
+    harness = Harness([*prefix, bad_event, *valid_output_lifecycle_events(correlation)])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return [event async for event in session.events()]
+
+    received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert "authority" in received[-1].message
+    assert not any(isinstance(event, forbidden_output) for event in received)
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert harness.wire.closed is True
+
+
+@pytest.mark.parametrize(("bad_event", "_forbidden_output"), output_envelope_authority_cases())
+def test_every_output_event_envelope_authority_preserves_direct_state(
+    bad_event, _forbidden_output
+):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        if bad_event["type"] != "response.created":
+            bind_response(session, "token-1")
+        before = output_authority_state(session)
+        with pytest.raises(ValueError, match="authority"):
+            session._map_event(bad_event)
+        assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    "discriminator",
+    ["function_call", "function_call_output", "tool", "tool_call"],
+)
+def test_recursive_output_authority_discriminator_is_rejected(discriminator):
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        before = output_authority_state(session)
+        with pytest.raises(ValueError, match="authority type"):
+            session._map_event(
+                {
+                    "type": "response.output_audio.done",
+                    "response_id": "resp-1",
+                    "item_id": "item-1",
+                    "metadata": {"nested": [{"type": discriminator}]},
+                }
+            )
+        assert output_authority_state(session) == before
+
+    asyncio.run(scenario())
+
+
+def test_output_event_envelope_authority_fails_before_response_started():
+    correlation = "token-1"
+    bad_created = {
+        "type": "response.created",
+        "response": {
+            "id": "resp-1",
+            "metadata": {"correlation": correlation},
+            "tool_calls": [],
+        },
+    }
+    harness = Harness([bad_created, *valid_output_lifecycle_events(correlation)])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert "authority" in received[-1].message
+    assert not any(isinstance(event, ResponseStarted) for event in received)
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert session._terminal is True
+
+
+def test_response_done_extra_authority_fails_event_pump_and_cleans_terminal_state():
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    done = response_done_event(correlation)
+    done["response"]["output"][0]["tool_calls"] = []
+    harness = Harness([created, *valid_output_lifecycle_events(correlation)[:-1], done])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert isinstance(received[-1], SessionFailure)
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert session._terminal is True
+    assert not session._active_responses
+    assert not session._completed_responses
+
+
+def test_valid_live_output_lifecycle_completes_exactly_once_and_cleans_terminal_state():
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    harness = Harness([created, *valid_output_lifecycle_events(correlation)])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert sum(isinstance(event, ResponseCompleted) for event in received) == 1
+    assert received[-1] == SessionClosed()
+    assert session._terminal is True
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._completed_responses
+
+
+def test_live_proven_output_envelopes_accept_event_ids_and_indexes_once():
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "event_id": "evt-created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    events = valid_output_lifecycle_events(correlation)
+    for index, event in enumerate(events):
+        event["event_id"] = f"evt-{index}"
+        if event["type"].startswith("response."):
+            event["output_index"] = 0
+        if event["type"].startswith("response.content_part") or "output_audio" in event["type"]:
+            event["content_index"] = 0
+    harness = Harness([created, *events])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return [event async for event in session.events()]
+
+    received = asyncio.run(scenario())
+    assert sum(isinstance(event, ResponseStarted) for event in received) == 1
+    assert sum(isinstance(event, OutputAudio) for event in received) == 1
+    assert sum(isinstance(event, ResponseCompleted) for event in received) == 1
+    assert received[-1] == SessionClosed()
+
+
+def test_invalid_intermediate_shape_does_not_mutate_binding_state_directly():
+    harness = Harness()
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
+        await session.start_response(response_request())
+        bind_response(session, "token-1")
+        before = (
+            dict(session._response_items),
+            dict(session._item_responses),
+            dict(session._final_output_transcripts),
+        )
+        with pytest.raises((TypeError, ValueError)):
+            session._map_event(
+                {
+                    "type": "response.output_item.added",
+                    "response_id": "resp-1",
+                    "item": {
+                        "id": "item-1",
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "in_progress",
+                        "content": [],
+                        "tool_calls": [],
+                    },
+                }
+            )
+        assert before == (
+            session._response_items,
+            session._item_responses,
+            session._final_output_transcripts,
+        )
+
+    asyncio.run(scenario())
+
+
+def test_explicit_response_send_failure_cleans_pending_and_is_terminally_visible():
+    harness = Harness()
+    harness.wire.send_error = core_rt.OpenAIWireError("response send exploded")
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: "failed-token").open_session(setup())
+        with pytest.raises(core_rt.OpenAIWireError, match="response send exploded"):
+            await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    assert not session._pending_responses
+    assert received == [
+        SessionFailure(
+            code="explicit_response_failed",
+            message="explicit response provider send failed",
+        )
+    ]
+    assert harness.wire.closed is True
+
+
+def test_missing_task1_symbols_leave_legacy_input_only_contract_available(monkeypatch):
+    contract = sys.modules["agent.realtime_voice_provider"]
+    shim = types.ModuleType(contract.__name__)
+    optional = {
+        "RealtimeInputAudioFormat",
+        "RealtimeOutputAudioFormat",
+        "RealtimeResponseRequest",
+        "ResponseStarted",
+        "OutputAudio",
+        "OutputTranscript",
+        "ResponseCompleted",
+    }
+    shim.__dict__.update(
+        {name: value for name, value in contract.__dict__.items() if name not in optional}
+    )
+    agent_package = sys.modules["agent"]
+    monkeypatch.setitem(sys.modules, "agent.realtime_voice_provider", shim)
+    monkeypatch.setattr(agent_package, "realtime_voice_provider", shim)
+    legacy = importlib.reload(core_rt)
+    try:
+        assert legacy.core_provider_available() is True
+        assert frozenset(
+            {
+                legacy.RealtimeCapability.INPUT_TRANSCRIPTION,
+                legacy.RealtimeCapability.INPUT_COMMIT_EVENTS,
+            }
+        ) == legacy.CORE_CAPABILITIES
+        assert legacy.SUPPORTED_OUTPUT_AUDIO_FORMAT is None
+    finally:
+        monkeypatch.undo()
+        importlib.reload(core_rt)
 
 
 def test_passive_diagnostic_distinguishes_contract_from_provider_readiness(monkeypatch):
@@ -160,16 +1982,8 @@ def test_passive_diagnostic_distinguishes_contract_from_provider_readiness(monke
         ),
         setup(automatic_response=True),
         setup(provider_options={"capabilities": ["tool_calling"]}),
-        setup(
-            input_audio=RealtimeInputAudioFormat(
-                "audio/pcm", 16_000, 1, "pcm_s16le", 2, "little"
-            )
-        ),
-        setup(
-            output_audio=RealtimeOutputAudioFormat(
-                "audio/pcm", 16_000, 1, "pcm_s16le", 2, "little"
-            )
-        ),
+        setup(audio=RealtimeAudioFormat("audio/pcm", 16_000, 1)),
+        setup(audio=RealtimeAudioFormat("audio/wav", 24_000, 1)),
     ],
 )
 def test_unsupported_setup_is_rejected_before_credentials_or_network(bad_setup):
@@ -205,28 +2019,6 @@ def test_core_connect_disables_response_in_update_and_sends_only_input_commands(
         {"type": "input_audio_buffer.commit"},
     ]
     assert harness.wire.closed is True
-
-
-def test_typed_setup_fields_are_exact_and_legacy_audio_remains_compatible():
-    assert RealtimeInputAudioFormat(
-        "audio/pcm", 24_000, 1, "pcm_s16le", 2, "little"
-    ) == core_rt.SUPPORTED_INPUT_AUDIO_FORMAT
-    assert RealtimeOutputAudioFormat(
-        "audio/pcm", 24_000, 1, "pcm_s16le", 2, "little"
-    ) == core_rt.SUPPORTED_OUTPUT_AUDIO_FORMAT
-
-    async def scenario():
-        typed = Harness()
-        session = await typed.provider().open_session(setup())
-        await session.close()
-
-        legacy = Harness()
-        session = await legacy.provider().open_session(
-            setup(input_audio=None, output_audio=None, audio=core_rt.SUPPORTED_AUDIO_FORMAT)
-        )
-        await session.close()
-
-    asyncio.run(scenario())
 
 
 def test_send_failure_closes_and_remains_visible_as_one_terminal_event():
@@ -349,10 +2141,10 @@ def test_exact_input_item_identity_maps_partial_and_final_operator_transcripts()
             ],
             "conflicting terminal transcript",
         ),
-        ([{"type": "response.created", "response": {"id": "response-1"}}], "unsolicited"),
+        ([{"type": "response.created", "response": {"id": "response-1"}}], "correlation"),
         (
             [{"type": "response.function_call_arguments.done", "call_id": "call-1"}],
-            "unsolicited",
+            "function",
         ),
         (
             [

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -700,7 +700,7 @@ def test_explicit_output_protocol_violations_fail_closed(bad_event, match):
 
     received = asyncio.run(scenario())
     assert isinstance(received[-1], SessionFailure)
-    assert match in received[-1].message
+    assert received[-1].message == "provider protocol failure"
     assert harness.wire.closed is True
 
 
@@ -733,7 +733,7 @@ def test_replayed_correlation_and_changed_item_identity_fail_closed():
             "delta": "cGNt",
         },
     ]
-    for events, match in ((replay_events, "replayed"), (wrong_item_events, "identity")):
+    for events in (replay_events, wrong_item_events):
         harness = Harness(events)
 
         async def scenario(harness=harness, correlation=correlation):
@@ -744,7 +744,7 @@ def test_replayed_correlation_and_changed_item_identity_fail_closed():
 
         received = asyncio.run(scenario())
         assert isinstance(received[-1], SessionFailure)
-        assert match in received[-1].message
+        assert received[-1].message == "provider protocol failure"
 
 
 def test_exact_setup_formats_are_validated_before_credentials_or_network():
@@ -1805,7 +1805,7 @@ def test_every_output_event_envelope_authority_fails_before_emission(
 
     received = asyncio.run(scenario())
     assert isinstance(received[-1], SessionFailure)
-    assert "authority" in received[-1].message
+    assert received[-1].message == "provider protocol failure"
     assert not any(isinstance(event, forbidden_output) for event in received)
     assert not any(isinstance(event, ResponseCompleted) for event in received)
     assert harness.wire.closed is True
@@ -2003,7 +2003,7 @@ def test_output_event_envelope_authority_fails_before_response_started():
 
     session, received = asyncio.run(scenario())
     assert isinstance(received[-1], SessionFailure)
-    assert "authority" in received[-1].message
+    assert received[-1].message == "provider protocol failure"
     assert not any(isinstance(event, ResponseStarted) for event in received)
     assert not any(isinstance(event, ResponseCompleted) for event in received)
     assert session._terminal is True
@@ -2056,7 +2056,7 @@ def test_terminal_transcript_digest_mismatch_fails_closed_and_clears_all_respons
     failures = [event for event in received if isinstance(event, SessionFailure)]
     assert len(failures) == 1
     assert failures[0].code == "provider_protocol_failure"
-    assert "digest" in failures[0].message
+    assert failures[0].message == "provider protocol failure"
     assert not any(isinstance(event, ResponseCompleted) for event in received)
     assert harness.wire.closed is True
     assert session._terminal is True
@@ -2433,7 +2433,7 @@ def test_send_failure_closes_and_remains_visible_as_one_terminal_event():
     assert harness.wire.closed is True
     assert len(events) == 1
     assert isinstance(events[0], SessionFailure)
-    assert "send exploded" in events[0].message
+    assert events[0].message == "provider send failed"
 
 
 def test_send_failure_remains_visible_when_event_pump_is_already_waiting():
@@ -2473,37 +2473,124 @@ def test_send_failure_remains_visible_when_event_pump_is_already_waiting():
     assert len(events) == 1
     assert isinstance(events[0], SessionFailure)
     assert events[0].code == "provider_send_failure"
-    assert "concurrent send exploded" in events[0].message
+    assert events[0].message == "provider send failed"
 
 
 @pytest.mark.parametrize(
-    "operation,marker",
+    ("operation", "provider_detail", "expected_code", "expected_message"),
     [
-        ("send_audio", "Bearer sentinel-send-secret"),
-        ("start_response", "password=sentinel-response-secret"),
+        (
+            "send_audio",
+            "arbitrary-sentinel-send Bearer sentinel-send-secret",
+            "provider_send_failure",
+            "provider send failed",
+        ),
+        (
+            "start_response",
+            "arbitrary-sentinel-response password=sentinel-response-secret",
+            "explicit_response_failed",
+            "explicit response provider send failed",
+        ),
+        (
+            "protocol",
+            "arbitrary-sentinel-protocol token=sentinel-protocol-secret",
+            "provider_protocol_failure",
+            "provider protocol failure",
+        ),
+        (
+            "eof",
+            "arbitrary-sentinel-eof api_key=sentinel-eof-secret",
+            "provider_eof",
+            "provider connection closed unexpectedly",
+        ),
     ],
 )
-def test_failure_paths_redact_credentials_and_release_raw_exceptions(operation, marker):
+def test_provider_failures_use_fixed_public_receipts_and_release_raw_detail(
+    operation, provider_detail, expected_code, expected_message
+):
     harness = Harness()
-    harness.wire.send_error = core_rt.OpenAIWireError(f"provider rejected {marker}")
+    if operation in {"send_audio", "start_response"}:
+        harness.wire.send_error = core_rt.OpenAIWireError(provider_detail)
+    elif operation == "protocol":
+        harness.wire.events = iter(
+            ({"type": "error", "error": {"message": provider_detail}},)
+        )
+    else:
+        harness.wire.events = iter((core_rt.OpenAIWireEOF(provider_detail),))
 
     async def scenario():
         session = await harness.provider(token_factory=lambda: "token-1").open_session(setup())
-        with pytest.raises(core_rt.OpenAIWireError):
-            if operation == "send_audio":
-                await session.send_audio(b"pcm")
-            else:
-                await session.start_response(response_request())
+        if operation in {"send_audio", "start_response"}:
+            with pytest.raises(core_rt.OpenAIWireError):
+                if operation == "send_audio":
+                    await session.send_audio(b"pcm")
+                else:
+                    await session.start_response(response_request())
         events = [event async for event in session.events()]
         await asyncio.sleep(0)
         return session, events
 
     session, events = asyncio.run(scenario())
-    assert len(events) == 1
-    assert isinstance(events[0], SessionFailure)
-    assert events[0].code in {"provider_send_failure", "explicit_response_failed"}
-    assert marker not in repr(events)
-    assert marker not in repr(vars(session))
+    assert events == [SessionFailure(code=expected_code, message=expected_message)]
+    assert provider_detail not in repr(events)
+    assert provider_detail not in repr(vars(session))
+    assert session._pending_send_failure is None
+    assert session._terminal is True
+    assert harness.wire.closed is True
+    assert not session._response_send_tasks
+    assert not session._detached_close_tasks
+
+
+def test_retained_send_failure_wins_over_secondary_protocol_failure_receipt():
+    provider_detail = "arbitrary-sentinel-race Bearer sentinel-race-secret"
+
+    class SendProtocolRaceWire(FakeWire):
+        def __init__(self):
+            super().__init__()
+            self.receive_started = asyncio.Event()
+            self.release_protocol = asyncio.Event()
+            self.send_started = asyncio.Event()
+            self.release_send = asyncio.Event()
+
+        async def __anext__(self):
+            self.receive_started.set()
+            await self.release_protocol.wait()
+            return {"type": "error", "error": {"message": "secondary protocol detail"}}
+
+        async def send_json(self, messages):
+            del messages
+            self.send_started.set()
+            await self.release_send.wait()
+            raise core_rt.OpenAIWireError(provider_detail)
+
+        async def close(self):
+            self.closed = True
+
+    async def scenario():
+        harness = Harness()
+        harness.wire = SendProtocolRaceWire()
+        session = await harness.provider().open_session(setup())
+        pump = asyncio.create_task(_collect(session))
+        await harness.wire.receive_started.wait()
+        sender = asyncio.create_task(session.send_audio(b"pcm"))
+        await harness.wire.send_started.wait()
+        harness.wire.release_send.set()
+        with pytest.raises(core_rt.OpenAIWireError):
+            await sender
+        harness.wire.release_protocol.set()
+        events = await pump
+        await asyncio.sleep(0)
+        return session, harness, events
+
+    async def _collect(session):
+        return [event async for event in session.events()]
+
+    session, harness, events = asyncio.run(scenario())
+    assert events == [
+        SessionFailure(code="provider_send_failure", message="provider send failed")
+    ]
+    assert provider_detail not in repr(events)
+    assert provider_detail not in repr(vars(session))
     assert session._pending_send_failure is None
     assert session._terminal is True
     assert harness.wire.closed is True
@@ -2903,7 +2990,7 @@ def test_protocol_violations_emit_one_terminal_failure_and_close(events, match):
     received = asyncio.run(scenario())
     failures = [event for event in received if isinstance(event, SessionFailure)]
     assert len(failures) == 1
-    assert match in failures[0].message
+    assert failures[0].message == "provider protocol failure"
     assert harness.wire.closed is True
 
 
@@ -2921,7 +3008,7 @@ def test_input_ledger_capacity_is_non_evicting_and_terminal():
     received = asyncio.run(scenario())
     assert len(received) == 1
     assert isinstance(received[0], SessionFailure)
-    assert "capacity" in received[0].message
+    assert received[0].message == "provider protocol failure"
     assert harness.wire.closed is True
 
 

--- a/tests/test_core_realtime_adapter.py
+++ b/tests/test_core_realtime_adapter.py
@@ -571,14 +571,11 @@ def test_explicit_output_protocol_violations_fail_closed(bad_event, match):
     if bad_event["type"] == "response.created":
         events = [bad_event]
     elif match == "item":
+        events = [created, *valid_output_lifecycle_events(correlation)[:-1], bad_event]
+    elif match == "base64":
         events = [
             created,
-            {
-                "type": "response.output_audio.delta",
-                "response_id": "resp-1",
-                "item_id": "item-1",
-                "delta": "cGNt",
-            },
+            *valid_output_lifecycle_events(correlation)[:2],
             bad_event,
         ]
     else:
@@ -611,6 +608,7 @@ def test_replayed_correlation_and_changed_item_identity_fail_closed():
     ]
     wrong_item_events = [
         created,
+        *valid_output_lifecycle_events(correlation)[:2],
         {
             "type": "response.output_audio.delta",
             "response_id": "resp-1",
@@ -1819,6 +1817,49 @@ def test_terminal_transcript_digest_mismatch_fails_closed_and_clears_all_respons
     assert len(failures) == 1
     assert failures[0].code == "provider_protocol_failure"
     assert "digest" in failures[0].message
+    assert not any(isinstance(event, ResponseCompleted) for event in received)
+    assert harness.wire.closed is True
+    assert session._terminal is True
+    assert not session._pending_responses
+    assert not session._active_responses
+    assert not session._response_items
+    assert not session._item_responses
+    assert not session._final_output_transcripts
+    assert not session._audio_delta_items
+    assert not session._audio_done_items
+    assert not session._output_item_added
+    assert not session._content_part_added
+    assert not session._content_part_done
+    assert not session._output_item_done
+    assert not session._conversation_item_done
+    assert not session._response_lifecycle
+    assert not session._completed_responses
+    assert not session._consumed_correlations
+
+
+def test_live_pre_start_audio_delta_fails_before_emission_and_cleans_all_response_state():
+    correlation = "token-1"
+    created = {
+        "type": "response.created",
+        "response": {"id": "resp-1", "metadata": {"correlation": correlation}},
+    }
+    lifecycle = valid_output_lifecycle_events(
+        correlation, transcript="Exact words, exactly."
+    )
+    harness = Harness([created, lifecycle[2], *lifecycle])
+
+    async def scenario():
+        session = await harness.provider(token_factory=lambda: correlation).open_session(setup())
+        await session.start_response(response_request())
+        return session, [event async for event in session.events()]
+
+    session, received = asyncio.run(scenario())
+    failures = [event for event in received if isinstance(event, SessionFailure)]
+    assert len(failures) == 1
+    assert failures[0].code == "provider_protocol_failure"
+    assert sum(isinstance(event, ResponseStarted) for event in received) == 1
+    assert not any(isinstance(event, OutputAudio) for event in received)
+    assert not any(isinstance(event, OutputTranscript) for event in received)
     assert not any(isinstance(event, ResponseCompleted) for event in received)
     assert harness.wire.closed is True
     assert session._terminal is True

--- a/tests/test_core_session.py
+++ b/tests/test_core_session.py
@@ -103,13 +103,14 @@ def test_core_setup_is_input_only_and_requests_only_commit_transcription():
     assert setup.instructions == ""
     assert setup.tools == ()
     assert setup.audio == talk_core_session.talk_core_realtime.SUPPORTED_AUDIO_FORMAT
+    assert setup.automatic_response is False
     assert setup.provider_options == {
-        "automatic_response": False,
         "capabilities": (
             "input_transcription",
             "input_commit_events",
         ),
     }
+    assert "automatic_response" not in setup.provider_options
 
 
 def test_core_runner_opens_exact_provider_and_routes_only_authorized_pcm():

--- a/tests/test_core_session.py
+++ b/tests/test_core_session.py
@@ -103,6 +103,14 @@ def test_core_setup_is_input_only_and_requests_only_commit_transcription():
     assert setup.instructions == ""
     assert setup.tools == ()
     assert setup.audio == talk_core_session.talk_core_realtime.SUPPORTED_AUDIO_FORMAT
+    assert (
+        setup.input_audio
+        == talk_core_session.talk_core_realtime.SUPPORTED_INPUT_AUDIO_FORMAT
+    )
+    assert (
+        setup.output_audio
+        == talk_core_session.talk_core_realtime.SUPPORTED_OUTPUT_AUDIO_FORMAT
+    )
     assert setup.automatic_response is False
     assert setup.provider_options == {
         "capabilities": (
@@ -178,6 +186,15 @@ def test_core_runner_opens_exact_provider_and_routes_only_authorized_pcm():
 
     assert audio.started and audio.stopped
     assert factory.opened[0][0] == talk_core_session.talk_core_realtime.PROVIDER_NAME
+    opened_setup = factory.opened[0][1]
+    assert (
+        opened_setup.input_audio
+        == talk_core_session.talk_core_realtime.SUPPORTED_INPUT_AUDIO_FORMAT
+    )
+    assert (
+        opened_setup.output_audio
+        == talk_core_session.talk_core_realtime.SUPPORTED_OUTPUT_AUDIO_FORMAT
+    )
     assert factory.opened[0][2]["required_capabilities"] == (
         talk_core_session.talk_core_realtime.CORE_CAPABILITIES
     )

--- a/tests/test_fake_provider_session.py
+++ b/tests/test_fake_provider_session.py
@@ -95,6 +95,52 @@ class Capture:
         self.finished = True
 
 
+class HostExecutionAttachment:
+    def __init__(self, *, block=False):
+        self.definitions = [
+            {
+                "name": "host_tool",
+                "description": "Run the canonical host tool.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"value": {"type": "integer"}},
+                },
+            }
+        ]
+        self.minted = []
+        self.executions = []
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.block = block
+        self.closed = False
+
+    def tool_definitions(self):
+        return self.definitions
+
+    def mint_tool_call_permit(self, **kwargs):
+        permit = object()
+        self.minted.append((kwargs, permit))
+        return permit
+
+    async def execute_tool_batch(self, permits):
+        self.executions.append(permits)
+        self.started.set()
+        if self.block:
+            await self.release.wait()
+        call_ids = [entry[0]["call_id"] for entry in self.minted]
+        return tuple(
+            {
+                "call_id": call_id,
+                "output": f"exact host output for {call_id}",
+                "receipt_id": f"receipt-{call_id}",
+            }
+            for call_id in reversed(call_ids)
+        )
+
+    def close(self):
+        self.closed = True
+
+
 @pytest.fixture(autouse=True)
 def _offline_policy(monkeypatch, tmp_path):
     Capture.instances.clear()
@@ -186,6 +232,124 @@ def test_fake_provider_ordinary_turn_preserves_audio_and_transcript_provenance()
     assert Capture.instances[0].turns == [("user", "hello"), ("assistant", "hi there")]
     assert Capture.instances[0].finished
     assert fake.closed and audio.stopped
+
+
+def test_host_attachment_tools_execute_as_one_batch_without_blocking_audio():
+    attachment = HostExecutionAttachment(block=True)
+    audio = Audio()
+    fake = FakeProviderSession(
+        [
+            rt.ResponseStarted(response_id="response-1"),
+            rt.FunctionCall(
+                response_id="response-1",
+                item_id="item-1",
+                call_id="call-1",
+                name="host_tool",
+                arguments='{"value":1}',
+            ),
+            rt.FunctionCall(
+                response_id="response-1",
+                item_id="item-2",
+                call_id="call-2",
+                name="host_tool",
+                arguments='{"value":2}',
+            ),
+            rt.ResponseFinished(response_id="response-1"),
+            rt.OutputAudio(data=b"audio-while-host-awaits", item_id="audio-1"),
+        ]
+    )
+
+    async def scenario():
+        running = asyncio.create_task(
+            talk_cli.run_talk_session(
+                audio=audio,
+                session_factory=lambda _auth: fake,
+                host_execution_attachment=attachment,
+            )
+        )
+        await asyncio.wait_for(attachment.started.wait(), 0.2)
+        for _ in range(20):
+            if audio.playback:
+                break
+            await asyncio.sleep(0)
+        assert audio.playback == [b"audio-while-host-awaits"]
+        assert not running.done()
+        attachment.release.set()
+        return await asyncio.wait_for(running, 0.5)
+
+    assert asyncio.run(scenario()) == 0
+    assert [tool.name for tool in fake.setup.tools] == ["host_tool"]
+    assert fake.setup.tools[0].parameters == attachment.definitions[0]["parameters"]
+    assert "limited legacy" not in fake.setup.instructions.lower()
+    assert "canonical hermes host tools" in fake.setup.instructions.lower()
+    assert [entry[0] for entry in attachment.minted] == [
+        {
+            "response_id": "response-1",
+            "item_id": "item-1",
+            "call_id": "call-1",
+            "batch_id": attachment.minted[0][0]["batch_id"],
+            "tool_name": "host_tool",
+            "arguments": {"value": 1},
+        },
+        {
+            "response_id": "response-1",
+            "item_id": "item-2",
+            "call_id": "call-2",
+            "batch_id": attachment.minted[0][0]["batch_id"],
+            "tool_name": "host_tool",
+            "arguments": {"value": 2},
+        },
+    ]
+    assert len(attachment.executions) == 1
+    assert attachment.executions[0] == tuple(entry[1] for entry in attachment.minted)
+    tool_batch = next(
+        batch for batch in fake.sent if any(isinstance(item, rt.SubmitToolResult) for item in batch)
+    )
+    assert tool_batch == (
+        rt.SubmitToolResult(call_id="call-1", output="exact host output for call-1"),
+        rt.SubmitToolResult(call_id="call-2", output="exact host output for call-2"),
+        rt.StartResponse(),
+    )
+    assert attachment.closed
+
+
+def test_malformed_host_tool_arguments_return_an_error_without_authority_or_effect():
+    attachment = HostExecutionAttachment()
+    fake = FakeProviderSession(
+        [
+            rt.ResponseStarted(response_id="response-1"),
+            rt.FunctionCall(
+                response_id="response-1",
+                item_id="item-1",
+                call_id="call-1",
+                name="host_tool",
+                arguments="[]",
+            ),
+            rt.ResponseFinished(response_id="response-1"),
+        ]
+    )
+
+    result, _audio = asyncio.run(
+        talk_cli.run_talk_session(
+            audio=Audio(),
+            session_factory=lambda _auth: fake,
+            host_execution_attachment=attachment,
+        )
+    ), None
+
+    assert result == 0
+    assert attachment.minted == []
+    assert attachment.executions == []
+    outputs = [
+        command
+        for batch in fake.sent
+        for command in batch
+        if isinstance(command, rt.SubmitToolResult)
+    ]
+    assert len(outputs) == 1
+    assert outputs[0].call_id == "call-1"
+    assert "valid json object" in outputs[0].output.lower()
+    assert attachment.closed
 
 
 def test_fake_provider_tools_stay_fifo_and_continue_exactly_once(monkeypatch):

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -355,6 +355,7 @@ def test_server_events_map_to_neutral_events_with_transcript_provenance():
             {
                 "type": "response.function_call_arguments.done",
                 "call_id": "call-1",
+                "item_id": "item-1",
                 "response_id": "resp-1",
                 "name": "search_memory",
                 "arguments": "{}",
@@ -386,6 +387,7 @@ def test_server_events_map_to_neutral_events_with_transcript_provenance():
     assert events[8].final is True
     assert events[9] == rt.FunctionCall(
         call_id="call-1",
+        item_id="item-1",
         response_id="resp-1",
         name="search_memory",
         arguments="{}",

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -212,6 +212,115 @@ def test_connect_configures_the_session_and_commands_map_to_openai_wire():
     assert adapter.state is rt.SessionState.CLOSED
 
 
+def test_wire_credentials_are_private_one_shot_and_cleared_on_every_terminal_path(
+    monkeypatch,
+):
+    token = "unit-test-token"
+    source = "unit-test-source"
+    descriptor = types.SimpleNamespace(client_secret="ephemeral")
+    configuration = {
+        "model": "gpt-realtime-test",
+        "voice": "cedar",
+        "instructions": "Be brief.",
+        "tools": None,
+        "automatic_response": False,
+        "session_update": {"type": "session.update", "session": {}},
+    }
+
+    def aiohttp_for(client):
+        return types.SimpleNamespace(
+            ClientSession=lambda: client,
+            WSMsgType=types.SimpleNamespace(TEXT="text", ERROR="error"),
+        )
+
+    def assert_private_and_cleared(wire):
+        assert not hasattr(wire, "auth_token")
+        assert not hasattr(wire, "auth_source")
+        assert wire._auth_token is None
+        assert wire._auth_source is None
+        snapshot = repr(vars(wire))
+        assert token not in snapshot
+        assert source not in snapshot
+
+    async def scenario():
+        minted = []
+
+        def mint_ephemeral_session(**kwargs):
+            minted.append((kwargs["auth_token"], kwargs["model"]))
+            return descriptor
+
+        monkeypatch.setattr(
+            openai_rt.talk_wire,
+            "mint_ephemeral_session",
+            mint_ephemeral_session,
+        )
+        success_client = _Client(_Socket())
+        success = openai_rt._OpenAIWireSession(
+            auth_token=token,
+            auth_source=source,
+            aiohttp_module=aiohttp_for(success_client),
+        )
+        await success.connect(**configuration)
+        assert minted == [(token, "gpt-realtime-test")]
+        assert_private_and_cleared(success)
+        with pytest.raises(openai_rt.OpenAIWireError, match="only run once"):
+            await success.connect(**configuration)
+        await success.close()
+        assert_private_and_cleared(success)
+
+        def fail_mint(**_kwargs):
+            raise RuntimeError("mint failed")
+
+        mint_failure = openai_rt._OpenAIWireSession(
+            auth_token=token,
+            auth_source=source,
+            mint_session=fail_mint,
+        )
+        with pytest.raises(RuntimeError, match="mint failed"):
+            await mint_failure.connect(**configuration)
+        assert_private_and_cleared(mint_failure)
+        with pytest.raises(openai_rt.OpenAIWireError, match="only run once"):
+            await mint_failure.connect(**configuration)
+        await mint_failure.close()
+        assert_private_and_cleared(mint_failure)
+
+        class FailingSocketContext:
+            async def __aenter__(self):
+                raise RuntimeError("socket connect failed")
+
+            async def __aexit__(self, *_exc):
+                return None
+
+        connect_client = _Client(_Socket())
+        connect_client.ws_connect = lambda *_args, **_kwargs: FailingSocketContext()
+        connect_failure = openai_rt._OpenAIWireSession(
+            auth_token=token,
+            auth_source=source,
+            aiohttp_module=aiohttp_for(connect_client),
+            mint_session=lambda **_configuration: descriptor,
+        )
+        with pytest.raises(RuntimeError, match="socket connect failed"):
+            await connect_failure.connect(**configuration)
+        assert connect_client.exited is True
+        assert_private_and_cleared(connect_failure)
+        with pytest.raises(openai_rt.OpenAIWireError, match="only run once"):
+            await connect_failure.connect(**configuration)
+        await connect_failure.close()
+        assert_private_and_cleared(connect_failure)
+
+        close_before_connect = openai_rt._OpenAIWireSession(
+            auth_token=token,
+            auth_source=source,
+            mint_session=lambda **_configuration: descriptor,
+        )
+        await close_before_connect.close()
+        assert_private_and_cleared(close_before_connect)
+        with pytest.raises(openai_rt.OpenAIWireError, match="only run once"):
+            await close_before_connect.connect(**configuration)
+
+    asyncio.run(scenario())
+
+
 def test_server_events_map_to_neutral_events_with_transcript_provenance():
     async def scenario():
         pcm = b"assistant pcm"

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -110,6 +110,53 @@ def _adapter(socket):
     return adapter, client
 
 
+def test_core_response_builder_is_exact_and_does_not_change_legacy_encoding():
+    response = openai_rt.build_core_response_create(
+        canonical_text="Exact words, exactly.",
+        correlation="opaque-correlation",
+        voice="cedar",
+        event_id="evt-opaque",
+    )
+
+    assert response == {
+        "type": "response.create",
+        "event_id": "evt-opaque",
+        "response": {
+            "conversation": "none",
+            "metadata": {"correlation": "opaque-correlation"},
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "Exact words, exactly."}
+                    ],
+                }
+            ],
+            "instructions": (
+                "Render the sole user input as speech verbatim. Speak every character's "
+                "words and punctuation naturally, but add, remove, or paraphrase nothing. "
+                "Do not preface or explain."
+            ),
+            "output_modalities": ["audio"],
+            "audio": {
+                "output": {
+                    "voice": "cedar",
+                    "format": {"type": "audio/pcm", "rate": 24000},
+                }
+            },
+            "tools": [],
+            "tool_choice": "none",
+        },
+    }
+    assert openai_rt.encode_command(
+        rt.StartResponse(metadata={"speaker": "opaque"})
+    ) == {
+        "type": "response.create",
+        "response": {"metadata": {"speaker": "opaque"}},
+    }
+
+
 def test_connect_configures_the_session_and_commands_map_to_openai_wire():
     async def scenario():
         socket = _Socket()

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -157,6 +157,17 @@ def test_core_response_builder_is_exact_and_does_not_change_legacy_encoding():
     }
 
 
+def test_core_response_cancel_builder_is_exact_and_legacy_cancel_is_unchanged():
+    assert openai_rt.build_core_response_cancel(
+        response_id="resp-exact", event_id="evt-unpredictable"
+    ) == {
+        "type": "response.cancel",
+        "event_id": "evt-unpredictable",
+        "response_id": "resp-exact",
+    }
+    assert openai_rt.encode_command(rt.CancelResponse()) == {"type": "response.cancel"}
+
+
 def test_connect_configures_the_session_and_commands_map_to_openai_wire():
     async def scenario():
         socket = _Socket()

--- a/tests/test_realtime_contract.py
+++ b/tests/test_realtime_contract.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import inspect
+import json
+import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
@@ -154,3 +157,115 @@ def test_realtime_contract_and_openai_adapter_are_shipped_modules():
     assert "talk_realtime" in shipped
     assert "talk_openai_realtime" in shipped
     assert "talk_core_realtime" in shipped
+
+
+_CORE_SHIM_PROBE = r'''
+import enum
+import json
+import sys
+import types
+
+module = types.ModuleType("agent.realtime_voice_provider")
+module.REALTIME_VOICE_PROVIDER_API_VERSION = 2
+
+class Capability(enum.Enum):
+    INPUT_TRANSCRIPTION = "input_transcription"
+    INPUT_COMMIT_EVENTS = "input_commit_events"
+    EXPLICIT_RESPONSE = "explicit_response"
+    RESPONSE_CANCELLATION = "response_cancellation"
+
+class Role(enum.Enum):
+    OPERATOR = "operator"
+
+class Provenance(enum.Enum):
+    OPERATOR_INPUT = "operator_input"
+
+class Session:
+    def __init__(self, capabilities): self.capabilities = capabilities; self._closed = False
+    async def close(self): self._closed = True; await self._close()
+    async def commit_audio(self): await self._commit_audio()
+
+class Provider: pass
+class Setup: pass
+class Audio:
+    def __init__(self, mime_type, sample_rate_hz, channels, *args, **kwargs):
+        self.mime_type, self.sample_rate_hz, self.channels = mime_type, sample_rate_hz, channels
+
+for name, value in {
+    "RealtimeCapability": Capability,
+    "TranscriptRole": Role,
+    "TranscriptProvenance": Provenance,
+    "RealtimeVoiceSession": Session,
+    "RealtimeVoiceProvider": Provider,
+    "RealtimeVoiceSetup": Setup,
+    "RealtimeAudioFormat": Audio,
+    "SessionReady": type("SessionReady", (), {}),
+    "SessionClosed": type("SessionClosed", (), {}),
+    "SessionFailure": type("SessionFailure", (), {}),
+    "InputTranscript": type("InputTranscript", (), {}),
+}.items(): setattr(module, name, value)
+
+for name in sys.argv[1].split(",") if sys.argv[1] else ():
+    setattr(module, name, type(name, (Audio,) if name.endswith("AudioFormat") else (), {}))
+
+agent = types.ModuleType("agent")
+agent.realtime_voice_provider = module
+sys.modules["agent"] = agent
+sys.modules["agent.realtime_voice_provider"] = module
+import talk_core_realtime as core
+print(json.dumps({
+    "available": core.core_provider_available(),
+    "explicit": core._EXPLICIT_RESPONSE_SURFACE_AVAILABLE,
+    "cancellation": core._RESPONSE_CANCELLATION_SURFACE_AVAILABLE,
+    "capabilities": sorted(item.value for item in core.CORE_CAPABILITIES),
+}))
+'''
+
+
+def _probe_core_shim(symbols):
+    completed = subprocess.run(
+        [sys.executable, "-c", _CORE_SHIM_PROBE, ",".join(symbols)],
+        cwd=Path.cwd(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def test_optional_core_surfaces_are_detected_independently_and_stay_unadvertised():
+    explicit = {
+        "RealtimeInputAudioFormat",
+        "RealtimeOutputAudioFormat",
+        "RealtimeResponseRequest",
+        "ResponseStarted",
+        "OutputAudio",
+        "OutputTranscript",
+        "ResponseCompleted",
+    }
+    cancellation = {"InputSpeechStarted", "Interruption"}
+
+    baseline = _probe_core_shim(set())
+    assert baseline == {
+        "available": True,
+        "explicit": False,
+        "cancellation": False,
+        "capabilities": ["input_commit_events", "input_transcription"],
+    }
+
+    explicit_only = _probe_core_shim(explicit)
+    assert explicit_only["available"] is True
+    assert explicit_only["explicit"] is True
+    assert explicit_only["cancellation"] is False
+    assert "explicit_response" not in explicit_only["capabilities"]
+
+    partial_cancellation = _probe_core_shim(explicit | {"InputSpeechStarted"})
+    assert partial_cancellation["available"] is True
+    assert partial_cancellation["explicit"] is True
+    assert partial_cancellation["cancellation"] is False
+
+    complete = _probe_core_shim(explicit | cancellation)
+    assert complete["available"] is True
+    assert complete["explicit"] is True
+    assert complete["cancellation"] is True
+    assert "response_cancellation" not in complete["capabilities"]

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -391,12 +391,55 @@ def test_core_join_captures_and_forwards_the_exact_host_factory(plugin, monkeypa
     assert ctx.commands["talk"]["invocation_context"] is True
 
 
+def test_join_captures_and_forwards_the_exact_host_execution_attachment(plugin, monkeypatch):
+    ctx = StubCtx()
+    plugin.register(ctx)
+    handler = ctx.commands["talk"]["handler"]
+    attachment = object()
+    invocation = types.SimpleNamespace(
+        capture_realtime_execution_attachment=lambda: attachment
+    )
+    forwarded = []
+    monkeypatch.setattr(
+        plugin.talk_discord,
+        "start_session",
+        lambda *, host_execution_attachment=None: (
+            forwarded.append(host_execution_attachment) or "starting provider-owned"
+        ),
+    )
+
+    async def call_from_a_loop():
+        return handler("join", invocation=invocation)
+
+    assert asyncio.run(call_from_a_loop()) == "starting provider-owned"
+    assert forwarded == [attachment]
+
+
+def test_join_on_an_older_host_keeps_the_explicitly_limited_fallback(plugin, monkeypatch):
+    ctx = StubCtx()
+    plugin.register(ctx)
+    handler = ctx.commands["talk"]["handler"]
+    calls = []
+    monkeypatch.setattr(
+        plugin.talk_discord,
+        "start_session",
+        lambda: calls.append("legacy") or "Starting limited legacy provider-owned voice.",
+    )
+
+    async def call_from_a_loop():
+        return handler("join", invocation=types.SimpleNamespace())
+
+    reply = asyncio.run(call_from_a_loop())
+    assert calls == ["legacy"]
+    assert "limited legacy" in reply.lower()
+
+
 def test_registered_command_description_labels_legacy_and_core_parity(plugin):
     ctx = StubCtx()
     plugin.register(ctx)
 
     description = ctx.commands["talk"]["description"]
-    assert "limited legacy" in description.lower()
+    assert "provider-owned" in description.lower()
     assert "core join" in description.lower()
 
 


### PR DESCRIPTION
## Summary

Rolls the reviewed native Realtime voice stack and the Realtime→Hermes execution bridge onto current `main` after #26.

- renders host-authoritative responses as native Realtime PCM
- preserves response-local cancellation and barge-in boundaries
- captures the contextual Hermes execution attachment for `/talk join`
- projects the host-authorized tool schemas without a second registry
- batches provider function calls into one canonical Hermes execution
- returns ordered durable tool results and requests one continuation
- keeps provider audio/event processing responsive while Hermes work runs

## Publication reconciliation

This is the current live-canary implementation. It supersedes the older experimental implementations in #27 and #28 rather than merging both older variants.

The rollup tree is byte-identical to reviewed branch `feat/realtime-orchestrator-20260813` at `46a43f96f135a75ebea97eb84e8c9c23559a4d8d`; commits were replayed onto current `main` so the PR has clean ancestry after #26.

## Verification

- `991 passed, 1 skipped`
- Ruff: passed
- `compileall`: passed
- `git diff --check`: passed
- rollup tree: `f45871d43d937b0188a86016901b73635095c474`
- reviewed/live-canary branch tree: `f45871d43d937b0188a86016901b73635095c474`

## Dependency

The canonical execution attachment lives in the companion Hermes Agent branch. A clean upstream Agent PR will be prepared separately against current `NousResearch/hermes-agent/main`.

Supersedes #27 and #28.