### PR TITLE
release: hermes-talk 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ but 0.4.0's release title named only the steering verb. They are recorded
 below under 0.4.0 — the first version that shipped them — with the gap
 named rather than smoothed.
 
-## 0.11.0 (Unreleased)
+## [0.11.0] — 2026-08-28
 
 A second realtime voice provider: Grok (xAI), behind the same
 provider-neutral session contract the OpenAI lane already speaks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-talk"
-version = "0.10.1"
+version = "0.11.0"
 description = "OpenAI Realtime speech-to-speech voice for Hermes Agent: duplex talk with live tool calling."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release 0.11.0: Grok (xAI) realtime voice provider (#70) + Grok input-transcript dedupe fix (#71).

- pyproject 0.10.1 -> 0.11.0
- CHANGELOG section finalized with date

On merge: tag v0.11.0 triggers publish.yml (OIDC -> PyPI).