### PR TITLE
release: v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ named rather than smoothed.
 
 ## [Unreleased]
 
+## [0.10.1] — 2026-08-27
+
+The voice session now knows what it is and where it lives, and the plugin
+installs clean under Hermes's new security scanner.
+
+### Added
+- Full Hermes self-knowledge in the voice session (hermes-talk#64). The
+  session now carries a lane line naming its own transport — a CLI session
+  says it is a terminal on the operator's machine and that Ctrl+C hangs up;
+  Discord and dashboard sessions name their own off switches — so "where are
+  you running from?" and "how do I turn you off?" get true answers. The
+  preamble steers "what can you do?" to the live `talk_capabilities` catalog
+  instead of a recitation from memory, and states the delegation ceiling
+  plainly: no direct clicking or typing, but delegated agents run the full
+  Hermes toolset including computer use — never "I can't" when the honest
+  answer is "I can hand that to an agent." A one-line host summary (enabled
+  skill/toolset counts) rides session mint when the catalog is already warm,
+  and stays absent rather than stalling startup when it is not.
+
 ### Fixed
 - The plugin now scans `safe` under the upstream `plugin_guard` security
   scanner (NousResearch/hermes-agent, gating `hermes plugins install` since

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-talk"
-version = "0.10.0"
+version = "0.10.1"
 description = "OpenAI Realtime speech-to-speech voice for Hermes Agent: duplex talk with live tool calling."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release 0.10.1

Changelog + version bump only — no code changes.

### Contents
- **#64 self-knowledge** (PR #66) — lane awareness, capability grounding, delegation ceiling (changelog entry added here; #66 shipped without one)
- **#65 scanner-clean** (PR #67) — passes upstream plugin_guard with zero critical/high; CI gate added

### Gate
Ruff clean; full suite green on #67 CI (6/6 test jobs + scan gate).