### PR TITLE
release: hermes-talk 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ but 0.4.0's release title named only the steering verb. They are recorded
 below under 0.4.0 — the first version that shipped them — with the gap
 named rather than smoothed.
 
-## 0.12.0 (Unreleased)
+## [0.12.0] — 2026-08-28
 
 A third realtime voice provider: Gemini Live (Google) — the zero-cost lane,
 free-tier AI Studio keys included — behind the same provider-neutral session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "hermes-talk"
-version = "0.11.0"
-description = "OpenAI Realtime speech-to-speech voice for Hermes Agent: duplex talk with live tool calling."
+version = "0.12.0"
+description = "Realtime speech-to-speech voice for Hermes Agent — OpenAI, xAI Grok, or Gemini Live — duplex talk with live tool calling."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }


### PR DESCRIPTION
Release 0.12.0: Gemini Live provider (#73).

- pyproject 0.11.0 -> 0.12.0
- pyproject description now names all three providers (it still said OpenAI-only)
- CHANGELOG finalized with date

On merge: tag v0.12.0 triggers publish.yml (OIDC -> PyPI).