### PR TITLE
release: hermes-talk 0.13.0

### DIFF
--- a/.github/workflows/plugin-guard.yml
+++ b/.github/workflows/plugin-guard.yml
@@ -40,14 +40,24 @@ jobs:
         run: |
           home="${RUNNER_TEMP}/plugin-guard"
           mkdir -p "${home}/tools"
-          # Fetch through the authenticated GitHub API, not the raw CDN:
-          # raw.githubusercontent.com returns persistent 429s on busy CI
-          # windows, while the API honors the GITHUB_TOKEN's higher limits.
-          # The scanner stays pinned to the SHA resolved above.
-          gh api "repos/NousResearch/hermes-agent/contents/tools/plugin_guard.py?ref=${{ steps.scanner.outputs.sha }}" \
-            -H "Accept: application/vnd.github.raw" > "${home}/tools/plugin_guard.py"
-          gh api "repos/NousResearch/hermes-agent/contents/tools/skills_guard.py?ref=${{ steps.scanner.outputs.sha }}" \
-            -H "Accept: application/vnd.github.raw" > "${home}/tools/skills_guard.py"
+          # Fetch through the authenticated GitHub API, not the raw CDN
+          # (raw.githubusercontent.com 429s persistently under load). Even the
+          # API can bounce at a sliding rate window, so retry patiently —
+          # the scanner stays pinned to the SHA resolved above.
+          fetch() {
+            local path="$1" out="$2" attempt
+            for attempt in 1 2 3 4 5 6; do
+              if gh api "repos/NousResearch/hermes-agent/contents/tools/${path}?ref=${{ steps.scanner.outputs.sha }}" \
+                  -H "Accept: application/vnd.github.raw" > "$out"; then
+                return 0
+              fi
+              echo "scanner fetch attempt ${attempt} failed; backing off"
+              sleep 25
+            done
+            return 1
+          }
+          fetch plugin_guard.py "${home}/tools/plugin_guard.py"
+          fetch skills_guard.py "${home}/tools/skills_guard.py"
           touch "${home}/tools/__init__.py"
 
       - name: Scan this repository

--- a/.github/workflows/plugin-guard.yml
+++ b/.github/workflows/plugin-guard.yml
@@ -35,15 +35,19 @@ jobs:
           echo "sha=${sha}" >> "$GITHUB_OUTPUT"
 
       - name: Download the pinned scanner outside the checkout
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           home="${RUNNER_TEMP}/plugin-guard"
           mkdir -p "${home}/tools"
-          base="https://raw.githubusercontent.com/NousResearch/hermes-agent/${{ steps.scanner.outputs.sha }}/tools"
-          # raw.githubusercontent.com can rate-limit (HTTP 429) on busy CI
-          # days; retry with backoff so a transient throttle cannot fail the
-          # gate. The scanner stays pinned to the SHA resolved above.
-          curl -fsSL --retry 6 --retry-delay 5 --retry-all-errors "${base}/plugin_guard.py" -o "${home}/tools/plugin_guard.py"
-          curl -fsSL --retry 6 --retry-delay 5 --retry-all-errors "${base}/skills_guard.py" -o "${home}/tools/skills_guard.py"
+          # Fetch through the authenticated GitHub API, not the raw CDN:
+          # raw.githubusercontent.com returns persistent 429s on busy CI
+          # windows, while the API honors the GITHUB_TOKEN's higher limits.
+          # The scanner stays pinned to the SHA resolved above.
+          gh api "repos/NousResearch/hermes-agent/contents/tools/plugin_guard.py?ref=${{ steps.scanner.outputs.sha }}" \
+            -H "Accept: application/vnd.github.raw" > "${home}/tools/plugin_guard.py"
+          gh api "repos/NousResearch/hermes-agent/contents/tools/skills_guard.py?ref=${{ steps.scanner.outputs.sha }}" \
+            -H "Accept: application/vnd.github.raw" > "${home}/tools/skills_guard.py"
           touch "${home}/tools/__init__.py"
 
       - name: Scan this repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ but 0.4.0's release title named only the steering verb. They are recorded
 below under 0.4.0 — the first version that shipped them — with the gap
 named rather than smoothed.
 
-## 0.13.0 (Unreleased)
+## [0.13.0] — 2026-08-28
 
 Custom voice: a cascade mode that lets the assistant speak in YOUR voice —
 any stock or cloned voice on the operator's ElevenLabs account — while the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-talk"
-version = "0.12.0"
+version = "0.13.0"
 description = "Realtime speech-to-speech voice for Hermes Agent — OpenAI, xAI Grok, or Gemini Live — duplex talk with live tool calling."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release 0.13.0: custom-voice cascade (#75) — speak through ElevenLabs, cloned voices included.

- pyproject 0.12.0 -> 0.13.0
- CHANGELOG finalized with date

On merge: tag v0.13.0 triggers publish.yml (OIDC -> PyPI).