### PR TITLE
fix: dedupe Grok cumulative input transcripts to one final per utterance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ provider-neutral session contract the OpenAI lane already speaks.
   refuses the event as unsupported, degrades to cancel-only with one logged
   receipt per session — a truncation that did not happen is never faked.
 
+### Fixed
+- Grok user transcripts no longer print duplicated: xAI's cumulative
+  input-transcription snapshots decode as non-final partials, identical
+  repeats are suppressed, and the completion event yields exactly one final
+  per input item (live smoke, 2026-08-28).
+
 ## [0.10.1] — 2026-08-27
 
 The voice session now knows what it is and where it lives, and the plugin

--- a/talk_grok_realtime.py
+++ b/talk_grok_realtime.py
@@ -39,6 +39,7 @@ import json
 import logging
 from collections.abc import Sequence
 from contextlib import AsyncExitStack
+from dataclasses import replace
 from typing import Any
 
 try:
@@ -292,9 +293,30 @@ def decode_event(event: dict[str, Any]) -> rt.RealtimeEvent | None:
                 provenance=rt.TranscriptProvenance.OUTPUT_AUDIO,
                 response_id=event.get("response_id"),
             )
+        if event_type in {
+            "conversation.item.input_audio_transcription.delta",
+            "conversation.item.input_audio_transcription.updated",
+        }:
+            # xAI's streaming input transcription is CUMULATIVE — every event
+            # repeats the full text so far, not a delta — so snapshots decode
+            # as non-final partials; the session suppresses identical repeats.
+            snapshot = event.get("delta")
+            if not isinstance(snapshot, str):
+                snapshot = event.get("transcript")
+            if not isinstance(snapshot, str) or not snapshot.strip():
+                return None
+            return rt.Transcript(
+                role=rt.TranscriptRole.USER,
+                text=snapshot.strip(),
+                final=False,
+                provenance=rt.TranscriptProvenance.INPUT_AUDIO,
+            )
         if event_type == "conversation.item.input_audio_transcription.completed":
-            # The streaming ``.updated`` sibling is a CUMULATIVE transcript,
-            # not a delta — only the final completion maps to a neutral turn.
+            # On the live wire (smoke, 2026-08-28) xAI emits this event more
+            # than once per input item — pre-commit copies are cumulative
+            # snapshots, and a final copy can repeat after the commit. The
+            # neutral "exactly one final per utterance" rule is enforced by
+            # the session's _InputTranscriptDedupe, not here.
             transcript = event.get("transcript")
             if not isinstance(transcript, str) or not transcript.strip():
                 return None
@@ -322,6 +344,57 @@ def decode_event(event: dict[str, Any]) -> rt.RealtimeEvent | None:
     except ValueError as exc:
         return _protocol_failure(exc)
     return None
+
+
+class _InputTranscriptDedupe:
+    """Per-utterance filter over xAI's cumulative input transcription stream.
+
+    Live wire behavior (smoke, 2026-08-28): xAI repeats cumulative snapshots
+    verbatim and can send ``.completed`` several times per input item, so the
+    decoded stream stutters. This filter keeps the neutral contract — live
+    non-final partials plus exactly one final per utterance:
+
+    - a new input item (``speech_started``/``committed`` with a new id)
+      resets the utterance, so two identical turns both print;
+    - a pre-commit ``.completed`` is still a cumulative snapshot, so it is
+      downgraded to a non-final partial;
+    - an identical repeat of the last emitted snapshot is suppressed;
+    - the first post-commit completion is the one final; later copies are
+      dropped. A final is never snapshot-suppressed — the relay only prints
+      finals, so suppressing one would erase the turn entirely.
+    """
+
+    def __init__(self) -> None:
+        self._item_id: str | None = None
+        self._committed = False
+        self._snapshot: str | None = None
+        self._final_emitted = False
+
+    def _reset(self) -> None:
+        self._committed = False
+        self._snapshot = None
+        self._final_emitted = False
+
+    def begin_item(self, item_id: str | None) -> None:
+        if isinstance(item_id, str) and item_id and item_id != self._item_id:
+            self._item_id = item_id
+            self._reset()
+
+    def mark_committed(self) -> None:
+        self._committed = True
+
+    def admit(self, event: rt.Transcript) -> rt.Transcript | None:
+        final = event.final and self._committed
+        if final:
+            if self._final_emitted:
+                return None
+            self._final_emitted = True
+        elif event.text == self._snapshot:
+            return None
+        self._snapshot = event.text
+        if final == event.final:
+            return event
+        return replace(event, final=False)
 
 
 class GrokWireError(RuntimeError):
@@ -523,6 +596,7 @@ class GrokRealtimeSession:
         self._terminal_emitted = False
         self._truncate_supported = True
         self._truncate_degrade_logged = False
+        self._input_dedupe = _InputTranscriptDedupe()
 
     async def connect(self, setup: rt.SessionSetup) -> None:
         if self.state is not rt.SessionState.NEW:
@@ -600,10 +674,23 @@ class GrokRealtimeSession:
             if self._observe_truncate_refusal(wire_event):
                 continue
             event = decode_event(wire_event)
-            if event is not None:
-                if isinstance(event, rt.ProviderFailure) and event.terminal:
-                    self.state = rt.SessionState.FAILED
-                return event
+            if event is None:
+                continue
+            if isinstance(event, rt.SpeechStarted):
+                self._input_dedupe.begin_item(event.input_id)
+            elif isinstance(event, rt.InputAudioCommitted):
+                self._input_dedupe.begin_item(event.input_id)
+                self._input_dedupe.mark_committed()
+            elif (
+                isinstance(event, rt.Transcript)
+                and event.provenance is rt.TranscriptProvenance.INPUT_AUDIO
+            ):
+                event = self._input_dedupe.admit(event)
+                if event is None:
+                    continue
+            if isinstance(event, rt.ProviderFailure) and event.terminal:
+                self.state = rt.SessionState.FAILED
+            return event
 
     async def close(self) -> None:
         await self._wire.close()

--- a/tests/test_grok_realtime.py
+++ b/tests/test_grok_realtime.py
@@ -372,6 +372,106 @@ def test_server_events_translate_to_neutral_events():
     assert len(events) == 12
 
 
+def test_cumulative_input_transcripts_dedupe_to_one_final_per_utterance():
+    # Live smoke against the real xAI API, 2026-08-28: one spoken utterance
+    # produced SIX final user transcripts in the terminal because xAI streams
+    # CUMULATIVE input-transcription snapshots (each repeats the full text so
+    # far, sometimes repeating an identical snapshot) and can emit the
+    # terminal ``.completed`` more than once per input item — including one
+    # last copy after ``input_audio_buffer.committed``. The neutral contract
+    # is live non-final partials plus exactly ONE final per utterance.
+    full = "Hey Grok, what is the weather in Paris right now?"
+    wire_events = [
+        {"type": "session.created", "session": {"id": "sess-1"}},
+        {
+            "type": "input_audio_buffer.speech_started",
+            "item_id": "input-1",
+            "audio_start_ms": 0,
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.updated",
+            "item_id": "input-1",
+            "transcript": "Hey Grok.",
+        },
+        # Identical repeated snapshot: suppressed, not re-emitted.
+        {
+            "type": "conversation.item.input_audio_transcription.updated",
+            "item_id": "input-1",
+            "transcript": "Hey Grok.",
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.updated",
+            "item_id": "input-1",
+            "transcript": "Hey Grok, what is the weather in",
+        },
+        # Pre-commit completions are still cumulative snapshots, not finals.
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "input-1",
+            "transcript": full,
+        },
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "input-1",
+            "transcript": full,
+        },
+        {
+            "type": "input_audio_buffer.speech_stopped",
+            "item_id": "input-1",
+            "audio_end_ms": 2400,
+        },
+        {"type": "input_audio_buffer.committed", "item_id": "input-1"},
+        # The true completion: exactly one final, after the commit.
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "input-1",
+            "transcript": full,
+        },
+        # A second post-commit copy must not print twice.
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "input-1",
+            "transcript": full,
+        },
+        # A new utterance with IDENTICAL text is a new turn, not a dupe.
+        {
+            "type": "input_audio_buffer.speech_started",
+            "item_id": "input-2",
+            "audio_start_ms": 5000,
+        },
+        {"type": "input_audio_buffer.committed", "item_id": "input-2"},
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "input-2",
+            "transcript": full,
+        },
+    ]
+
+    async def scenario():
+        adapter, _client = _adapter(_Socket(wire_events))
+        await adapter.connect(_setup())
+        events = [event async for event in adapter]
+        await adapter.close()
+        return events
+
+    events = asyncio.run(scenario())
+
+    transcripts = [
+        event
+        for event in events
+        if isinstance(event, rt.Transcript)
+        and event.provenance is rt.TranscriptProvenance.INPUT_AUDIO
+    ]
+    assert [(event.text, event.final) for event in transcripts] == [
+        ("Hey Grok.", False),
+        ("Hey Grok, what is the weather in", False),
+        (full, False),
+        (full, True),
+        (full, True),
+    ]
+    assert [event.text for event in transcripts if event.final] == [full, full]
+
+
 def test_session_updated_echo_is_a_receipt_not_authority():
     # The normalized echo carries turn_detection/tools at the session root and
     # may omit the id; it is never parsed for authority and never fails.


### PR DESCRIPTION
## Problem

xAI emits `conversation.item.input_audio_transcription.completed` multiple times per input item (pre-commit cumulative copies + a post-commit copy), plus `.updated`/\.delta` siblings repeating identical cumulative snapshots. The Grok decoder mapped every copy to `Transcript(user, final=True)`, and the relay prints every final input transcript — one spoken sentence printed up to 6 times in the terminal.

## Fix (`talk_grok_realtime.py` only)

- `.delta`/`.updated` decode as non-final partials.
- New `_InputTranscriptDedupe`: resets per input item, downgrades pre-commit `.completed` to partials, suppresses identical repeated snapshots, admits exactly one post-commit final per utterance.
- Relay untouched — it already ignores non-final user partials.

## Evidence

- New test replays the live-smoke timeline (incl. a second utterance with identical text proving per-item reset): **fails before** (4 finals, 0 partials), **passes after**.
- `tests/test_grok_realtime.py` 24/24. Suite: 1126 passed + 1 pre-existing Windows process-claiming flake (fails identically on pristine base; unrelated).
- Ruff clean.