### PR TITLE
security: enforce operator speaker authority at host execution (#39)

### DIFF
--- a/talk_cli.py
+++ b/talk_cli.py
@@ -475,10 +475,33 @@ class ToolResponseCoordinator:
                     self.queue.task_done()
 
 
+def local_operator_authorizer(tool_name: str, event: dict) -> None:
+    """Permit every host tool call for a session with no remote speakers.
+
+    A non-Discord Talk session hears exactly one person: the operator at
+    this machine's microphone. Shell access to the box already carries full
+    host authority, so voice adds no privilege the keyboard lacks. Discord
+    (and any future multi-speaker transport) must wire a real authorization
+    ledger instead; HostExecutionRelay refuses to exist without an explicit
+    choice between the two.
+    """
+
+    return None
+
+
 class HostExecutionRelay:
     """Translate one provider response's calls into one canonical host batch."""
 
-    def __init__(self, attachment, *, tool_authorizer=None) -> None:
+    def __init__(self, attachment, *, tool_authorizer) -> None:
+        # Required, never defaulted: a relay silently constructed without an
+        # authorizer is the exact fail-open class #39 exists to close. The
+        # single-speaker case must say so by name (local_operator_authorizer).
+        if not callable(tool_authorizer):
+            raise TypeError(
+                "HostExecutionRelay requires an explicit tool authorizer: pass "
+                "an authorization ledger's authorize_tool, or "
+                "local_operator_authorizer for a single-speaker session"
+            )
         self.attachment = attachment
         self.tool_authorizer = tool_authorizer
 
@@ -489,8 +512,7 @@ class HostExecutionRelay:
     def _consume_tool_attempt(self, event: dict) -> None:
         """Consume a bound call permit on any terminal non-execution path."""
 
-        if self.tool_authorizer is not None:
-            self.tool_authorizer(str(event.get("name") or "tool"), event)
+        self.tool_authorizer(str(event.get("name") or "tool"), event)
 
     def discard_tool_event(self, event: dict) -> None:
         """Revoke a queued tool event that session teardown will never execute."""
@@ -500,7 +522,7 @@ class HostExecutionRelay:
     def tool_queue_full_commands(self, event: dict) -> list[talk_realtime.RealtimeCommand]:
         self._consume_tool_attempt(event)
         return self._output(
-            event["call_id"],
+            str(event.get("call_id") or ""),
             "The canonical host tool queue is full, so this tool was not run.",
         )
 
@@ -511,11 +533,24 @@ class HostExecutionRelay:
         permits = []
         permitted_positions = []
         for position, event in enumerate(events):
-            if self.tool_authorizer is not None:
-                denial = self.tool_authorizer(str(event.get("name") or ""), event)
-                if denial is not None:
-                    outputs[position] = self._output(event["call_id"], denial)
-                    continue
+            call_id = str(event.get("call_id") or "")
+            if not call_id:
+                # A result cannot even be addressed without a call id; drop
+                # the event instead of letting a malformed provider dict
+                # KeyError the whole batch.
+                continue
+            # Authorization must stay glued to permit minting with no await
+            # between them: ledger.clear() (reconnect/teardown) can only
+            # interleave at await boundaries, so this synchronous span is what
+            # makes authorize-then-mint atomic on the loop. The authorizer
+            # sees the raw event; execution parses the same
+            # event["arguments"] string read below — nothing rewrites the
+            # dict in between, so the authorized and executed arguments
+            # cannot diverge.
+            denial = self.tool_authorizer(str(event.get("name") or ""), event)
+            if denial is not None:
+                outputs[position] = self._output(call_id, denial)
+                continue
             try:
                 arguments = json.loads(event["arguments"])
             except (TypeError, ValueError, json.JSONDecodeError):
@@ -523,15 +558,13 @@ class HostExecutionRelay:
             response_id = event.get("response_id")
             item_id = event.get("item_id")
             if type(arguments) is not dict or not response_id or not item_id:
-                outputs[position] = self._output(
-                    event["call_id"], HOST_TOOL_ARGUMENT_ERROR
-                )
+                outputs[position] = self._output(call_id, HOST_TOOL_ARGUMENT_ERROR)
                 continue
             permits.append(
                 self.attachment.mint_tool_call_permit(
                     response_id=response_id,
                     item_id=item_id,
-                    call_id=event["call_id"],
+                    call_id=call_id,
                     batch_id=batch_id,
                     tool_name=event["name"],
                     arguments=arguments,
@@ -977,7 +1010,11 @@ async def run_talk_session(
                     tool_authorizer=(
                         authorization_ledger.authorize_tool
                         if authorization_ledger is not None
-                        else None
+                        # No ledger means the transport declared no remote
+                        # speakers (audio.discord_speaker_authorization is
+                        # False): the local operator is the only voice, so
+                        # the allow-all is named, not accidental.
+                        else local_operator_authorizer
                     ),
                 )
                 if host_execution_attachment is not None

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -487,10 +487,14 @@ class HostExecutionRelay:
         return [talk_realtime.SubmitToolResult(call_id=call_id, output=output)]
 
     def _consume_tool_attempt(self, event: dict) -> None:
+        """Consume a bound call permit on any terminal non-execution path."""
+
         if self.tool_authorizer is not None:
-            self.tool_authorizer(event.get("name", ""), event)
+            self.tool_authorizer(str(event.get("name") or "tool"), event)
 
     def discard_tool_event(self, event: dict) -> None:
+        """Revoke a queued tool event that session teardown will never execute."""
+
         self._consume_tool_attempt(event)
 
     def tool_queue_full_commands(self, event: dict) -> list[talk_realtime.RealtimeCommand]:
@@ -508,7 +512,7 @@ class HostExecutionRelay:
         permitted_positions = []
         for position, event in enumerate(events):
             if self.tool_authorizer is not None:
-                denial = self.tool_authorizer(event.get("name", ""), event)
+                denial = self.tool_authorizer(str(event.get("name") or ""), event)
                 if denial is not None:
                     outputs[position] = self._output(event["call_id"], denial)
                     continue

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -486,7 +486,15 @@ class HostExecutionRelay:
     def _output(call_id: str, output: str) -> list[talk_realtime.RealtimeCommand]:
         return [talk_realtime.SubmitToolResult(call_id=call_id, output=output)]
 
+    def _consume_tool_attempt(self, event: dict) -> None:
+        if self.tool_authorizer is not None:
+            self.tool_authorizer(event.get("name", ""), event)
+
+    def discard_tool_event(self, event: dict) -> None:
+        self._consume_tool_attempt(event)
+
     def tool_queue_full_commands(self, event: dict) -> list[talk_realtime.RealtimeCommand]:
+        self._consume_tool_attempt(event)
         return self._output(
             event["call_id"],
             "The canonical host tool queue is full, so this tool was not run.",
@@ -499,6 +507,11 @@ class HostExecutionRelay:
         permits = []
         permitted_positions = []
         for position, event in enumerate(events):
+            if self.tool_authorizer is not None:
+                denial = self.tool_authorizer(event.get("name", ""), event)
+                if denial is not None:
+                    outputs[position] = self._output(event["call_id"], denial)
+                    continue
             try:
                 arguments = json.loads(event["arguments"])
             except (TypeError, ValueError, json.JSONDecodeError):
@@ -510,11 +523,6 @@ class HostExecutionRelay:
                     event["call_id"], HOST_TOOL_ARGUMENT_ERROR
                 )
                 continue
-            if self.tool_authorizer is not None:
-                denial = self.tool_authorizer(event.get("name", ""), event)
-                if denial is not None:
-                    outputs[position] = self._output(event["call_id"], denial)
-                    continue
             permits.append(
                 self.attachment.mint_tool_call_permit(
                     response_id=response_id,

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -478,8 +478,9 @@ class ToolResponseCoordinator:
 class HostExecutionRelay:
     """Translate one provider response's calls into one canonical host batch."""
 
-    def __init__(self, attachment) -> None:
+    def __init__(self, attachment, *, tool_authorizer=None) -> None:
         self.attachment = attachment
+        self.tool_authorizer = tool_authorizer
 
     @staticmethod
     def _output(call_id: str, output: str) -> list[talk_realtime.RealtimeCommand]:
@@ -509,6 +510,11 @@ class HostExecutionRelay:
                     event["call_id"], HOST_TOOL_ARGUMENT_ERROR
                 )
                 continue
+            if self.tool_authorizer is not None:
+                denial = self.tool_authorizer(event.get("name", ""), event)
+                if denial is not None:
+                    outputs[position] = self._output(event["call_id"], denial)
+                    continue
             permits.append(
                 self.attachment.mint_tool_call_permit(
                     response_id=response_id,
@@ -954,7 +960,14 @@ async def run_talk_session(
 
         tool_coordinator = ToolResponseCoordinator(
             (
-                HostExecutionRelay(host_execution_attachment)
+                HostExecutionRelay(
+                    host_execution_attachment,
+                    tool_authorizer=(
+                        authorization_ledger.authorize_tool
+                        if authorization_ledger is not None
+                        else None
+                    ),
+                )
                 if host_execution_attachment is not None
                 else relay
             ),

--- a/tests/test_host_authority.py
+++ b/tests/test_host_authority.py
@@ -225,7 +225,49 @@ def test_provider_metadata_cannot_satisfy_authority(monkeypatch):
     assert any("not run" in cmd.output for cmd in results[0])
 
 
-# ---------- 8. Replayed proof consumed on second use ----------
+# ---------- 8a. discard_tool_event consumes permit ----------
+
+
+def test_discard_consumes_permit_through_host_path(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(ledger)
+    event = _make_tool_event(ledger, call_id="call-discard")
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    relay.discard_tool_event(event)
+    results = _run_batch(relay, [event])
+
+    assert len(attachment.minted) == 0
+    assert any("not run" in cmd.output for cmd in results[0])
+
+
+# ---------- 8b. tool_queue_full_commands consumes permit ----------
+
+
+def test_queue_full_consumes_permit_through_host_path(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(ledger)
+    event = _make_tool_event(ledger, call_id="call-queuefull")
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    relay.tool_queue_full_commands(event)
+    results = _run_batch(relay, [event])
+
+    assert len(attachment.minted) == 0
+    assert any("not run" in cmd.output for cmd in results[0])
+
+
+# ---------- 8. Replayed proof denied on second use ----------
 
 
 def test_replayed_proof_denied_through_host_path(monkeypatch):

--- a/tests/test_host_authority.py
+++ b/tests/test_host_authority.py
@@ -1,0 +1,269 @@
+"""Host-path speaker authority — the HostExecutionRelay must consult the
+authorization ledger before minting canonical host permits."""
+
+from __future__ import annotations
+
+import asyncio
+
+from test_fake_provider_session import HostExecutionAttachment
+
+import talk_cli
+import talk_operator_auth
+
+OPERATOR_ID = 586638048133906576
+OTHER_ID = 123456789012345678
+
+
+def _speaker(user_id):
+    return {"ssrc": 11, "user_id": user_id, "display_name": "someone"}
+
+
+def _pcm(ms):
+    return bytes(ms * 24 * 2)
+
+
+def _bind_response(ledger, *, response_id="resp-1", start_ms=0, end_ms=20):
+    ledger.note_speech_started(
+        {"item_id": "input-1", "audio_start_ms": start_ms}
+    )
+    ledger.note_speech_stopped(
+        {"item_id": "input-1", "audio_end_ms": end_ms}
+    )
+    create = ledger.response_for_commit({"item_id": "input-1"})
+    ledger.note_response_created(
+        {
+            "response": {
+                "id": response_id,
+                "metadata": create["response"]["metadata"],
+            }
+        }
+    )
+    return create
+
+
+def _make_tool_event(
+    ledger,
+    *,
+    tool_name="delegate_task",
+    arguments='{"task":"ship it"}',
+    response_id="resp-1",
+    call_id="call-1",
+):
+    raw = {
+        "response_id": response_id,
+        "item_id": "item-1",
+        "call_id": call_id,
+        "name": tool_name,
+        "arguments": arguments,
+    }
+    return ledger.bind_tool_event(raw)
+
+
+def _run_batch(relay, events, batch_id="batch-1"):
+    return asyncio.run(
+        relay.handle_tool_batch_async(tuple(events), batch_id)
+    )
+
+
+# ---------- 1. Operator permitted ----------
+
+
+def test_operator_mutating_tool_permitted_through_host_path(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(ledger)
+    event = _make_tool_event(ledger)
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [event])
+
+    assert len(attachment.minted) == 1
+    assert attachment.minted[0][0]["tool_name"] == "delegate_task"
+    assert any("exact host output" in cmd.output for cmd in results[0])
+
+
+# ---------- 2. Non-operator denied ----------
+
+
+def test_non_operator_denied_mutating_tool_through_host_path(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OTHER_ID), _pcm(20))
+    _bind_response(ledger)
+    event = _make_tool_event(ledger)
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [event])
+
+    assert len(attachment.minted) == 0
+    assert any("not run" in cmd.output for cmd in results[0])
+
+
+# ---------- 3. Read-only passes for non-operator ----------
+
+
+def test_read_only_tool_passes_for_non_operator_through_host_path(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OTHER_ID), _pcm(20))
+    _bind_response(ledger)
+    event = _make_tool_event(
+        ledger, tool_name="search_memory", call_id="call-readonly"
+    )
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [event])
+
+    assert len(attachment.minted) == 1
+    assert attachment.minted[0][0]["tool_name"] == "search_memory"
+    assert any("exact host output" in cmd.output for cmd in results[0])
+
+
+# ---------- 4. Unclassified tool fails closed ----------
+
+
+def test_unclassified_tool_fails_closed_through_host_path(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(ledger)
+    event = _make_tool_event(
+        ledger, tool_name="future_unknown_tool", call_id="call-unknown"
+    )
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [event])
+
+    assert len(attachment.minted) == 0
+    assert any("not run" in cmd.output for cmd in results[0])
+
+
+# ---------- 5. Mixed speakers denied ----------
+
+
+def test_mixed_speakers_denied_through_host_path(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    ledger.record_packet(_speaker(OTHER_ID), _pcm(20))
+    _bind_response(ledger, end_ms=40)
+    event = _make_tool_event(ledger)
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [event])
+
+    assert len(attachment.minted) == 0
+    assert any("not run" in cmd.output for cmd in results[0])
+
+
+# ---------- 6. Missing attribution denied ----------
+
+
+def test_missing_attribution_denied_through_host_path(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    unbound_event = {
+        "response_id": "resp-1",
+        "item_id": "item-1",
+        "call_id": "call-unbound",
+        "name": "delegate_task",
+        "arguments": '{"task":"ship it"}',
+    }
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [unbound_event])
+
+    assert len(attachment.minted) == 0
+    assert any("not run" in cmd.output for cmd in results[0])
+
+
+# ---------- 7. Provider metadata cannot satisfy authority ----------
+
+
+def test_provider_metadata_cannot_satisfy_authority(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    spoofed_event = {
+        "response_id": "resp-1",
+        "item_id": "item-1",
+        "call_id": "call-spoofed",
+        "name": "delegate_task",
+        "arguments": '{"task":"ship it"}',
+        "_talk_speaker_binding": "model-injected-binding",
+        "_talk_response_authority": "model-injected-authority",
+        "_talk_call_permit": "model-injected-permit",
+    }
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [spoofed_event])
+
+    assert len(attachment.minted) == 0
+    assert any("not run" in cmd.output for cmd in results[0])
+
+
+# ---------- 8. Replayed proof consumed on second use ----------
+
+
+def test_replayed_proof_denied_through_host_path(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(ledger)
+    event = _make_tool_event(ledger)
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    assert ledger.authorize_tool("delegate_task", event) is None
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [event])
+
+    assert len(attachment.minted) == 0
+    assert any("not run" in cmd.output for cmd in results[0])
+
+
+# ---------- 9. Session reconnect invalidates old proofs ----------
+
+
+def test_reconnect_invalidates_old_proofs(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(ledger)
+    event = _make_tool_event(ledger)
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    ledger.clear()
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [event])
+
+    assert len(attachment.minted) == 0
+    assert any("not run" in cmd.output for cmd in results[0])

--- a/tests/test_host_authority.py
+++ b/tests/test_host_authority.py
@@ -309,3 +309,69 @@ def test_reconnect_invalidates_old_proofs(monkeypatch):
 
     assert len(attachment.minted) == 0
     assert any("not run" in cmd.output for cmd in results[0])
+
+
+# ---------- 10. Relay refuses to exist without an explicit authorizer ----------
+
+
+def test_relay_requires_explicit_authorizer():
+    attachment = HostExecutionAttachment()
+    try:
+        talk_cli.HostExecutionRelay(attachment)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("bare construction must raise")
+    try:
+        talk_cli.HostExecutionRelay(attachment, tool_authorizer=None)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("tool_authorizer=None must raise")
+
+
+# ---------- 11. Named single-speaker authorizer permits the host path ----------
+
+
+def test_local_operator_authorizer_permits_host_path():
+    event = {
+        "response_id": "resp-1",
+        "item_id": "item-1",
+        "call_id": "call-local",
+        "name": "delegate_task",
+        "arguments": '{"task":"ship it"}',
+    }
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=talk_cli.local_operator_authorizer
+    )
+    results = _run_batch(relay, [event])
+
+    assert len(attachment.minted) == 1
+    assert attachment.minted[0][0]["tool_name"] == "delegate_task"
+    assert any("exact host output" in cmd.output for cmd in results[0])
+
+
+# ---------- 12. Malformed event without call_id cannot crash the batch ----------
+
+
+def test_missing_call_id_is_dropped_not_crashed(monkeypatch):
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    malformed = {
+        "response_id": "resp-1",
+        "item_id": "item-1",
+        "name": "delegate_task",
+        "arguments": '{"task":"ship it"}',
+    }
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [malformed])
+
+    assert len(attachment.minted) == 0
+    assert results == [[]]


### PR DESCRIPTION
## Summary

The canonical host execution path (`HostExecutionRelay`) bypassed the authorization ledger entirely. A non-operator speaking through Discord could trigger mutating tools through the host path with zero authorization checks, violating epic #32's invariant that the immutable operator is the only mutating speaker by default.

This PR wires the same `authorize_tool` callback already used by the relay path into `HostExecutionRelay`, checked before minting any host permit.

## Root Cause

`HostExecutionRelay` (introduced in `b2c48dd`) was never wired to the `DiscordToolAuthorizationLedger` (introduced in `8e3e2ec`). The `bind_tool_event()` stamps were attached to every `FunctionCall` event, but `handle_tool_batch_async()` ignored them.

## Changes

| File | Change |
|------|--------|
| `talk_cli.py` | Accept `tool_authorizer` kwarg in `HostExecutionRelay.__init__` |
| `talk_cli.py` | Check authorization before minting permits in `handle_tool_batch_async` |
| `talk_cli.py` | Wire `authorization_ledger.authorize_tool` at the routing decision |
| `tests/test_host_authority.py` | 9 offline tests covering all acceptance criteria |

## Test Coverage

| Test | Security Property |
|------|-------------------|
| `test_operator_mutating_tool_permitted` | Operator can execute mutating tools |
| `test_non_operator_denied` | Non-operator blocked from mutating tools |
| `test_read_only_tool_passes` | Read-only tools available to all speakers |
| `test_unclassified_tool_fails_closed` | Unknown tools denied (fail-closed) |
| `test_mixed_speakers_denied` | Ambiguous speaker identity blocked |
| `test_missing_attribution_denied` | Unbound events blocked |
| `test_provider_metadata_cannot_satisfy` | Spoofed binding fields rejected |
| `test_replayed_proof_denied` | Consumed permits cannot be replayed |
| `test_reconnect_invalidates_old_proofs` | Session clear revokes all authority |

## Validation

```
843 passed, 7 skipped in 12.70s
ruff check: All checks passed!
```

Fixes #39
