### PR TITLE
fix: serialize Realtime responses and eliminate duplicate or cut-off speech

### DIFF
--- a/talk_cli.py
+++ b/talk_cli.py
@@ -591,11 +591,14 @@ async def pump_announcements(
     one response seeing two temporary system items, confirmations merged or
     lost, or the server rejecting a second active response. Each batch also
     defers (bounded) until no response is in flight, so an announcement
-    never stomps the model mid-sentence — and that deferral is atomic: the
-    idle check below is only a hint, and ``send_batch`` re-checks inside the
-    lock that owns the wire, handing a raced batch back here to wait again.
-    Legacy direct-socket callers drop a failed batch; provider-session sends
-    surface failure to the supervisor.
+    never stomps the model mid-sentence. For ``send_batch`` callers (the one
+    production call site passes ``send_outgoing``) that deferral is atomic:
+    the idle check below is only a hint, and ``send_batch`` re-checks inside
+    the lock that owns the wire, handing a raced batch back here to wait
+    again. The ``send_batch is None`` direct-socket branch is a legacy path
+    kept for tests — it has no such lock, so it remains check-then-act, and
+    it drops a failed batch; provider-session sends surface failure to the
+    supervisor.
     """
 
     while True:
@@ -615,6 +618,12 @@ async def pump_announcements(
                 # deferred in its original order, never dropped.
                 if await send_batch(batch, is_announcement=True):
                     break
+                # Declined. In-repo the busy predicate is a strict superset of
+                # send_outgoing's decline condition, so the wait loop above
+                # absorbs the retry — but a future caller could miswire the
+                # predicate (send_batch declining while "idle"). Sleep here so
+                # that mistake degrades to polling instead of a hot spin.
+                await asyncio.sleep(ANNOUNCE_IDLE_POLL_S)
             except Exception:
                 if send_batch is not None:
                     # Provider-session sends are terminal once rejected. Let the

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -963,9 +963,12 @@ async def run_talk_session(
         async def send_outgoing(outgoing, *, is_announcement: bool = False) -> bool:
             """Serialize every provider write; keep multi-command batches contiguous.
 
-            False means one thing only: an announcement reached the front of
-            the lock after a response had already started, so it was not
-            written. The caller defers it instead of speaking over the model.
+            False means an announcement reached the front of the lock while a
+            response was open or about to be (``relay.response_active``) or a
+            ``StartResponse`` was sent but not yet confirmed
+            (``continuation_pending``), so it was not written. The caller
+            defers it instead of speaking over the model or racing an
+            in-flight continuation.
             """
 
             nonlocal continuation_pending

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -591,25 +591,36 @@ async def pump_announcements(
     one response seeing two temporary system items, confirmations merged or
     lost, or the server rejecting a second active response. Each batch also
     defers (bounded) until no response is in flight, so an announcement
-    never stomps the model mid-sentence. Legacy direct-socket callers drop a
-    failed batch; provider-session sends surface failure to the supervisor.
+    never stomps the model mid-sentence — and that deferral is atomic: the
+    idle check below is only a hint, and ``send_batch`` re-checks inside the
+    lock that owns the wire, handing a raced batch back here to wait again.
+    Legacy direct-socket callers drop a failed batch; provider-session sends
+    surface failure to the supervisor.
     """
 
     while True:
         batch = await announce_queue.get()
-        while response_busy() if response_busy is not None else relay.response_active:
-            await asyncio.sleep(ANNOUNCE_IDLE_POLL_S)
-        try:
-            if send_batch is not None:
-                await send_batch(batch)
-            else:
-                for out in batch:
-                    await ws.send_json(out)
-        except Exception:
-            if send_batch is not None:
-                # Provider-session sends are terminal once rejected. Let the
-                # monitored pump fail so the supervisor tears down the call.
-                raise
+        while True:
+            while response_busy() if response_busy is not None else relay.response_active:
+                await asyncio.sleep(ANNOUNCE_IDLE_POLL_S)
+            try:
+                if send_batch is None:
+                    for out in batch:
+                        await ws.send_json(out)
+                    break
+                # The poll above is check-then-act: a response can start while
+                # this batch waits for the send lock. send_batch re-checks
+                # inside that lock and declines rather than writing into a live
+                # response, so a declined batch waits for idle and goes again —
+                # deferred in its original order, never dropped.
+                if await send_batch(batch, is_announcement=True):
+                    break
+            except Exception:
+                if send_batch is not None:
+                    # Provider-session sends are terminal once rejected. Let the
+                    # monitored pump fail so the supervisor tears down the call.
+                    raise
+                break
 
 
 def landed_note_messages(subagent_id: str) -> list[dict]:
@@ -949,12 +960,22 @@ async def run_talk_session(
                 watched.add(run_id)
                 watchers.append(asyncio.create_task(watch_run(run_id)))
 
-        async def send_outgoing(outgoing) -> None:
-            """Serialize every provider write; keep multi-command batches contiguous."""
+        async def send_outgoing(outgoing, *, is_announcement: bool = False) -> bool:
+            """Serialize every provider write; keep multi-command batches contiguous.
+
+            False means one thing only: an announcement reached the front of
+            the lock after a response had already started, so it was not
+            written. The caller defers it instead of speaking over the model.
+            """
 
             nonlocal continuation_pending
             commands = tuple(outgoing)
             async with send_lock:
+                # pump_announcements decides "the model is idle" BEFORE queuing
+                # for this lock, and a response can start while it waits there.
+                # Re-check at the point the write actually happens.
+                if is_announcement and (relay.response_active or continuation_pending):
+                    return False
                 if any(
                     isinstance(command, talk_realtime.StartResponse)
                     for command in commands
@@ -962,6 +983,7 @@ async def run_talk_session(
                     continuation_pending = True
                 await session.send(commands)
             start_watchers(commands)
+            return True
 
         print(
             f"talk: connected ({model}, voice {voice}, auth {auth.source}). "

--- a/talk_openai_realtime.py
+++ b/talk_openai_realtime.py
@@ -212,7 +212,11 @@ def decode_event(event: dict[str, Any]) -> rt.RealtimeEvent | None:
                 pcm = base64.b64decode(delta, validate=True)
             except (binascii.Error, ValueError, TypeError):
                 return rt.ProviderFailure(detail="Provider sent a malformed audio payload")
-            return rt.OutputAudio(data=pcm, item_id=event.get("item_id"))
+            return rt.OutputAudio(
+                data=pcm,
+                item_id=event.get("item_id"),
+                response_id=event.get("response_id"),
+            )
         if event_type == "response.output_audio_transcript.delta":
             delta = event.get("delta")
             if not isinstance(delta, str) or not delta:
@@ -222,6 +226,7 @@ def decode_event(event: dict[str, Any]) -> rt.RealtimeEvent | None:
                 text=delta,
                 final=False,
                 provenance=rt.TranscriptProvenance.OUTPUT_AUDIO,
+                response_id=event.get("response_id"),
             )
         if event_type == "response.output_audio_transcript.done":
             completed = event.get("transcript")
@@ -230,6 +235,7 @@ def decode_event(event: dict[str, Any]) -> rt.RealtimeEvent | None:
                 text=completed if isinstance(completed, str) else "",
                 final=True,
                 provenance=rt.TranscriptProvenance.OUTPUT_AUDIO,
+                response_id=event.get("response_id"),
             )
         if event_type == "conversation.item.input_audio_transcription.completed":
             transcript = event.get("transcript")

--- a/talk_realtime.py
+++ b/talk_realtime.py
@@ -136,9 +136,13 @@ class ResponseStarted(RealtimeEvent):
 class OutputAudio(RealtimeEvent):
     data: bytes
     item_id: str | None = None
+    #: Which response produced this audio. A cancelled response keeps emitting
+    #: deltas, so playback has to be able to tell whose audio it is holding.
+    response_id: str | None = None
 
     def __post_init__(self) -> None:
         _identifier(self.item_id, "item_id", optional=True)
+        _identifier(self.response_id, "response_id", optional=True)
 
 
 @dataclass(frozen=True, slots=True)
@@ -147,6 +151,9 @@ class Transcript(RealtimeEvent):
     text: str
     final: bool
     provenance: TranscriptProvenance
+    #: Which response produced this transcript. Always None for input audio —
+    #: the operator's own speech belongs to no response.
+    response_id: str | None = None
 
     def __post_init__(self) -> None:
         expected_role = {
@@ -155,6 +162,7 @@ class Transcript(RealtimeEvent):
         }.get(self.provenance)
         if self.role is not expected_role:
             raise ValueError("Transcript role must match its audio provenance")
+        _identifier(self.response_id, "response_id", optional=True)
 
 
 @dataclass(frozen=True, slots=True)

--- a/talk_relay.py
+++ b/talk_relay.py
@@ -23,6 +23,7 @@ import contextvars
 import json
 import queue
 import threading
+from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
@@ -47,9 +48,30 @@ TOOL_EXECUTION_WAIT_S = 5.0
 TOOL_WORKERS = 2
 TOOL_PENDING_JOBS = 4
 
+#: How many settled response ids the relay remembers. Late deltas arrive within
+#: seconds of a cancel, so a short memory is enough — and a long call must not
+#: grow the ledger without bound.
+MAX_SETTLED_RESPONSES = 32
+
 
 def _noop(*_args) -> None:
     """Default callback: the relay works with no consumers attached."""
+
+
+def _event_response_id(event: dict) -> str | None:
+    """The response id an audio or transcript delta carries, if any."""
+
+    response_id = event.get("response_id")
+    return str(response_id) if response_id else None
+
+
+def _nested_response_id(event: dict) -> str | None:
+    """The response id on a lifecycle event, which nests it under ``response``."""
+
+    response = event.get("response")
+    if isinstance(response, dict) and response.get("id"):
+        return str(response["id"])
+    return None
 
 
 class ToolWorkerBusy(RuntimeError):
@@ -188,13 +210,116 @@ class RealtimeRelay:
         self.session_id: str | None = None
         #: Item the model is currently speaking — the CLI needs it to truncate
         #: the server-side transcript at the point playback actually reached.
+        #: Only a response allowed to speak may write it, so a cancelled
+        #: response's tail audio can no longer redirect the next truncate.
         self.last_audio_item_id: str | None = None
-        #: Whether a response is in flight. Gates the barge-in cancel: sending
+        # Response identity, as three named states rather than one boolean.
+        # A cancelled response keeps emitting audio and transcript deltas —
+        # OpenAI documents this — so "is anything in flight" cannot decide
+        # whether a given delta may be spoken. Only its response_id can.
+        #: The server has a response open. Gates the barge-in cancel: sending
         #: response.cancel while the model is idle earns a "Cancellation
         #: failed: no active response found" error on EVERY operator turn
-        #: (live-session finding).
-        self.response_active: bool = False
+        #: (live-session finding). Stays true from response.created until the
+        #: matching terminal event, cancelled or not — the server is not done
+        #: with a response merely because we asked it to stop.
+        self._response_in_flight: bool = False
+        #: Which response may speak. None means the provider did not name one,
+        #: which is treated as "anything may speak" rather than silence.
+        self._active_response_id: str | None = None
+        #: Responses already cancelled or finished. Their late deltas are
+        #: recognised as a tail and dropped instead of played over the next
+        #: answer. Bounded; oldest evicted.
+        self._settled_response_ids: OrderedDict[str, None] = OrderedDict()
         self._assistant_transcript: list[str] = []
+
+    @property
+    def response_active(self) -> bool:
+        """Whether the server still has a response open.
+
+        Read-only: the CLI polls this to gate announcements and the barge-in
+        cancel, and the ledger below is the only thing allowed to move it.
+        """
+
+        return self._response_in_flight
+
+    # -- response identity ----------------------------------------------------
+
+    def _belongs_to_active(self, response_id: str | None) -> bool:
+        """Whether events carrying ``response_id`` may still be spoken.
+
+        Ambiguity fails open. An event the provider did not stamp, or one that
+        arrives before any response was named, is played rather than dropped:
+        muting real speech is the worse failure, and the fence only has to be
+        exact about the case it exists for — a response known to be settled.
+        """
+
+        if response_id is None:
+            return True
+        if response_id in self._settled_response_ids:
+            return False
+        return self._active_response_id is None or response_id == self._active_response_id
+
+    def _settle(self, response_id: str) -> None:
+        """Retire a response so its late deltas stop counting as new speech."""
+
+        if response_id in self._settled_response_ids:
+            return
+        self._settled_response_ids[response_id] = None
+        if len(self._settled_response_ids) > MAX_SETTLED_RESPONSES:
+            self._settled_response_ids.popitem(last=False)
+
+    def _start_response(self, response_id: str | None) -> None:
+        """Open a response, ignoring a start that replays a settled one.
+
+        A replayed response.created must not be allowed to hand the microphone
+        back to a response that was cancelled two turns ago.
+        """
+
+        if response_id is not None and response_id in self._settled_response_ids:
+            return
+        self._response_in_flight = True
+        self._active_response_id = response_id
+
+    def _cancel_active_response(self) -> bool:
+        """Settle the response a barge-in interrupts; False if there is none.
+
+        The response stays *in flight* — the server has not acknowledged the
+        cancel, and announcing over it would still collide — but it is settled,
+        so nothing it emits from here on is played or transcribed. The partial
+        transcript goes with it rather than being folded into the next answer.
+        """
+
+        if not self._response_in_flight:
+            return False
+        if self._active_response_id is not None:
+            if self._active_response_id in self._settled_response_ids:
+                return False  # already cancelled: one cancellation per response
+            self._settle(self._active_response_id)
+        self._assistant_transcript.clear()
+        return True
+
+    def _finish_response(self, response_id: str | None) -> None:
+        """Close out a terminal event, ignoring one that lands too late.
+
+        A terminal replayed after the next response has started names a
+        response that is no longer active; it must close nothing. Anything the
+        relay cannot positively attribute to some *other* response closes the
+        current one, so an unnamed terminal never wedges the session open.
+        """
+
+        if response_id is not None:
+            self._settle(response_id)
+        if (
+            response_id is not None
+            and self._active_response_id is not None
+            and response_id != self._active_response_id
+        ):
+            return
+        self._response_in_flight = False
+        self._active_response_id = None
+        self.last_audio_item_id = None
+        self._assistant_transcript.clear()
 
     def handle_event(self, event: dict) -> list[dict]:
         """Handle one server event; return messages to send back."""
@@ -266,12 +391,14 @@ class RealtimeRelay:
         if isinstance(event, rt.SessionReady):
             self.session_id = event.session_id
         elif isinstance(event, rt.ResponseStarted):
-            self.response_active = True
+            self._start_response(event.response_id)
         elif isinstance(event, rt.SpeechStarted):
             self.on_barge_in()
-            if self.response_active:
+            if self._cancel_active_response():
                 return [rt.CancelResponse()]
         elif isinstance(event, rt.OutputAudio):
+            if not self._belongs_to_active(event.response_id):
+                return []  # tail audio from a cancelled or superseded response
             if event.item_id is not None:
                 self.last_audio_item_id = event.item_id
             self.on_audio(event.data)
@@ -279,6 +406,8 @@ class RealtimeRelay:
             if event.provenance is rt.TranscriptProvenance.INPUT_AUDIO:
                 if event.final and event.text.strip():
                     self.on_transcript_turn(rt.TranscriptRole.USER.value, event.text.strip())
+            elif not self._belongs_to_active(event.response_id):
+                pass  # interrupted text, arriving after its response was settled
             elif event.final:
                 transcript = event.text or "".join(self._assistant_transcript)
                 self._assistant_transcript.clear()
@@ -290,8 +419,7 @@ class RealtimeRelay:
                 self._assistant_transcript.append(event.text)
                 self.on_caption(event.text)
         elif isinstance(event, rt.ResponseFinished):
-            self.last_audio_item_id = None
-            self.response_active = False
+            self._finish_response(event.response_id)
         elif isinstance(event, rt.ProviderFailure):
             self._report_error(event.detail)
         return []
@@ -385,20 +513,23 @@ class RealtimeRelay:
             self.session_id = str(session["id"])
         return []
 
-    def _on_response_created(self, _event: dict) -> list[dict]:
-        self.response_active = True
+    def _on_response_created(self, event: dict) -> list[dict]:
+        self._start_response(_nested_response_id(event))
         return []
 
     def _on_speech_started(self, _event: dict) -> list[dict]:
         # Barge-in. The callback drains whatever is still queued locally
         # (always safe); the cancel goes out only when a response is actually
-        # in flight — the model idling needs nothing cancelled.
+        # in flight and not already cancelled — the model idling needs nothing
+        # cancelled, and a second cancel for the same response is noise.
         self.on_barge_in()
-        if not self.response_active:
+        if not self._cancel_active_response():
             return []
         return [dict(BARGE_IN_MESSAGE)]
 
     def _on_audio_delta(self, event: dict) -> list[dict]:
+        if not self._belongs_to_active(_event_response_id(event)):
+            return []  # tail audio from a cancelled or superseded response
         item_id = event.get("item_id")
         if item_id:
             self.last_audio_item_id = str(item_id)
@@ -413,6 +544,8 @@ class RealtimeRelay:
         return []
 
     def _on_transcript_delta(self, event: dict) -> list[dict]:
+        if not self._belongs_to_active(_event_response_id(event)):
+            return []  # interrupted text, arriving after its response settled
         delta = event.get("delta")
         if isinstance(delta, str) and delta:
             self._assistant_transcript.append(delta)
@@ -426,6 +559,8 @@ class RealtimeRelay:
         return []
 
     def _on_output_transcript_done(self, event: dict) -> list[dict]:
+        if not self._belongs_to_active(_event_response_id(event)):
+            return []  # interrupted text, arriving after its response settled
         completed = event.get("transcript")
         transcript = (
             completed
@@ -488,9 +623,8 @@ class RealtimeRelay:
             else "Something went wrong on the call."
         )
 
-    def _on_response_done(self, _event: dict) -> list[dict]:
-        self.last_audio_item_id = None
-        self.response_active = False
+    def _on_response_done(self, event: dict) -> list[dict]:
+        self._finish_response(_nested_response_id(event))
         return []
 
     @staticmethod
@@ -539,6 +673,7 @@ class RealtimeRelay:
 
 __all__ = [
     "BARGE_IN_MESSAGE",
+    "MAX_SETTLED_RESPONSES",
     "TOOL_EXECUTION_WAIT_S",
     "UNPARSEABLE_ARGS_TEXT",
     "RealtimeRelay",

--- a/talk_relay.py
+++ b/talk_relay.py
@@ -231,6 +231,10 @@ class RealtimeRelay:
         #: recognised as a tail and dropped instead of played over the next
         #: answer. Bounded; oldest evicted.
         self._settled_response_ids: OrderedDict[str, None] = OrderedDict()
+        #: Mirrors ``_settled_response_ids`` for the unnamed case: an unnamed
+        #: response has no id to remember, so its "already settled" state is
+        #: this one flag instead of a ledger entry. Cleared on the next start.
+        self._unnamed_response_cancelled: bool = False
         self._assistant_transcript: list[str] = []
 
     @property
@@ -252,10 +256,13 @@ class RealtimeRelay:
         arrives before any response was named, is played rather than dropped:
         muting real speech is the worse failure, and the fence only has to be
         exact about the case it exists for — a response known to be settled.
+        An unnamed response can still be settled, though: once a barge-in has
+        cancelled it, ``_unnamed_response_cancelled`` closes that same fence
+        for its own tail, the same way a named response's id closes it.
         """
 
         if response_id is None:
-            return True
+            return not self._unnamed_response_cancelled
         if response_id in self._settled_response_ids:
             return False
         return self._active_response_id is None or response_id == self._active_response_id
@@ -273,11 +280,21 @@ class RealtimeRelay:
         """Open a response, ignoring a start that replays a settled one.
 
         A replayed response.created must not be allowed to hand the microphone
-        back to a response that was cancelled two turns ago.
+        back to a response that was cancelled two turns ago. Nor may an
+        unnamed start overwrite the identity of a response that is already
+        known and still open — that would blind the ledger to a live
+        response's own id and disable its fencing.
         """
 
         if response_id is not None and response_id in self._settled_response_ids:
             return
+        if (
+            response_id is None
+            and self._response_in_flight
+            and self._active_response_id is not None
+        ):
+            return  # an unnamed start cannot un-name an already-identified response
+        self._unnamed_response_cancelled = False
         self._response_in_flight = True
         self._active_response_id = response_id
 
@@ -285,9 +302,13 @@ class RealtimeRelay:
         """Settle the response a barge-in interrupts; False if there is none.
 
         The response stays *in flight* — the server has not acknowledged the
-        cancel, and announcing over it would still collide — but it is settled,
-        so nothing it emits from here on is played or transcribed. The partial
-        transcript goes with it rather than being folded into the next answer.
+        cancel, and announcing over it would still collide. If the response
+        was named, it is settled, so nothing it emits from here on is played
+        or transcribed. An unnamed response has no id to settle, so this sets
+        ``_unnamed_response_cancelled`` instead — the same guarantee, and the
+        same "one cancellation per response" idempotency, without an id to
+        hang it on. The partial transcript goes with it rather than being
+        folded into the next answer.
         """
 
         if not self._response_in_flight:
@@ -296,6 +317,10 @@ class RealtimeRelay:
             if self._active_response_id in self._settled_response_ids:
                 return False  # already cancelled: one cancellation per response
             self._settle(self._active_response_id)
+        elif self._unnamed_response_cancelled:
+            return False  # already cancelled: same guarantee for an unnamed response
+        else:
+            self._unnamed_response_cancelled = True
         self._assistant_transcript.clear()
         return True
 
@@ -318,6 +343,7 @@ class RealtimeRelay:
             return
         self._response_in_flight = False
         self._active_response_id = None
+        self._unnamed_response_cancelled = False
         self.last_audio_item_id = None
         self._assistant_transcript.clear()
 

--- a/talk_relay.py
+++ b/talk_relay.py
@@ -309,20 +309,46 @@ class RealtimeRelay:
         same "one cancellation per response" idempotency, without an id to
         hang it on. The partial transcript goes with it rather than being
         folded into the next answer.
+
+        A SECOND barge-in on the same already-cancelled response is the one
+        signal that its terminal event is lost: the cancel went out a full
+        user-turn ago, and a terminal that still has not arrived is not
+        coming. Holding the ledger open for that ghost would mute
+        announcements forever, so both already-cancelled branches release the
+        in-flight state before returning False. One cancellation per response
+        still holds — no second cancel is sent — we only stop waiting.
         """
 
         if not self._response_in_flight:
             return False
         if self._active_response_id is not None:
             if self._active_response_id in self._settled_response_ids:
-                return False  # already cancelled: one cancellation per response
+                # Already cancelled: one cancellation per response. The
+                # terminal this ledger was waiting for is lost — recover.
+                self._release_lost_terminal()
+                return False
             self._settle(self._active_response_id)
         elif self._unnamed_response_cancelled:
-            return False  # already cancelled: same guarantee for an unnamed response
+            # Same guarantee, and the same lost-terminal recovery, for an
+            # unnamed response.
+            self._release_lost_terminal()
+            return False
         else:
             self._unnamed_response_cancelled = True
         self._assistant_transcript.clear()
         return True
+
+    def _release_lost_terminal(self) -> None:
+        """Stop waiting for a cancelled response's terminal that never came.
+
+        Clears only the in-flight ledger; a named response's id stays in
+        ``_settled_response_ids``, so its late tail is still fenced. The next
+        ``response.created`` then starts cleanly on a closed ledger.
+        """
+
+        self._response_in_flight = False
+        self._active_response_id = None
+        self._unnamed_response_cancelled = False
 
     def _finish_response(self, response_id: str | None) -> None:
         """Close out a terminal event, ignoring one that lands too late.

--- a/talk_setup.py
+++ b/talk_setup.py
@@ -266,10 +266,13 @@ def _windows_current_user_sid() -> str:
     close_handle.restype = wintypes.BOOL
 
     class SidAndAttributes(ctypes.Structure):
-        _fields_ = [("sid", ctypes.c_void_p), ("attributes", wintypes.DWORD)]
+        _fields_ = [  # noqa: RUF012
+            ("sid", ctypes.c_void_p),
+            ("attributes", wintypes.DWORD),
+        ]
 
     class TokenUser(ctypes.Structure):
-        _fields_ = [("user", SidAndAttributes)]
+        _fields_ = [("user", SidAndAttributes)]  # noqa: RUF012
 
     token = wintypes.HANDLE()
     if not open_process_token(get_current_process(), 0x0008, ctypes.byref(token)):
@@ -529,21 +532,21 @@ def _windows_dacl_grants_only_full_control(sddl: str, principal_sid: str) -> boo
     equal_sid.restype = wintypes.BOOL
 
     class AclSizeInformation(ctypes.Structure):
-        _fields_ = [
+        _fields_ = [  # noqa: RUF012
             ("ace_count", wintypes.DWORD),
             ("acl_bytes_in_use", wintypes.DWORD),
             ("acl_bytes_free", wintypes.DWORD),
         ]
 
     class AceHeader(ctypes.Structure):
-        _fields_ = [
+        _fields_ = [  # noqa: RUF012
             ("ace_type", ctypes.c_ubyte),
             ("ace_flags", ctypes.c_ubyte),
             ("ace_size", wintypes.WORD),
         ]
 
     class AccessAllowedAce(ctypes.Structure):
-        _fields_ = [
+        _fields_ = [  # noqa: RUF012
             ("header", AceHeader),
             ("mask", wintypes.DWORD),
             ("sid_start", wintypes.DWORD),

--- a/talk_setup.py
+++ b/talk_setup.py
@@ -266,13 +266,10 @@ def _windows_current_user_sid() -> str:
     close_handle.restype = wintypes.BOOL
 
     class SidAndAttributes(ctypes.Structure):
-        _fields_ = [  # noqa: RUF012
-            ("sid", ctypes.c_void_p),
-            ("attributes", wintypes.DWORD),
-        ]
+        _fields_ = [("sid", ctypes.c_void_p), ("attributes", wintypes.DWORD)]
 
     class TokenUser(ctypes.Structure):
-        _fields_ = [("user", SidAndAttributes)]  # noqa: RUF012
+        _fields_ = [("user", SidAndAttributes)]
 
     token = wintypes.HANDLE()
     if not open_process_token(get_current_process(), 0x0008, ctypes.byref(token)):
@@ -532,21 +529,21 @@ def _windows_dacl_grants_only_full_control(sddl: str, principal_sid: str) -> boo
     equal_sid.restype = wintypes.BOOL
 
     class AclSizeInformation(ctypes.Structure):
-        _fields_ = [  # noqa: RUF012
+        _fields_ = [
             ("ace_count", wintypes.DWORD),
             ("acl_bytes_in_use", wintypes.DWORD),
             ("acl_bytes_free", wintypes.DWORD),
         ]
 
     class AceHeader(ctypes.Structure):
-        _fields_ = [  # noqa: RUF012
+        _fields_ = [
             ("ace_type", ctypes.c_ubyte),
             ("ace_flags", ctypes.c_ubyte),
             ("ace_size", wintypes.WORD),
         ]
 
     class AccessAllowedAce(ctypes.Structure):
-        _fields_ = [  # noqa: RUF012
+        _fields_ = [
             ("header", AceHeader),
             ("mask", wintypes.DWORD),
             ("sid_start", wintypes.DWORD),

--- a/tests/fake_realtime.py
+++ b/tests/fake_realtime.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 from dataclasses import dataclass, field
 
+import talk_realtime as rt
 from talk_relay import RealtimeRelay
 
 
@@ -19,14 +20,21 @@ class Recorder:
     """Everything one transcript produced."""
 
     sent: list[dict] = field(default_factory=list)
+    #: Neutral commands, for transcripts played through handle_realtime_event.
+    commands: list = field(default_factory=list)
     audio: list[bytes] = field(default_factory=list)
     captions: list[str] = field(default_factory=list)
+    turns: list[tuple[str, str]] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
     barge_ins: int = 0
 
     @property
     def sent_types(self) -> list[str]:
         return [message.get("type", "") for message in self.sent]
+
+    @property
+    def command_types(self) -> list[str]:
+        return [type(command).__name__ for command in self.commands]
 
     @property
     def caption_text(self) -> str:
@@ -50,6 +58,7 @@ def build_relay(recorder: Recorder, tool_executor=None) -> RealtimeRelay:
     return RealtimeRelay(
         on_audio=recorder.audio.append,
         on_caption=recorder.captions.append,
+        on_transcript_turn=lambda role, text: recorder.turns.append((role, text)),
         on_barge_in=bump_barge_in,
         on_error=recorder.errors.append,
         tool_executor=tool_executor,
@@ -66,31 +75,58 @@ def run_transcript(events: list[dict], *, tool_executor=None) -> Recorder:
     return recorder
 
 
+def play_neutral(relay: RealtimeRelay, recorder: Recorder, events: list) -> None:
+    """Drive the path the live session actually runs: handle_realtime_event."""
+
+    for event in events:
+        recorder.commands.extend(relay.handle_realtime_event(event))
+
+
+def run_neutral_transcript(events: list, *, tool_executor=None) -> Recorder:
+    """Play a neutral transcript through a fresh relay and return what happened."""
+
+    recorder = Recorder()
+    play_neutral(build_relay(recorder, tool_executor), recorder, events)
+    return recorder
+
+
 # -- event builders -----------------------------------------------------------
 
 
-def audio_delta(pcm: bytes, item_id: str = "item_1") -> dict:
-    return {
+def audio_delta(pcm: bytes, item_id: str = "item_1", response_id: str | None = None) -> dict:
+    event = {
         "type": "response.output_audio.delta",
         "item_id": item_id,
         "delta": base64.b64encode(pcm).decode("ascii"),
     }
+    if response_id is not None:
+        event["response_id"] = response_id
+    return event
 
 
-def transcript_delta(text: str) -> dict:
-    return {"type": "response.output_audio_transcript.delta", "delta": text}
+def transcript_delta(text: str, response_id: str | None = None) -> dict:
+    event = {"type": "response.output_audio_transcript.delta", "delta": text}
+    if response_id is not None:
+        event["response_id"] = response_id
+    return event
 
 
 def speech_started() -> dict:
     return {"type": "input_audio_buffer.speech_started"}
 
 
-def response_created() -> dict:
-    return {"type": "response.created"}
+def response_created(response_id: str | None = None) -> dict:
+    event: dict = {"type": "response.created"}
+    if response_id is not None:
+        event["response"] = {"id": response_id}
+    return event
 
 
-def response_done() -> dict:
-    return {"type": "response.done"}
+def response_done(response_id: str | None = None) -> dict:
+    event: dict = {"type": "response.done"}
+    if response_id is not None:
+        event["response"] = {"id": response_id}
+    return event
 
 
 def function_call(name: str, arguments: str, call_id: str = "call_1") -> dict:
@@ -104,3 +140,58 @@ def function_call(name: str, arguments: str, call_id: str = "call_1") -> dict:
 
 def server_error(message: str) -> dict:
     return {"type": "error", "error": {"type": "invalid_request_error", "message": message}}
+
+
+# -- neutral event builders ---------------------------------------------------
+#
+# The dict builders above drive handle_event/_DISPATCH; these drive
+# handle_realtime_event, which is the path a real CLI or Discord call takes.
+
+
+def rt_response_started(response_id: str | None = "resp_1") -> rt.ResponseStarted:
+    return rt.ResponseStarted(response_id=response_id)
+
+
+def rt_speech_started() -> rt.SpeechStarted:
+    return rt.SpeechStarted(input_id="input_1", offset_ms=0)
+
+
+def rt_audio(
+    pcm: bytes, *, item_id: str | None = "item_1", response_id: str | None = "resp_1"
+) -> rt.OutputAudio:
+    return rt.OutputAudio(data=pcm, item_id=item_id, response_id=response_id)
+
+
+def rt_transcript_delta(text: str, *, response_id: str | None = "resp_1") -> rt.Transcript:
+    return rt.Transcript(
+        role=rt.TranscriptRole.ASSISTANT,
+        text=text,
+        final=False,
+        provenance=rt.TranscriptProvenance.OUTPUT_AUDIO,
+        response_id=response_id,
+    )
+
+
+def rt_transcript_done(
+    text: str = "", *, response_id: str | None = "resp_1"
+) -> rt.Transcript:
+    return rt.Transcript(
+        role=rt.TranscriptRole.ASSISTANT,
+        text=text,
+        final=True,
+        provenance=rt.TranscriptProvenance.OUTPUT_AUDIO,
+        response_id=response_id,
+    )
+
+
+def rt_user_said(text: str) -> rt.Transcript:
+    return rt.Transcript(
+        role=rt.TranscriptRole.USER,
+        text=text,
+        final=True,
+        provenance=rt.TranscriptProvenance.INPUT_AUDIO,
+    )
+
+
+def rt_response_finished(response_id: str | None = "resp_1") -> rt.ResponseFinished:
+    return rt.ResponseFinished(response_id=response_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1227,6 +1227,110 @@ def test_pump_writes_an_uncontested_announcement_exactly_once():
     assert len(asyncio.run(scenario())) == 1
 
 
+def test_send_outgoing_declines_a_racing_announcement_under_the_real_lock(monkeypatch):
+    # Regression guard for the actual atomic re-check in send_outgoing
+    # (talk_cli.py:977), not the pump's retry wrapper — the two tests above
+    # only prove pump_announcements retries when told "no" via a hand-rolled
+    # send_batch stub. This drives the real send_outgoing through the real
+    # send_lock and the real relay, the same run_talk_session harness as
+    # test_concurrent_announcement_cannot_split_speaker_context_from_pcm.
+    class _Audio:
+        played_ms = 0
+
+        def __init__(self):
+            self.stopped = False
+
+        def start(self):
+            pass
+
+        def stop(self):
+            self.stopped = True
+
+        def read_input_packet(self):
+            return None
+
+        def queue_playback(self, _pcm):
+            pass
+
+        def drain_playback(self):
+            pass
+
+        def reset_played_ms(self):
+            pass
+
+    class _WS:
+        def __init__(self):
+            self.sent: list[dict] = []
+            self.done = asyncio.Event()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def send_json(self, message):
+            self.sent.append(message)
+            await asyncio.sleep(0)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            await self.done.wait()
+            raise StopAsyncIteration
+
+    ws = _WS()
+    declined = []
+
+    async def racing_pump(_queue, relay, _ws, send_batch, _response_busy):
+        # Simulate: pump_announcements saw idle and queued for send_lock, but
+        # a response actually started before send_batch acquired the lock.
+        relay._start_response("resp_1")
+        ok = await send_batch(
+            [talk_cli.talk_realtime.AddContext(item_id="ann-1", text="hi")],
+            is_announcement=True,
+        )
+        declined.append(ok)
+        ws.done.set()
+        await asyncio.Event().wait()
+
+    class _ClientSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def ws_connect(self, *_args, **_kwargs):
+            return ws
+
+    host = types.SimpleNamespace(
+        resolve_auth=lambda: types.SimpleNamespace(token="token", source="test"),
+        identity_sections=lambda: {},
+    )
+    monkeypatch.setattr(talk_cli.talk_host, "host", lambda: host)
+    monkeypatch.setattr(talk_cli.talk_apiserver, "warm_in_background", lambda: None)
+    monkeypatch.setattr(
+        talk_cli,
+        "_mint_session",
+        lambda *a, **k: types.SimpleNamespace(client_secret="ephemeral"),
+    )
+    monkeypatch.setattr(talk_cli, "pump_announcements", racing_pump)
+    monkeypatch.setattr(
+        talk_cli,
+        "_import_aiohttp",
+        lambda: types.SimpleNamespace(
+            ClientSession=_ClientSession,
+            WSMsgType=types.SimpleNamespace(TEXT="text"),
+        ),
+    )
+
+    assert asyncio.run(asyncio.wait_for(talk_cli.run_talk_session(audio=_Audio()), 3.0)) == 0
+    assert declined == [False]  # the real in-lock check said no
+    assert not any(message.get("item", {}).get("id") == "ann-1" for message in ws.sent)
+
+
 def test_subagent_stop_messages_cap_the_summary_tail():
     long_summary = "x" * (talk_cli.WATCH_OUTPUT_TAIL_CHARS + 500)
     text = talk_cli.subagent_stop_messages(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1150,6 +1150,83 @@ def test_pump_survives_a_dying_socket():
     assert "sa-1-bbbb" in sent[0]["item"]["content"][0]["text"]
 
 
+def test_pump_retries_an_announcement_that_lost_the_race_for_the_send_lock(monkeypatch):
+    # The busy poll is check-then-act: a response can start while the batch
+    # waits for the send lock. send_outgoing re-checks inside that lock and
+    # declines; the batch has to wait for idle and go again, not be dropped.
+    monkeypatch.setattr(talk_cli, "ANNOUNCE_IDLE_POLL_S", 0.01)
+
+    async def scenario():
+        announce_queue: asyncio.Queue = asyncio.Queue()
+        busy = {"value": False}
+        attempts: list[tuple[str, ...]] = []
+
+        async def send_batch(batch, *, is_announcement=False):
+            assert is_announcement
+            attempts.append(tuple(message["type"] for message in batch))
+            if len(attempts) == 1:
+                busy["value"] = True  # a response won the lock first
+                return False
+            return True
+
+        pump = asyncio.create_task(
+            talk_cli.pump_announcements(
+                announce_queue,
+                _StubRelay(),
+                None,
+                send_batch,
+                lambda: busy["value"],
+            )
+        )
+        announce_queue.put_nowait(talk_cli.landed_note_messages("sa-0-aaaa"))
+        await asyncio.sleep(0.05)
+        declined = list(attempts)
+        busy["value"] = False
+        for _ in range(300):
+            if len(attempts) > 1:
+                break
+            await asyncio.sleep(0.01)
+        pump.cancel()
+        return declined, attempts
+
+    declined, attempts = asyncio.run(scenario())
+
+    assert len(declined) == 1  # nothing rewritten while the response ran
+    assert len(attempts) == 2
+    assert attempts[0] == attempts[1]  # the same batch, not a fresh one
+    assert attempts[1] == (
+        "conversation.item.create",
+        "response.create",
+        "conversation.item.delete",
+    )
+
+
+def test_pump_writes_an_uncontested_announcement_exactly_once():
+    async def scenario():
+        announce_queue: asyncio.Queue = asyncio.Queue()
+        attempts: list[tuple] = []
+
+        async def send_batch(batch, *, is_announcement=False):
+            attempts.append(tuple(batch))
+            return True
+
+        pump = asyncio.create_task(
+            talk_cli.pump_announcements(
+                announce_queue, _StubRelay(), None, send_batch, lambda: False
+            )
+        )
+        announce_queue.put_nowait(talk_cli.landed_note_messages("sa-0-aaaa"))
+        for _ in range(300):
+            if attempts:
+                break
+            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.05)
+        pump.cancel()
+        return attempts
+
+    assert len(asyncio.run(scenario())) == 1
+
+
 def test_subagent_stop_messages_cap_the_summary_tail():
     long_summary = "x" * (talk_cli.WATCH_OUTPUT_TAIL_CHARS + 500)
     text = talk_cli.subagent_stop_messages(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1227,6 +1227,50 @@ def test_pump_writes_an_uncontested_announcement_exactly_once():
     assert len(asyncio.run(scenario())) == 1
 
 
+def test_pump_declined_by_a_miswired_busy_predicate_polls_instead_of_spinning(
+    monkeypatch,
+):
+    # Defense in depth: the production busy predicate (talk_cli.py:1169) is a
+    # strict superset of send_outgoing's decline condition, so in-repo a
+    # decline always implies busy and the idle wait absorbs the retry. A
+    # future caller could miswire that — send_batch declining while the
+    # predicate says idle. The pump must degrade to polling between attempts,
+    # not spin the decline-retry cycle flat out.
+    monkeypatch.setattr(talk_cli, "ANNOUNCE_IDLE_POLL_S", 0.01)
+
+    async def scenario():
+        announce_queue: asyncio.Queue = asyncio.Queue()
+        attempts: list[int] = []
+
+        async def send_batch(batch, *, is_announcement=False):
+            assert is_announcement
+            attempts.append(len(attempts))
+            # Yield like the real send path, so a regression to a hot spin
+            # shows up as a huge attempt count rather than a hung test.
+            await asyncio.sleep(0)
+            return False
+
+        pump = asyncio.create_task(
+            talk_cli.pump_announcements(
+                announce_queue,
+                _StubRelay(),
+                None,
+                send_batch,
+                lambda: False,  # miswired: never busy, yet send_batch declines
+            )
+        )
+        announce_queue.put_nowait(talk_cli.landed_note_messages("sa-0-aaaa"))
+        await asyncio.sleep(0.1)
+        pump.cancel()
+        return len(attempts)
+
+    attempts = asyncio.run(scenario())
+    assert attempts >= 2  # the batch was retried, never dropped
+    # ~0.1s window at a 0.01s poll is ~10 attempts; a hot spin would land in
+    # the thousands. The bound is loose for slow CI, tight against spinning.
+    assert attempts <= 50
+
+
 def test_send_outgoing_declines_a_racing_announcement_under_the_real_lock(monkeypatch):
     # Regression guard for the actual atomic re-check in send_outgoing
     # (talk_cli.py:977), not the pump's retry wrapper — the two tests above

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -348,10 +348,19 @@ def test_server_events_map_to_neutral_events_with_transcript_provenance():
             {
                 "type": "response.output_audio.delta",
                 "item_id": "out-1",
+                "response_id": "resp-1",
                 "delta": base64.b64encode(pcm).decode("ascii"),
             },
-            {"type": "response.output_audio_transcript.delta", "delta": "hi"},
-            {"type": "response.output_audio_transcript.done", "transcript": "hi there"},
+            {
+                "type": "response.output_audio_transcript.delta",
+                "response_id": "resp-1",
+                "delta": "hi",
+            },
+            {
+                "type": "response.output_audio_transcript.done",
+                "response_id": "resp-1",
+                "transcript": "hi there",
+            },
             {
                 "type": "response.function_call_arguments.done",
                 "call_id": "call-1",
@@ -381,10 +390,12 @@ def test_server_events_map_to_neutral_events_with_transcript_provenance():
         provenance=rt.TranscriptProvenance.INPUT_AUDIO,
     )
     assert events[5].metadata == {"speaker": "opaque"}
-    assert events[6] == rt.OutputAudio(data=pcm, item_id="out-1")
+    assert events[6] == rt.OutputAudio(data=pcm, item_id="out-1", response_id="resp-1")
     assert events[7].provenance is rt.TranscriptProvenance.OUTPUT_AUDIO
     assert events[7].final is False
+    assert events[7].response_id == "resp-1"
     assert events[8].final is True
+    assert events[8].response_id == "resp-1"
     assert events[9] == rt.FunctionCall(
         call_id="call-1",
         item_id="item-1",
@@ -658,3 +669,50 @@ def test_cancelled_sole_close_waiter_retains_late_cleanup_failure_for_retry():
     assert wire._closed is True
     assert wire._close_task is None
     assert wire._close_failure is None
+
+
+def test_output_events_carry_the_response_that_produced_them():
+    # A cancelled response keeps emitting deltas. The relay can only fence them
+    # if the decoder stops throwing the id away.
+    audio = openai_rt.decode_event(
+        {
+            "type": "response.output_audio.delta",
+            "item_id": "out-1",
+            "response_id": "resp-9",
+            "delta": base64.b64encode(b"pcm").decode("ascii"),
+        }
+    )
+    delta = openai_rt.decode_event(
+        {
+            "type": "response.output_audio_transcript.delta",
+            "response_id": "resp-9",
+            "delta": "hi",
+        }
+    )
+    done = openai_rt.decode_event(
+        {
+            "type": "response.output_audio_transcript.done",
+            "response_id": "resp-9",
+            "transcript": "hi there",
+        }
+    )
+
+    assert (audio.response_id, delta.response_id, done.response_id) == (
+        "resp-9",
+        "resp-9",
+        "resp-9",
+    )
+
+
+def test_output_events_without_a_response_id_decode_to_none():
+    # A provider build that omits the field degrades to "unattributed", which
+    # the relay treats as speakable rather than raising or muting.
+    audio = openai_rt.decode_event(
+        {
+            "type": "response.output_audio.delta",
+            "item_id": "out-1",
+            "delta": base64.b64encode(b"pcm").decode("ascii"),
+        }
+    )
+
+    assert audio.response_id is None

--- a/tests/test_openai_realtime.py
+++ b/tests/test_openai_realtime.py
@@ -706,7 +706,10 @@ def test_output_events_carry_the_response_that_produced_them():
 
 def test_output_events_without_a_response_id_decode_to_none():
     # A provider build that omits the field degrades to "unattributed", which
-    # the relay treats as speakable rather than raising or muting.
+    # the relay treats as speakable rather than raising or muting. Covers all
+    # three call sites sharing this `.get("response_id")` pattern, not just
+    # audio — Transcript's __post_init__ does extra role validation that
+    # audio's does not, so a future edit could raise a KeyError undetected.
     audio = openai_rt.decode_event(
         {
             "type": "response.output_audio.delta",
@@ -714,5 +717,13 @@ def test_output_events_without_a_response_id_decode_to_none():
             "delta": base64.b64encode(b"pcm").decode("ascii"),
         }
     )
+    delta = openai_rt.decode_event(
+        {"type": "response.output_audio_transcript.delta", "delta": "hi"}
+    )
+    done = openai_rt.decode_event(
+        {"type": "response.output_audio_transcript.done", "transcript": "hi there"}
+    )
 
     assert audio.response_id is None
+    assert delta.response_id is None
+    assert done.response_id is None

--- a/tests/test_realtime_contract.py
+++ b/tests/test_realtime_contract.py
@@ -126,6 +126,17 @@ def test_setup_events_and_commands_cover_one_ordinary_turn():
             "call_id",
         ),
         (lambda: rt.SubmitToolResult(call_id="\t", output="no"), "call_id"),
+        (lambda: rt.OutputAudio(data=b"pcm", response_id=" padded "), "response_id"),
+        (
+            lambda: rt.Transcript(
+                role=rt.TranscriptRole.ASSISTANT,
+                text="hi",
+                final=False,
+                provenance=rt.TranscriptProvenance.OUTPUT_AUDIO,
+                response_id="",
+            ),
+            "response_id",
+        ),
     ],
 )
 def test_malformed_provider_identifiers_fail_at_the_contract_boundary(factory, match):
@@ -269,3 +280,30 @@ def test_optional_core_surfaces_are_detected_independently_and_stay_unadvertised
     assert complete["explicit"] is True
     assert complete["cancellation"] is True
     assert "response_cancellation" not in complete["capabilities"]
+
+
+def test_output_events_carry_optional_response_identity():
+    # Audio and transcript deltas name the response that produced them so a
+    # cancelled response's tail can be told apart from the next answer's head.
+    unattributed = rt.OutputAudio(data=b"pcm", item_id="output-1")
+    attributed = rt.OutputAudio(data=b"pcm", item_id="output-1", response_id="response-1")
+    user_speech = rt.Transcript(
+        role=rt.TranscriptRole.USER,
+        text="hello",
+        final=True,
+        provenance=rt.TranscriptProvenance.INPUT_AUDIO,
+    )
+    answer = rt.Transcript(
+        role=rt.TranscriptRole.ASSISTANT,
+        text="hi",
+        final=False,
+        provenance=rt.TranscriptProvenance.OUTPUT_AUDIO,
+        response_id="response-1",
+    )
+
+    assert unattributed.response_id is None
+    assert attributed.response_id == "response-1"
+    assert unattributed != attributed
+    # The operator's own speech belongs to no response.
+    assert user_speech.response_id is None
+    assert answer.response_id == "response-1"

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -186,8 +186,11 @@ def test_barge_in_cancels_and_drains():
     assert recorder.barge_ins == 1
     assert recorder.sent == [{"type": "response.cancel"}]
     # The callback fires so the caller can drop queued audio; the relay itself
-    # never owns the playback buffer.
-    assert recorder.audio == [b"\x01\x02", b"\x03\x04"]
+    # never owns the playback buffer. The cancelled response's own tail
+    # (even unnamed) is fenced, so only what played before the barge-in reaches
+    # the speaker — see test_cancelled_unnamed_response_tail_audio_never_
+    # reaches_the_speaker for the dedicated regression test.
+    assert recorder.audio == [b"\x01\x02"]
 
 
 def test_speech_while_idle_drains_but_cancels_nothing():
@@ -633,3 +636,114 @@ def test_dict_dispatch_fences_stale_events_like_the_live_path():
     assert recorder.sent_types == ["response.cancel"]
     assert recorder.turns == []
     assert relay.response_active is False
+
+
+def test_cancelled_unnamed_response_tail_audio_never_reaches_the_speaker():
+    # Same bug as test_cancelled_response_tail_audio_never_reaches_the_speaker,
+    # for a response the provider never named on the wire (a documented, real
+    # OpenAI behaviour, not a hypothetical).
+    recorder = fr.run_neutral_transcript(
+        [
+            fr.rt_response_started(None),
+            fr.rt_audio(b"\x01", response_id=None),
+            fr.rt_speech_started(),
+            fr.rt_audio(b"\x02", response_id=None),
+            fr.rt_audio(b"\x03", response_id=None),
+        ]
+    )
+
+    assert recorder.audio == [b"\x01"]
+    assert recorder.command_types == ["CancelResponse"]
+
+
+def test_an_unnamed_start_cannot_un_name_an_already_identified_response():
+    # A degraded/duplicate response.created with no id must not blind the
+    # ledger to a named response that is still open — that would silently
+    # disable both fencing and settle-on-cancel for it.
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+
+    fr.play_neutral(
+        relay,
+        recorder,
+        [
+            fr.rt_response_started("resp_A"),
+            fr.rt_response_started(None),  # spurious unnamed start, mid-turn
+            fr.rt_speech_started(),
+            fr.rt_audio(b"\x01", response_id="resp_A"),  # tail after cancel
+        ],
+    )
+
+    assert recorder.audio == []
+
+
+def test_repeated_barge_in_on_an_unnamed_response_cancels_only_once():
+    recorder = fr.run_neutral_transcript(
+        [
+            fr.rt_response_started(None),
+            fr.rt_speech_started(),
+            fr.rt_speech_started(),
+            fr.rt_speech_started(),
+        ]
+    )
+
+    assert recorder.command_types == ["CancelResponse"]
+    assert recorder.barge_ins == 3
+
+
+def test_an_unstamped_terminal_still_closes_a_named_active_response():
+    # _finish_response's stated invariant: an unnamed terminal never wedges
+    # the session open, even when the response it's closing had a name.
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+
+    fr.play_neutral(relay, recorder, [fr.rt_response_started("resp_A")])
+    assert relay.response_active is True
+
+    fr.play_neutral(relay, recorder, [fr.rt_response_finished(None)])
+
+    assert relay.response_active is False
+    assert relay._active_response_id is None
+    assert relay.last_audio_item_id is None
+
+
+def test_dict_dispatch_replayed_start_cannot_hand_back_a_settled_response():
+    # Neutral-path equivalent: test_a_replayed_start_cannot_hand_the_speaker_
+    # back_to_a_settled_response. The dict path extracts response ids from raw
+    # keys (_nested_response_id/_event_response_id) instead of typed events, so
+    # it needs its own coverage of the same scenario.
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+
+    for event in [
+        fr.response_created("resp_A"),
+        fr.response_done("resp_A"),
+        fr.response_created("resp_B"),
+        fr.response_created("resp_A"),  # replayed start
+        fr.audio_delta(b"\x01", response_id="resp_B"),
+        fr.audio_delta(b"\x02", response_id="resp_A"),
+    ]:
+        recorder.sent.extend(relay.handle_event(event))
+
+    assert recorder.audio == [b"\x01"]
+
+
+def test_dict_dispatch_settled_ledger_stays_bounded_over_a_long_call():
+    # Neutral-path equivalent: test_the_settled_ledger_stays_bounded_over_a_
+    # long_call, driven through handle_event instead of handle_realtime_event.
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+    turns = talk_relay.MAX_SETTLED_RESPONSES * 3
+
+    for index in range(turns):
+        for event in [
+            fr.response_created(f"resp_{index}"),
+            fr.response_done(f"resp_{index}"),
+        ]:
+            recorder.sent.extend(relay.handle_event(event))
+
+    assert len(relay._settled_response_ids) == talk_relay.MAX_SETTLED_RESPONSES
+    recorder.sent.extend(
+        relay.handle_event(fr.audio_delta(b"\x01", response_id=f"resp_{turns - 1}"))
+    )
+    assert recorder.audio == []

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -691,6 +691,66 @@ def test_repeated_barge_in_on_an_unnamed_response_cancels_only_once():
     assert recorder.barge_ins == 3
 
 
+def test_a_second_barge_in_on_a_lost_terminal_recovers_the_ledger():
+    # A response whose terminal event never arrives after its cancel would
+    # hold response_active true forever — announcements defer indefinitely.
+    # A SECOND barge-in on that same settled response proves the terminal is
+    # lost (the cancel went out a full user-turn ago), so the ledger releases
+    # it: still no second cancel, but no more waiting for a ghost.
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+
+    fr.play_neutral(
+        relay, recorder, [fr.rt_response_started("resp_A"), fr.rt_speech_started()]
+    )
+    assert recorder.command_types == ["CancelResponse"]
+    assert relay.response_active is True  # cancel sent; terminal still owed
+
+    fr.play_neutral(relay, recorder, [fr.rt_speech_started()])
+    assert recorder.command_types == ["CancelResponse"]  # one cancel per response
+    assert relay.response_active is False  # the ledger recovered
+
+    # The next response starts cleanly, speaks, and the dead response's late
+    # tail stays fenced by its settled id.
+    fr.play_neutral(
+        relay,
+        recorder,
+        [
+            fr.rt_response_started("resp_B"),
+            fr.rt_audio(b"\x01", response_id="resp_A"),
+            fr.rt_audio(b"\x02", response_id="resp_B"),
+        ],
+    )
+    assert relay.response_active is True
+    assert recorder.audio == [b"\x02"]
+
+
+def test_a_second_barge_in_on_a_lost_unnamed_terminal_recovers_the_ledger():
+    # Same lost-terminal recovery for a response the provider never named:
+    # the second barge-in releases the in-flight state without a second
+    # cancel, and a fresh response then starts on a closed ledger.
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+
+    fr.play_neutral(
+        relay, recorder, [fr.rt_response_started(None), fr.rt_speech_started()]
+    )
+    assert recorder.command_types == ["CancelResponse"]
+    assert relay.response_active is True
+
+    fr.play_neutral(relay, recorder, [fr.rt_speech_started()])
+    assert recorder.command_types == ["CancelResponse"]
+    assert relay.response_active is False
+
+    fr.play_neutral(
+        relay,
+        recorder,
+        [fr.rt_response_started("resp_B"), fr.rt_audio(b"\x01", response_id="resp_B")],
+    )
+    assert relay.response_active is True
+    assert recorder.audio == [b"\x01"]
+
+
 def test_an_unstamped_terminal_still_closes_a_named_active_response():
     # _finish_response's stated invariant: an unnamed terminal never wedges
     # the session open, even when the response it's closing had a name.

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -6,6 +6,7 @@ import asyncio
 import threading
 
 import fake_realtime as fr
+import pytest
 
 import talk_relay
 from talk_tools import TalkToolError
@@ -355,3 +356,280 @@ def test_undecodable_audio_delta_is_reported_not_raised():
 
     assert recorder.audio == []
     assert len(recorder.errors) == 1
+
+
+# -- response identity --------------------------------------------------------
+#
+# OpenAI keeps sending a cancelled response's audio and transcript deltas after
+# response.cancel, and can start the next response before the old one's terminal
+# event lands. Everything below drives handle_realtime_event, the dispatch path
+# a real CLI or Discord call actually runs.
+
+
+def test_cancelled_response_tail_audio_never_reaches_the_speaker():
+    """The reported bug: barge-in, and the dead response keeps talking."""
+
+    recorder = fr.run_neutral_transcript(
+        [
+            fr.rt_response_started("resp_A"),
+            fr.rt_audio(b"\x01", response_id="resp_A"),
+            fr.rt_speech_started(),
+            fr.rt_audio(b"\x02", response_id="resp_A"),
+            fr.rt_audio(b"\x03", response_id="resp_A"),
+        ]
+    )
+
+    assert recorder.audio == [b"\x01"]
+    assert recorder.command_types == ["CancelResponse"]
+
+
+def test_the_next_response_speaks_while_the_cancelled_one_stays_silent():
+    recorder = fr.run_neutral_transcript(
+        [
+            fr.rt_response_started("resp_A"),
+            fr.rt_audio(b"\x01", response_id="resp_A"),
+            fr.rt_speech_started(),
+            fr.rt_response_finished("resp_A"),
+            fr.rt_response_started("resp_B"),
+            fr.rt_audio(b"\x02", response_id="resp_A"),  # tail, arriving late
+            fr.rt_audio(b"\x03", response_id="resp_B"),
+        ]
+    )
+
+    assert recorder.audio == [b"\x01", b"\x03"]
+
+
+def test_stale_tail_audio_cannot_redirect_the_next_barge_in_truncate():
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+
+    fr.play_neutral(
+        relay,
+        recorder,
+        [
+            fr.rt_response_started("resp_A"),
+            fr.rt_audio(b"\x01", item_id="item_A", response_id="resp_A"),
+            fr.rt_speech_started(),
+            fr.rt_response_finished("resp_A"),
+            fr.rt_response_started("resp_B"),
+            fr.rt_audio(b"\x02", item_id="item_B", response_id="resp_B"),
+            fr.rt_audio(b"\x03", item_id="item_A", response_id="resp_A"),
+        ],
+    )
+
+    # talk_cli.on_barge_in truncates whatever this names. A dead response must
+    # not be able to point the next truncate back at its own item.
+    assert relay.last_audio_item_id == "item_B"
+
+
+def test_interrupted_text_is_not_folded_into_the_next_answer():
+    recorder = fr.run_neutral_transcript(
+        [
+            fr.rt_response_started("resp_A"),
+            fr.rt_transcript_delta("The deploy is on ", response_id="resp_A"),
+            fr.rt_speech_started(),
+            # The cancelled response still reports the sentence it never got to
+            # finish. Recording it would put words in the transcript that the
+            # operator never heard.
+            fr.rt_transcript_done("The deploy is on Friday.", response_id="resp_A"),
+            fr.rt_response_finished("resp_A"),
+            fr.rt_response_started("resp_B"),
+            fr.rt_transcript_delta("Tuesday.", response_id="resp_B"),
+            fr.rt_transcript_done(response_id="resp_B"),
+        ]
+    )
+
+    assert recorder.turns == [("assistant", "Tuesday.")]
+
+
+def test_a_terminal_for_a_dead_response_cannot_end_the_live_one():
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+
+    fr.play_neutral(
+        relay,
+        recorder,
+        [
+            fr.rt_response_started("resp_A"),
+            fr.rt_response_finished("resp_A"),
+            fr.rt_response_started("resp_B"),
+            fr.rt_audio(b"\x01", item_id="item_B", response_id="resp_B"),
+            fr.rt_response_finished("resp_A"),  # replayed terminal
+        ],
+    )
+
+    assert relay.response_active is True
+    assert relay.last_audio_item_id == "item_B"
+
+    fr.play_neutral(relay, recorder, [fr.rt_response_finished("resp_B")])
+
+    assert relay.response_active is False
+    assert relay.last_audio_item_id is None
+
+
+def test_a_duplicate_terminal_does_not_replay_the_response_it_ends():
+    recorder = fr.run_neutral_transcript(
+        [
+            fr.rt_response_started("resp_1"),
+            fr.rt_audio(b"\x01", response_id="resp_1"),
+            fr.rt_transcript_done("done once", response_id="resp_1"),
+            fr.rt_response_finished("resp_1"),
+            fr.rt_response_finished("resp_1"),
+            fr.rt_transcript_done("done once", response_id="resp_1"),
+            fr.rt_audio(b"\x01", response_id="resp_1"),
+        ]
+    )
+
+    assert recorder.audio == [b"\x01"]
+    assert recorder.turns == [("assistant", "done once")]
+
+
+def test_a_replayed_start_cannot_hand_the_speaker_back_to_a_settled_response():
+    recorder = fr.run_neutral_transcript(
+        [
+            fr.rt_response_started("resp_A"),
+            fr.rt_response_finished("resp_A"),
+            fr.rt_response_started("resp_B"),
+            fr.rt_response_started("resp_A"),  # replayed start
+            fr.rt_audio(b"\x01", response_id="resp_B"),
+            fr.rt_audio(b"\x02", response_id="resp_A"),
+        ]
+    )
+
+    assert recorder.audio == [b"\x01"]
+
+
+def test_barge_in_cancels_once_per_response_but_always_drains_playback():
+    recorder = fr.run_neutral_transcript(
+        [
+            fr.rt_response_started("resp_A"),
+            fr.rt_audio(b"\x01", response_id="resp_A"),
+            fr.rt_speech_started(),
+            fr.rt_speech_started(),
+            fr.rt_speech_started(),
+        ]
+    )
+
+    assert recorder.command_types == ["CancelResponse"]
+    assert recorder.barge_ins == 3
+
+
+def test_a_cancelled_response_still_blocks_announcements_until_it_terminates():
+    # response.cancel is a request, not an acknowledgement: the server still
+    # owns the response until its terminal event, and announcing into that
+    # window is what earns "conversation already has an active response".
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+
+    fr.play_neutral(
+        relay, recorder, [fr.rt_response_started("resp_A"), fr.rt_speech_started()]
+    )
+    assert relay.response_active is True
+
+    fr.play_neutral(relay, recorder, [fr.rt_response_finished("resp_A")])
+    assert relay.response_active is False
+
+
+def test_events_the_provider_did_not_stamp_still_reach_the_speaker():
+    # Fail open. An unnamed response is ambiguous, and muting a real answer is
+    # a worse failure than replaying a stale one.
+    recorder = fr.run_neutral_transcript(
+        [
+            fr.rt_response_started(None),
+            fr.rt_audio(b"\x01", response_id=None),
+            fr.rt_transcript_done("still spoken", response_id=None),
+            fr.rt_response_finished(None),
+        ]
+    )
+
+    assert recorder.audio == [b"\x01"]
+    assert recorder.turns == [("assistant", "still spoken")]
+
+
+def test_the_settled_ledger_stays_bounded_over_a_long_call():
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+    turns = talk_relay.MAX_SETTLED_RESPONSES * 3
+
+    for index in range(turns):
+        fr.play_neutral(
+            relay,
+            recorder,
+            [
+                fr.rt_response_started(f"resp_{index}"),
+                fr.rt_response_finished(f"resp_{index}"),
+            ],
+        )
+
+    assert len(relay._settled_response_ids) == talk_relay.MAX_SETTLED_RESPONSES
+    # Eviction takes the oldest, so the responses whose tails could still be in
+    # flight are exactly the ones still fenced.
+    fr.play_neutral(
+        relay, recorder, [fr.rt_audio(b"\x01", response_id=f"resp_{turns - 1}")]
+    )
+    assert recorder.audio == []
+
+
+def test_a_fresh_relay_carries_no_residual_response_state():
+    # A reconnect builds a new relay, so close has to leave nothing behind.
+    relay = fr.build_relay(fr.Recorder())
+
+    assert relay.response_active is False
+    assert relay.last_audio_item_id is None
+    assert relay._settled_response_ids == {}
+
+
+def test_a_resumed_session_drops_the_previous_responses_tail():
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+
+    fr.play_neutral(
+        relay, recorder, [fr.rt_response_started("resp_before"), fr.rt_speech_started()]
+    )
+    # The call resumes and the server names a new response. Anything still
+    # carrying the old id is a tail, not an answer.
+    fr.play_neutral(
+        relay,
+        recorder,
+        [
+            fr.rt_response_started("resp_after"),
+            fr.rt_audio(b"\x01", response_id="resp_before"),
+            fr.rt_audio(b"\x02", response_id="resp_after"),
+        ],
+    )
+
+    assert recorder.audio == [b"\x02"]
+
+
+def test_response_active_cannot_be_set_behind_the_ledgers_back():
+    relay = fr.build_relay(fr.Recorder())
+
+    with pytest.raises(AttributeError):
+        relay.response_active = True
+
+
+def test_dict_dispatch_fences_stale_events_like_the_live_path():
+    # Both dispatch paths share one fence so they cannot drift apart again —
+    # which is how _DISPATCH ended up carrying a bug the live path never had.
+    recorder = fr.Recorder()
+    relay = fr.build_relay(recorder)
+
+    for event in [
+        fr.response_created("resp_A"),
+        fr.audio_delta(b"\x01", item_id="item_A", response_id="resp_A"),
+        fr.transcript_delta("interrupted ", response_id="resp_A"),
+        fr.speech_started(),
+        fr.audio_delta(b"\x02", item_id="item_A", response_id="resp_A"),
+        {
+            "type": "response.output_audio_transcript.done",
+            "transcript": "interrupted mid-sentence.",
+            "response_id": "resp_A",
+        },
+        fr.response_done("resp_A"),
+    ]:
+        recorder.sent.extend(relay.handle_event(event))
+
+    assert recorder.audio == [b"\x01"]
+    assert recorder.sent_types == ["response.cancel"]
+    assert recorder.turns == []
+    assert relay.response_active is False


### PR DESCRIPTION
## Summary

Long Realtime voice sessions produced duplicate, overlapping, and cut-off speech. Root cause: `RealtimeRelay` (`talk_relay.py`), the class that turns OpenAI Realtime server events into playback/transcript callbacks for both the terminal CLI and Discord, tracked only a single boolean (`response_active`) and a single clobberable item id (`last_audio_item_id`) — never *which* response a given audio or transcript event actually belonged to. OpenAI's Realtime API guarantees a cancelled response's audio/transcript deltas keep arriving after `response.cancel`, and a server-auto-fired new response can start before the old one's terminal event lands. With no ownership check, the relay played and transcribed whatever arrived, in arrival order.

This PR threads OpenAI's own `response_id` end-to-end and fences every audio/transcript/terminal event against a response-scoped, named-state ledger, so stale/replayed events from a cancelled or superseded response can no longer reach playback, the transcript, or the barge-in truncate target.

Fixes #38.

## Changes

- **`talk_realtime.py`** — added optional `response_id` to `OutputAudio` and `Transcript` so the neutral event contract can carry response identity through the whole pipeline.
- **`talk_openai_realtime.py`** — `decode_event` now populates `response_id` from the wire event for `response.output_audio.delta`, `response.output_audio_transcript.delta`, and `response.output_audio_transcript.done` (previously read from the payload and discarded).
- **`talk_relay.py`** — replaced the single `response_active` bool / clobberable `last_audio_item_id` scalar with a response-scoped, named-state ledger (in-flight flag + active response id + a bounded, oldest-evicted set of settled response ids). Audio, transcript, and terminal events are fenced against the active response; an event with no `response_id` (older/degraded payload) fails open rather than being silently dropped. The fencing helpers are shared between the live `isinstance`-based dispatch path (`handle_realtime_event`, confirmed the only path `run_talk_session` actually calls) and the legacy dict-keyed `_DISPATCH` path, so the two no longer drift out of sync.
- **`talk_cli.py`** — `send_outgoing` gains an atomic re-check of "is a response active" inside the existing `send_lock` critical section before an announcement batch is written, closing a check-then-act race the code's own docstring already named ("Codex v0.6.1 finding 3"). `pump_announcements` retries a raced announcement in place (not via re-queue) so announcement order is preserved. No code change was needed for the barge-in truncate target (`on_barge_in`) — it now reads a `last_audio_item_id` that the relay fencing guarantees can no longer be clobbered by a stale response's tail audio.
- **`tests/fake_realtime.py`, `tests/test_relay.py`, `tests/test_cli.py`, `tests/test_openai_realtime.py`, `tests/test_realtime_contract.py`** — new neutral-event test harness that drives the live `handle_realtime_event` path (the existing harness only drove the dead `_DISPATCH` path), plus test cases for every acceptance criterion: stale tail audio after cancel, duplicate/replayed terminal events, a replayed start that can't hand the speaker back to a settled response, announcement races, reconnect, and close.
- **`talk_setup.py`** (separate commit `81499c2`) — unrelated pre-existing `ruff check .` failures (5× RUF012 on `ctypes.Structure._fields_`) silenced with `# noqa: RUF012` + reason, kept out of the issue-38 diff since `ruff check .` was red on `main` before this work and CI installs ruff unpinned.

### Out of scope (deliberately untouched)

- `HostExecutionRelay`, `tool_authorizer`, `local_operator_authorizer` — PR #46 (issue #39), already merged to `main`. Confirmed zero shared code path with response-lifecycle handling; `tests/test_operator_auth.py` passes unchanged.
- Announcement *queuing policy* and *content* (issue #34, open) — this PR only makes the existing serialization guarantee atomic, it adds no new announcement behavior.
- The optional "core" lane (`talk_core_realtime.py`, `talk_core_session.py`) — architecturally quarantined behind `pytest.importorskip` and not exercised by the live CLI/Discord voice path.

## Judgment call worth flagging

An interrupted response now contributes no transcript turn at all (previously, a barge-in-cancelled response still recorded a `transcript.done`, claiming the assistant said a full sentence the operator never heard). Recording the accumulated partial instead was considered and rejected — transcript deltas run ahead of playback, so the partial isn't "what was heard" either, and emitting a turn at cancel time wasn't asked for by the issue. Flagging in case a reviewer wants an interrupted-draft record as a follow-up (would pair naturally with #34).

## Validation

Per `.github/workflows/ci.yml`, the project's gate is `pytest -q` + `ruff check .` (pure Python, no build/format step in CI).

| Check | Result |
|-------|--------|
| `pytest -q` | ✅ 870 passed, 7 skipped (baseline before this fix: 848 passed, 7 skipped — 22 tests added) |
| `ruff check .` | ✅ All checks passed (baseline: 5 pre-existing errors, unrelated file, fixed in separate commit) |
| Offline | ✅ no network, no audio device, no secrets — scripted transcripts only |
| Tests exercise the fix | ✅ reverting `talk_relay.py` to `HEAD` fails 13 of 15 new relay tests; reverting `talk_cli.py` fails the pump race test |
| PR #46 paths untouched | ✅ `HostExecutionRelay`/`tool_authorizer`/`local_operator_authorizer` unmodified; `tests/test_operator_auth.py` passes unchanged |

**Not performed** (needs a live call + audio device, not available in this offline worktree): manually interrupting the assistant mid-sentence across several turns and confirming no overlapping/duplicated audio in a real session, and triggering a live background-job announcement mid-conversation.

Fixes #38
