### PR TITLE
feat: full Hermes self-knowledge in the voice session — lane awareness, capability grounding, delegation ceiling

### DIFF
--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -199,7 +199,7 @@ def _mint(auth_token: str, voice: str):
         model=talk_config.talk_model(),
         voice=voice,
         instructions=talk_identity.build_instructions(
-            talk_host.host().identity_sections(), tools=tools
+            talk_host.host().identity_sections(), tools=tools, lane="dashboard"
         ),
         tools=tools,
     )

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -38,6 +38,7 @@ try:
         talk_apiserver,
         talk_audio,
         talk_auth,
+        talk_capabilities,
         talk_config,
         talk_doctor,
         talk_host,
@@ -59,6 +60,7 @@ except ImportError:  # pragma: no cover - flat-module fallback (Hermes file-path
     import talk_apiserver
     import talk_audio
     import talk_auth
+    import talk_capabilities
     import talk_config
     import talk_doctor
     import talk_host
@@ -939,11 +941,46 @@ def _neutral_response_command(message: dict) -> talk_realtime.StartResponse:
     )
 
 
+def _host_summary_line() -> str | None:
+    """One mint-time line about the attached host, or ``None`` when unknown.
+
+    Best-effort and NEVER blocking: it reads only the capability catalog's
+    current snapshot through :func:`talk_capabilities.status`, which never
+    waits on the network. A cold, failed, or absent catalog buys no line —
+    session start must never stall or fail for a nicety (hermes-talk#64).
+    """
+
+    try:
+        snapshot = talk_capabilities.status()
+    except Exception:  # noqa: BLE001 — a summary line is never worth a session
+        return None
+    if snapshot.source == talk_capabilities.SOURCE_NONE:
+        return None
+
+    def usable(entry: dict) -> bool:
+        # A catalog flag disqualifies only when present AND negative; an
+        # entry carrying no flag is not accused of one.
+        return not (
+            entry.get("enabled") is False
+            or entry.get("disabled") is True
+            or entry.get("installed") is False
+            or entry.get("configured") is False
+        )
+
+    skills = sum(1 for entry in snapshot.skills if usable(entry))
+    toolsets = sum(1 for entry in snapshot.toolsets if usable(entry))
+    return (
+        f"Hermes host attached: {skills} skills enabled, "
+        f"{toolsets} toolsets active."
+    )
+
+
 async def run_talk_session(
     audio: object | None = None,
     *,
     session_factory=None,
     host_execution_attachment=None,
+    lane: str = "cli",
 ) -> int:
     """Run one voice session. Returns a process exit code.
 
@@ -951,6 +988,11 @@ async def run_talk_session(
     the terminal's microphone by default, or a Discord voice channel
     (:class:`talk_discord.DiscordAudio`). Everything above this line is the
     same session either way: the same tools, ledger, and announcements.
+
+    ``lane`` names the transport for the prompt's where-am-I line. Only the
+    CLI lane composes a host summary: it is the lane whose session setup may
+    spend an in-process read, and even there a cold or failed catalog yields
+    no line rather than a stalled start.
     """
 
     hermes_home = talk_config.get_hermes_home()
@@ -980,6 +1022,8 @@ async def run_talk_session(
         talk_host.host().identity_sections(),
         tools=tools,
         host_execution=host_execution_attachment is not None,
+        lane=lane,
+        host_summary=_host_summary_line() if lane == "cli" else None,
     )
 
     # Find out NOW whether the api_server lane is up. The verdict is needed by

--- a/talk_discord.py
+++ b/talk_discord.py
@@ -1453,11 +1453,12 @@ def start_session(
         _SESSION_GENERATION += 1
         generation = _SESSION_GENERATION
         if host_execution_attachment is None:
-            session = talk_cli.run_talk_session(audio=audio)
+            session = talk_cli.run_talk_session(audio=audio, lane="discord")
         else:
             session = talk_cli.run_talk_session(
                 audio=audio,
                 host_execution_attachment=host_execution_attachment,
+                lane="discord",
             )
         task = loop.create_task(session)
         task.add_done_callback(_done)

--- a/talk_identity.py
+++ b/talk_identity.py
@@ -62,6 +62,9 @@ VOICE_PREAMBLE = (
     + ANTI_GUESS_RULE
     + "Use only the function tools explicitly listed for this session. After a tool result, answer "
     "in one to three spoken sentences; never read raw output verbatim. "
+    "When you are asked what you or Hermes can do, call the talk_capabilities "
+    "tool and answer from what it returns — never recite capabilities from "
+    "memory. "
     "Judge how much permission an action needs by what it can DAMAGE, not by "
     "how big it feels. Work that only costs tokens and lands somewhere "
     "reversible — a lookup, a draft, or a task handed to delegate_task — you start on "
@@ -77,6 +80,10 @@ VOICE_PREAMBLE = (
     "second time for that same action. That approval covers only what you "
     "just summarized, so if the target or the arguments change at all, "
     "summarize the new version and ask again. "
+    "You cannot click, type, or drive a screen yourself, but agents you "
+    "delegate to run the full Hermes toolset — files, shell, browser, "
+    "computer use, and connected apps. Never answer \"I can't\" when the "
+    "honest answer is \"I can hand that to an agent.\" "
     "When you hand work to delegate_task, the brief you write is the ONLY "
     "thing that agent ever sees. It starts fresh, with no access to this "
     "call, so never pass 'do that', 'what we just discussed', or any other "
@@ -105,6 +112,44 @@ _HOST_TRANSCRIPT_CONTRACT = (
     "a second canonical Hermes inference turn. The temporary live transcript is handed off "
     "after the call closes for durable-memory review."
 )
+
+#: The one true sentence about WHERE this session is running, per lane
+#: (hermes-talk#64). A session asked "where are you running from?" used to
+#: answer "a service in the infrastructure" because nothing in the prompt
+#: said otherwise. Each lane names its own surface and its real hang-up
+#: control; an unknown lane gets the generic line rather than an invented
+#: one. One sentence each: like everything here, it is re-billed per turn.
+LANE_LINES: dict[str, str] = {
+    "cli": (
+        "You are running as a `hermes talk` session in a terminal on the "
+        "operator's own machine — Ctrl+C in that terminal ends the call."
+    ),
+    "discord": (
+        "You are live in a Discord voice channel — `/talk leave` or the "
+        "operator leaving the channel ends the call."
+    ),
+    "dashboard": (
+        "You are live in the Hermes dashboard browser tab — the hang-up "
+        "control or closing the tab ends the call."
+    ),
+}
+
+#: What an unrecognized or absent lane ships: true on every surface, and it
+#: names no control the session cannot vouch for.
+GENERIC_LANE_LINE = (
+    "You are live on a voice call; the operator can end it from the surface "
+    "they joined on."
+)
+
+#: Cap on the mint-time host summary line. It is one line of prompt, never a
+#: section: the producer composes it, this cap is the guarantee it stays one.
+HOST_SUMMARY_CAP = 200
+
+
+def lane_line(lane: str | None) -> str:
+    """The lane sentence for one built prompt. Never falsy, never invented."""
+
+    return LANE_LINES.get(str(lane or "").strip().lower(), GENERIC_LANE_LINE)
 
 
 def _tool_contract(tools: list[dict] | None, *, host_execution: bool = False) -> str:
@@ -155,12 +200,20 @@ def build_instructions(
     *,
     tools: list[dict] | None = None,
     host_execution: bool = False,
+    lane: str | None = None,
+    host_summary: str | None = None,
 ) -> str:
     """Assemble the Realtime session prompt.
 
     ``host_sections`` is whatever the host adapter could resolve, keyed by
     uppercase section name. Unknown keys are rendered after the known ones so
     a host that grows a section does not need a change here.
+
+    ``lane`` names the transport the session was minted on ("cli", "discord",
+    "dashboard"); anything else ships the generic lane line. ``host_summary``
+    is one producer-composed line about the attached host (skill/toolset
+    counts), rendered only when provided and capped at HOST_SUMMARY_CAP —
+    ``None`` means nothing renders, never an empty line.
     """
 
     sections: list[str] = []
@@ -179,6 +232,14 @@ def build_instructions(
             header = IDENTITY_HEADERS.get(name.upper(), name.replace("_", " ").title())
             sections.append(f"{header}:\n\n{body}")
 
+    if host_summary is not None:
+        summary = host_summary.strip()[:HOST_SUMMARY_CAP]
+        if summary:
+            sections.append(summary)
+    # The lane line rides unconditionally, just ahead of the clock: it is one
+    # sentence, it depends on no host, and a session asked where it runs must
+    # answer the truth even on a lane whose prompt carries no sections at all.
+    sections.append(lane_line(lane))
     # The clock rides last and unconditionally: it is one line, it is the most
     # perishable thing in the prompt, and a session with no host sections at
     # all should still be able to say what day it is.
@@ -193,12 +254,16 @@ def build_instructions(
 __all__ = [
     "ANTI_GUESS_RULE",
     "DEFAULT_SECTION_CAP",
+    "GENERIC_LANE_LINE",
+    "HOST_SUMMARY_CAP",
     "IDENTITY_CAPS",
     "IDENTITY_HEADERS",
     "IDENTITY_ORDER",
+    "LANE_LINES",
     "VOICE_PREAMBLE",
     "advertised_tool_names",
     "build_instructions",
     "cap_section",
     "current_moment",
+    "lane_line",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,10 @@ import types
 import pytest
 
 import talk_audio
+import talk_capabilities
 import talk_cli
 import talk_host
+import talk_identity
 import talk_operator_auth
 import talk_relay
 
@@ -1558,3 +1560,107 @@ def test_cli_entry_raises_systemexit_on_failure(monkeypatch):
         assert exc.code == 1
     else:  # pragma: no cover - the assertion we are here for
         raise AssertionError("nonzero session code did not raise SystemExit")
+
+
+# -- the mint-time host summary (hermes-talk#64) -------------------------------
+
+
+def _catalog_snapshot(**overrides):
+    base = {
+        "source": talk_capabilities.SOURCE_API_SERVER,
+        "skills": (),
+        "toolsets": (),
+        "capabilities": {},
+        "health": {},
+        "detail": "the Hermes api server",
+    }
+    return talk_capabilities.CatalogSnapshot(**(base | overrides))
+
+
+def test_host_summary_counts_only_usable_entries(monkeypatch):
+    monkeypatch.setattr(
+        talk_capabilities,
+        "status",
+        lambda: _catalog_snapshot(
+            skills=(
+                {"name": "web_search", "installed": True},
+                {"name": "retired", "enabled": False},
+            ),
+            toolsets=(
+                {"name": "browser", "enabled": True, "configured": True},
+                {"name": "email", "enabled": False, "configured": False},
+                {"name": "files"},  # no flags is not an accusation
+            ),
+        ),
+    )
+
+    assert talk_cli._host_summary_line() == (
+        "Hermes host attached: 1 skills enabled, 2 toolsets active."
+    )
+
+
+def test_host_summary_is_none_when_the_catalog_has_no_answer(monkeypatch):
+    monkeypatch.setattr(
+        talk_capabilities,
+        "status",
+        lambda: _catalog_snapshot(
+            source=talk_capabilities.SOURCE_NONE, detail="still checking"
+        ),
+    )
+
+    assert talk_cli._host_summary_line() is None
+
+
+def test_host_summary_swallows_a_raising_catalog(monkeypatch):
+    def boom():
+        raise RuntimeError("catalog exploded")
+
+    monkeypatch.setattr(talk_capabilities, "status", boom)
+
+    assert talk_cli._host_summary_line() is None
+
+
+def _capture_instructions(monkeypatch, tmp_path):
+    """Drive session setup far enough to mint the prompt, then fail on audio."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("TALK_VOICE", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(talk_cli.talk_transcript, "sweep_transcripts", lambda _home: None)
+    seen: dict = {}
+    real = talk_cli.talk_identity.build_instructions
+
+    def record(*args, **kwargs):
+        seen.update(kwargs)
+        seen["instructions"] = real(*args, **kwargs)
+        return seen["instructions"]
+
+    monkeypatch.setattr(talk_cli.talk_identity, "build_instructions", record)
+
+    def fail(_self):
+        raise talk_audio.TalkAudioError("no mic")
+
+    monkeypatch.setattr(talk_audio.DuplexAudio, "start", fail)
+    return seen
+
+
+def test_the_cli_lane_and_host_summary_ride_the_minted_prompt(monkeypatch, tmp_path):
+    seen = _capture_instructions(monkeypatch, tmp_path)
+
+    assert asyncio.run(talk_cli.run_talk_session()) == 1
+    assert seen["lane"] == "cli"
+    # Under pytest the catalog's REST lane is inert, so the cold cache has no
+    # answer — and no line — rather than a stalled session start.
+    assert seen["host_summary"] is None
+    assert talk_identity.LANE_LINES["cli"] in seen["instructions"]
+
+
+def test_a_caller_named_lane_buys_no_summary(monkeypatch, tmp_path):
+    """Only the CLI lane composes a host summary this slice."""
+
+    seen = _capture_instructions(monkeypatch, tmp_path)
+
+    assert asyncio.run(talk_cli.run_talk_session(lane="discord")) == 1
+    assert seen["lane"] == "discord"
+    assert seen["host_summary"] is None
+    assert talk_identity.LANE_LINES["discord"] in seen["instructions"]

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -24,6 +24,7 @@ import talk_apiserver
 import talk_capabilities
 import talk_config
 import talk_host
+import talk_identity
 import talk_runs
 import talk_tools
 import talk_vault
@@ -173,6 +174,16 @@ def test_mint_advertises_the_full_tool_surface(minted, monkeypatch):
         "talk_capabilities",
     ]
     assert minted["session"]["tool_choice"] == "auto"
+
+
+def test_mint_prompt_names_the_dashboard_lane(minted):
+    """The browser tab is this lane's room; the prompt must say so (#64)."""
+
+    call(api.create_session, FakeRequest(body={}))
+
+    instructions = minted["session"]["instructions"]
+    assert talk_identity.LANE_LINES["dashboard"] in instructions
+    assert talk_identity.LANE_LINES["cli"] not in instructions
 
 
 def test_mint_honours_a_requested_voice(minted):

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -379,7 +379,7 @@ def test_failure_receipt_falls_back_to_the_adapter_send_path(monkeypatch):
 
         adapter.send = adapter_send
 
-        async def fail_from_bridge(audio):
+        async def fail_from_bridge(audio, **_kwargs):
             audio._bridge_failure = "the Discord voice connection changed"
             return 1
 
@@ -399,7 +399,7 @@ def test_undeliverable_failure_receipt_is_preserved_for_status(monkeypatch):
         _connection, _receiver, _vc, adapter = _wired_host(monkeypatch)
         adapter._voice_text_channels = {}  # no linked text room is available
 
-        async def fail_from_bridge(audio):
+        async def fail_from_bridge(audio, **_kwargs):
             audio._bridge_failure = "the Discord voice credentials changed"
             return 1
 
@@ -425,7 +425,7 @@ def test_legacy_join_receipt_and_status_label_the_limited_lane_and_core_parity(m
         _wired_host(monkeypatch)
         gate = asyncio.Event()
 
-        async def keep_open(audio):
+        async def keep_open(audio, **_kwargs):
             await gate.wait()
             return 0
 
@@ -440,6 +440,44 @@ def test_legacy_join_receipt_and_status_label_the_limited_lane_and_core_parity(m
         assert len(receipt) < 240
         gate.set()
         await asyncio.sleep(0)
+
+    asyncio.run(scenario())
+
+
+def test_both_session_call_sites_pass_the_discord_lane(monkeypatch):
+    """The lane line is only true if every path names its own room (#64)."""
+
+    async def scenario():
+        _wired_host(monkeypatch)
+        gate = asyncio.Event()
+        seen: list[dict] = []
+
+        async def keep_open(audio, **kwargs):
+            seen.append(kwargs)
+            await gate.wait()
+            return 0
+
+        monkeypatch.setattr(talk_cli, "run_talk_session", keep_open)
+
+        # Legacy lane: no host execution attachment.
+        talk_discord.start_session(7)
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert seen[-1]["lane"] == "discord"
+        assert "host_execution_attachment" not in seen[-1]
+
+        # Let the first session finish so the slot frees for the second.
+        gate.set()
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        # Host-execution lane: the attachment passes through with the lane.
+        attachment = object()
+        talk_discord.start_session(7, host_execution_attachment=attachment)
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert seen[-1]["lane"] == "discord"
+        assert seen[-1]["host_execution_attachment"] is attachment
 
     asyncio.run(scenario())
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -64,6 +64,11 @@ def test_legacy_capability_claims_are_derived_from_the_advertised_tool_schemas()
     assert {tool["name"] for tool in tools} == set(
         talk_identity.advertised_tool_names(instructions)
     )
+    # The delegation ceiling (#64) is the one sanctioned mention of the full
+    # toolset — it belongs to DELEGATED agents, never to this session itself.
+    delegation = "agents you delegate to run the full Hermes toolset"
+    assert delegation in instructions
+    scrubbed = instructions.replace(delegation, "")
     for unavailable_claim in (
         "what is on the web",
         "state of this machine",
@@ -73,7 +78,7 @@ def test_legacy_capability_claims_are_derived_from_the_advertised_tool_schemas()
         "Discord tools",
         "full Hermes tools",
     ):
-        assert unavailable_claim not in instructions
+        assert unavailable_claim not in scrubbed
 
 
 def test_legacy_prompt_tells_the_truth_about_current_call_transcripts():
@@ -103,8 +108,9 @@ def test_sections_render_in_priority_order():
 def test_sections_are_capped_per_name():
     body = "x" * 50_000
     instructions = talk_identity.build_instructions({"WORKING": body})
-    # -1 is the clock line now; the section body is the block before it.
-    rendered = instructions.split("\n\n")[-2]
+    # The lane line and the clock trail every prompt; the section body is the
+    # block before them.
+    rendered = instructions.split("\n\n")[-3]
     assert len(rendered) == talk_identity.IDENTITY_CAPS["WORKING"]
 
 
@@ -164,3 +170,105 @@ def test_unknown_section_uses_the_default_cap():
 
 def test_cap_section_trims_whitespace():
     assert talk_identity.cap_section("PERSONA", "  be terse  ") == "be terse"
+
+
+# --- self-knowledge: lane, capability steer, delegation ceiling (issue #64) ----
+#
+# An orphaned CLI canary (the 2026-08-26 dogfood transcript) could not say
+# where it was running, recited its capabilities from memory, and flat-refused
+# computer use. The lane line and the two preamble facts ship on EVERY prompt,
+# exactly like the clock — a lane with no host sections is precisely where
+# they are needed.
+
+
+def test_each_known_lane_renders_its_exact_sentence():
+    expected = {
+        "cli": (
+            "You are running as a `hermes talk` session in a terminal on the "
+            "operator's own machine — Ctrl+C in that terminal ends the call."
+        ),
+        "discord": (
+            "You are live in a Discord voice channel — `/talk leave` or the "
+            "operator leaving the channel ends the call."
+        ),
+        "dashboard": (
+            "You are live in the Hermes dashboard browser tab — the hang-up "
+            "control or closing the tab ends the call."
+        ),
+    }
+    # The map is the contract: a renamed key must fail here, not on a call.
+    assert set(talk_identity.LANE_LINES) == set(expected)
+    for lane, sentence in expected.items():
+        instructions = talk_identity.build_instructions(None, lane=lane)
+        assert sentence in instructions
+        for other in set(expected.values()) - {sentence}:
+            assert other not in instructions
+        assert talk_identity.GENERIC_LANE_LINE not in instructions
+
+
+def test_an_unknown_or_absent_lane_never_invents_a_hangup_control():
+    for lane in (None, "", "gateway"):
+        instructions = talk_identity.build_instructions(None, lane=lane)
+        assert talk_identity.GENERIC_LANE_LINE in instructions
+        for known in talk_identity.LANE_LINES.values():
+            assert known not in instructions
+        # The generic line names no surface, so it can name no control.
+        assert "Ctrl+C" not in instructions
+        assert "/talk leave" not in instructions
+
+
+def test_lane_names_are_case_and_whitespace_insensitive():
+    assert talk_identity.lane_line(" CLI ") == talk_identity.LANE_LINES["cli"]
+
+
+def test_the_capability_steer_and_delegation_ceiling_ship_on_every_prompt():
+    """Both facts ride the preamble: the one carrier no ctx gate, pinned
+    include list, or failed scan can ever drop — including a prompt with no
+    host sections at all."""
+
+    for sections in (None, {}, {"PERSONA": "be terse"}):
+        instructions = talk_identity.build_instructions(sections)
+        assert "call the talk_capabilities tool" in instructions
+        assert "never recite capabilities from memory" in instructions
+        assert "full Hermes toolset" in instructions
+        assert "computer use" in instructions
+        assert "Never answer" in instructions
+        assert 'the honest answer is "I can hand that to an agent."' in instructions
+
+
+def test_the_clock_still_trails_and_the_lane_line_just_precedes_it():
+    built = talk_identity.build_instructions(
+        {"PERSONA": "be terse"},
+        lane="discord",
+        host_summary="Hermes host attached: 3 skills enabled, 1 toolsets active.",
+    )
+
+    assert built.strip().endswith(talk_identity.current_moment())
+    assert built.index("Hermes host attached:") < built.index(
+        talk_identity.LANE_LINES["discord"]
+    )
+    assert built.index(talk_identity.LANE_LINES["discord"]) < built.index(
+        talk_identity.current_moment()
+    )
+
+
+def test_host_summary_renders_when_provided():
+    line = "Hermes host attached: 12 skills enabled, 4 toolsets active."
+    instructions = talk_identity.build_instructions(None, host_summary=line)
+
+    assert line in instructions
+
+
+def test_host_summary_renders_nothing_when_absent_or_blank():
+    assert "Hermes host attached" not in talk_identity.build_instructions(None)
+    blank = talk_identity.build_instructions(None, host_summary="   ")
+
+    # A blank summary is no summary at all — never an empty prompt block.
+    assert blank == talk_identity.build_instructions(None)
+
+
+def test_host_summary_is_capped_at_200_chars():
+    instructions = talk_identity.build_instructions(None, host_summary="s" * 999)
+
+    assert "s" * talk_identity.HOST_SUMMARY_CAP in instructions
+    assert "s" * (talk_identity.HOST_SUMMARY_CAP + 1) not in instructions

--- a/tests/test_identity_injection.py
+++ b/tests/test_identity_injection.py
@@ -489,9 +489,9 @@ def test_an_oversized_memory_section_is_capped_in_the_prompt(_hermetic, monkeypa
     instructions = talk_identity.build_instructions(talk_host.host().identity_sections())
 
     # Measure the rendered body only — the preamble has its own "m"s, and the
-    # clock line trails every prompt.
+    # lane line and the clock trail every prompt.
     body = instructions.split(talk_identity.IDENTITY_HEADERS["MEMORY"] + ":\n\n", 1)[1]
-    body = body.split("\n\n" + talk_identity.current_moment())[0]
+    body = body.split("\n\n" + talk_identity.lane_line(None))[0]
     assert len(body) == talk_identity.IDENTITY_CAPS["MEMORY"]
 
 


### PR DESCRIPTION
Part of #32
Closes #64

## Evidence

Discovered by an accidental live dogfood (2026-08-26): an orphaned `hermes talk` CLI session — a canary that survived its wrapper kill — held a real conversation with the operator (transcript `state/talk-transcripts/dfb837dbf5bd49df9a62fdcbbef93452.jsonl`). Operator context (#36) worked; the failures were all self-knowledge. Asked where it was running, it answered "a service in the infrastructure." Asked what Hermes can do, it recited four Talk verbs from its prompt and never called `talk_capabilities` (#40). Asked for computer use, it flat-refused — "I can't control your computer, period" — when the honest answer was "I can't click directly, but I can hand that to an agent."

## Design

Three additive, token-budgeted prompt facts (Realtime instructions are re-read and re-billed on every turn, so each addition is one to three sentences):

- **Lane awareness** — `talk_identity.build_instructions` gains `lane`, mapped by `LANE_LINES` to one true sentence per transport: CLI (terminal on the operator's machine, Ctrl+C ends the call), Discord (`/talk leave` or leaving the channel), dashboard (hang-up control or closing the tab). Unknown/absent lanes get a generic line that names no invented control. The line renders unconditionally, just ahead of the clock (which stays strictly last), so it ships even on a prompt with zero host sections.
- **Capability grounding** — one preamble sentence: when asked what you or Hermes can do, call the `talk_capabilities` tool and answer from what it returns, never recite from memory.
- **Delegation ceiling** — two preamble sentences: the session cannot click, type, or drive a screen itself, but delegated agents run the full Hermes toolset (files, shell, browser, computer use, connected apps); never answer "I can't" when the honest answer is "I can hand that to an agent."
- **Mint-time host summary (fail-open)** — `build_instructions` gains `host_summary`, rendered as one line capped at 200 chars before the lane line. The CLI lane composes it from the capability catalog's cached snapshot (`talk_capabilities.status()` — never blocks, no new network calls): "Hermes host attached: N skills enabled, M toolsets active." A cold, failed, or absent catalog yields `None` and nothing renders; session start never stalls for it. Discord and dashboard pass `None` this slice.

Lane plumbing: `run_talk_session(..., lane="cli")`; both `talk_discord.start_session` call sites pass `lane="discord"` (legacy and host-execution paths); `dashboard/plugin_api.py`'s mint passes `lane="dashboard"`.

## Deliberate test updates

- `test_sections_are_capped_per_name` / `test_an_oversized_memory_section_is_capped_in_the_prompt` — the lane line now trails sections ahead of the clock; the block math is updated, clock-still-last is pinned by a new test.
- `test_legacy_capability_claims_are_derived_from_the_advertised_tool_schemas` — the anti-overclaim guard banned the substring "full Hermes tools". The delegation-ceiling sentence is the one sanctioned mention (it belongs to delegated agents, never to the session); the guard now asserts that sentence is present and applies the ban list to the prompt with it scrubbed.
- Three Discord test fakes gained `**_kwargs` because `run_talk_session` now takes `lane`.

## Test evidence

`python -m pytest -q` — **1096 passed, 7 skipped** (16 new tests: per-lane exact sentences, unknown-lane generic line with no invented controls, capability steer + delegation ceiling present on every prompt including empty-sections prompts, host summary present/absent/blank/capped-at-200, CLI producer counting and fail-open paths, both Discord call sites passing `lane="discord"`, dashboard mint carrying the dashboard lane). `python -m ruff check .` — clean.
