### PR TITLE
feat: cascade voice on Discord + dashboard lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ but 0.4.0's release title named only the steering verb. They are recorded
 below under 0.4.0 — the first version that shipped them — with the gap
 named rather than smoothed.
 
+## 0.14.0 (Unreleased)
+
+The custom-voice cascade leaves the terminal: Discord rooms and the dashboard
+tab speak through ElevenLabs too.
+
+### Added
+- Discord lane: cascade voice in the voice channel. The lane already enters
+  the terminal's shared `run_talk_session`, so the 0.13.0 wiring —
+  fail-closed config, text-output session setup, observe-before-relay,
+  teardown — applied by construction; this release PROVES it through the
+  real `DiscordAudio` surface (fake voice channel, scripted TTS socket):
+  cascade PCM24k takes the relay's exact 24k→48k conversion into the room,
+  barge-in kills the TTS stream and drains the channel in one step, and a
+  non-OpenAI provider refuses before the channel is touched.
+- Dashboard lane: `POST /api/plugins/hermes-talk/cascade-tts` — a server-side
+  relay for the browser. The tab mints a text-output session (`/session`
+  answers `voiceMode: "cascade"` and skips the provider-voice validation),
+  streams the model's `response.output_text` deltas to the route as NDJSON
+  (`{"delta": ...}` lines, one terminal `{"done": ...}`), and plays the
+  PCM24k that streams back through its AudioContext. Only an explicit `done`
+  completes an answer: an aborted stream (barge-in, tab closed) cancels the
+  TTS instead of flushing it, and a malformed or oversized line cancels with
+  one logged receipt rather than half-speaking. The ElevenLabs key never
+  leaves the server — the route sits behind the same `TALK_DASHBOARD_TOKEN` /
+  loopback gate as the mint, and `CascadeVoice` gains an `on_stream_end`
+  hook so the route knows when a response's audio has settled.
+- `talk_config.cascade_voice_config(provider)`: the cascade fail-closed
+  resolution (provider gate, TTS knob, key, voice id, model) in one place,
+  so the terminal, Discord, and dashboard lanes refuse identically.
+
 ## [0.13.0] — 2026-08-28
 
 Custom voice: a cascade mode that lets the assistant speak in YOUR voice —

--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ call itself survives. `TALK_VOICE_MODE` is fail-closed and defaults to
 a `cascade` check: mode, TTS provider, redacted key presence, voice-id
 status — no live probe.
 
+The cascade speaks on every Talk surface:
+
+| Surface | How the cascade speaks |
+| --- | --- |
+| Terminal (`hermes talk`) | The provider session opens in text-output mode; the cascade feeds the SAME playback sink the relay feeds. |
+| Discord (`talk join`) | The same shared session loop; cascade PCM24k takes the relay's exact path through the 24k→48k voice-channel conversion. |
+| Dashboard tab | The browser keeps its WebRTC socket but mints a text-output session and relays the model's text deltas to `POST /api/plugins/hermes-talk/cascade-tts`; the server-side cascade speaks them and streams PCM back. The ElevenLabs key never reaches the browser — the route sits behind the same `TALK_DASHBOARD_TOKEN` / loopback gate as the mint, and barge-in aborts the fetch, which cancels the TTS exactly like the terminal lane. |
+
 ## Use
 
 ```bash

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -84,6 +84,13 @@
     return apiCall(path, { method: "POST", body: JSON.stringify(body || {}) }, timeoutMs);
   }
 
+  /** NDJSON encoder for the cascade relay, minted lazily (cascade mode only). */
+  let relayEncoder = null;
+  function encodeRelayLine(line) {
+    if (!relayEncoder) relayEncoder = new TextEncoder();
+    return relayEncoder.encode(JSON.stringify(line) + "\n");
+  }
+
   /** fetchJSON throws Error("<status>: <body>") — the gate's refusals look like this. */
   function isAuthError(err) {
     return /^(401|403)\b/.test(String((err && err.message) || ""));
@@ -109,6 +116,12 @@
    * barge-in has no browser analogue and none is faked here. What IS mirrored
    * from talk_relay is the response.cancel gate — cancelling while the model
    * is idle earns a "no active response" error on every operator turn.
+   *
+   * Cascade mode (session.voiceMode === "cascade"): the session was minted
+   * with text output, so no audio track ever arrives. Instead the model's
+   * response.output_text deltas stream to POST /cascade-tts as NDJSON and the
+   * PCM24k that comes back plays through an AudioContext. The ElevenLabs key
+   * never touches this page — the server owns it.
    */
   class TalkTransport {
     constructor(session, callbacks) {
@@ -124,6 +137,18 @@
       this.continuationPending = false;
       this.toolBatch = null;
       this.toolTail = Promise.resolve();
+      this.cascade = session && session.voiceMode === "cascade";
+      // Every response gets its own relay stream; a tool-call continuation
+      // can start streaming while the previous answer's PCM still drains, so
+      // in-flight streams are a SET, and playback carries a generation that
+      // barge-in bumps — a chunk decoded before the operator spoke but
+      // scheduled after must not play (the Python cascade's rule, mirrored).
+      this.cascadeReq = null;
+      this.cascadeReqs = new Set();
+      this.pcmContext = null;
+      this.pcmNextTime = 0;
+      this.pcmSources = [];
+      this.pcmGeneration = 0;
     }
 
     async start() {
@@ -198,6 +223,12 @@
       this.closed = true;
       if (this.offerAbort) this.offerAbort.abort();
       this.offerAbort = null;
+      this.abortCascade();
+      if (this.pcmContext) {
+        const ctx = this.pcmContext;
+        this.pcmContext = null;
+        if (ctx.close) Promise.resolve(ctx.close()).catch(() => {});
+      }
       if (this.channel) this.channel.close();
       this.channel = null;
       if (this.peer) this.peer.close();
@@ -233,6 +264,21 @@
         case "response.output_audio_transcript.done":
           if (event.transcript) this.cb.onTranscript("assistant", event.transcript, true);
           return;
+        case "response.output_text.delta":
+          // Cascade sessions: the model's answer arrives as TEXT, not audio.
+          // The caption uses it directly; the relay speaks it server-side.
+          if (event.delta) this.cb.onTranscript("assistant", event.delta, false);
+          if (event.delta && this.cascade) this.cascadeSend({ delta: event.delta });
+          return;
+        case "response.output_text.done": {
+          const text = typeof event.text === "string" ? event.text : "";
+          if (text) this.cb.onTranscript("assistant", text, true);
+          if (this.cascade) {
+            this.cascadeSend({ done: text });
+            this.finishCascadeStream();
+          }
+          return;
+        }
         case "response.created":
           this.continuationPending = false;
           this.responseActive = true;
@@ -240,11 +286,17 @@
           return;
         case "response.done":
           this.responseActive = false;
+          // A response that ends with its text stream still open was
+          // interrupted upstream; its half-spoken answer dies with it.
+          if (this.cascade && this.cascadeReq && this.cascadeReq.sink) this.abortCascade();
           this.finishToolResponse();
           this.cb.onStatus("Listening…");
           return;
         case "input_audio_buffer.speech_started":
           this.cb.onStatus("Listening…");
+          // Barge-in kills the cascade mid-word too: abort the relay fetch
+          // (the server cancels the TTS on EOF) and stop every queued buffer.
+          if (this.cascade) this.abortCascade();
           // Barge-in. Server VAD already interrupts; the explicit cancel is the
           // relay's contract, and the gate is why it does not error every turn.
           if (this.responseActive) this.send({ type: "response.cancel" });
@@ -274,6 +326,136 @@
       // same suppression talk_relay applies.
       if (detail.toLowerCase().indexOf("no active response") !== -1) return;
       this.cb.onError(detail ? "Realtime error: " + detail : "Realtime error.");
+    }
+
+    // -- cascade relay (custom voice; the server speaks, the page plays) -----
+
+    /**
+     * Open the relay POST for one response's text stream. The request body is
+     * a ReadableStream (duplex: "half") so deltas flow while the PCM answer
+     * streams back — the first sentence plays while the model is still
+     * writing the second, same as the terminal lane's sentence pipelining.
+     */
+    startCascadeStream() {
+      const req = { controller: new AbortController(), sink: null };
+      this.cascadeReq = req;
+      this.cascadeReqs.add(req);
+      const body = new ReadableStream({
+        start: (controller) => {
+          req.sink = controller;
+        },
+      });
+      const headers = { "content-type": "application/x-ndjson" };
+      const token = readToken();
+      if (token) headers["x-talk-token"] = token;
+      // Raw fetch, not apiCall: this is a bidirectional byte stream, not JSON.
+      fetch(API + "/cascade-tts", {
+        method: "POST",
+        headers: headers,
+        body: body,
+        duplex: "half",
+        signal: req.controller.signal,
+      })
+        .then((res) => {
+          if (!res.ok || !res.body) return undefined;
+          return this.playCascadePcm(req, res.body.getReader());
+        })
+        .catch(() => {
+          // Aborts (barge-in, stop) and refusals alike land here: the answer
+          // degrades to text-only on screen, which is already true.
+        });
+    }
+
+    cascadeSend(line) {
+      // The previous response's relay may still be draining PCM — that is no
+      // reason to drop THIS response's text; it opens its own stream.
+      if (!this.cascadeReq || !this.cascadeReq.sink) this.startCascadeStream();
+      const sink = this.cascadeReq && this.cascadeReq.sink;
+      // An upload stream carries BYTES — a string chunk is a fetch-type error.
+      if (sink) sink.enqueue(encodeRelayLine(line));
+    }
+
+    /** The response's text is complete; the PCM answer keeps streaming. */
+    finishCascadeStream() {
+      const req = this.cascadeReq;
+      if (req && req.sink) {
+        try { req.sink.close(); } catch (e) { /* an errored stream is already closed */ }
+        req.sink = null;
+      }
+    }
+
+    /** Barge-in or hang-up: every in-flight answer stops, server and speaker. */
+    abortCascade() {
+      const reqs = this.cascadeReqs;
+      this.cascadeReqs = new Set();
+      this.cascadeReq = null;
+      reqs.forEach((req) => {
+        if (req.sink) {
+          try { req.sink.close(); } catch (e) { /* already closed */ }
+        }
+        req.controller.abort();
+      });
+      this.stopPcmPlayback();
+    }
+
+    stopPcmPlayback() {
+      for (let i = 0; i < this.pcmSources.length; i++) {
+        try {
+          this.pcmSources[i].stop();
+        } catch (e) {
+          /* a finished source throws on stop — that is the goal anyway */
+        }
+      }
+      this.pcmSources = [];
+      this.pcmNextTime = 0;
+      this.pcmGeneration += 1;
+    }
+
+    /** PCM24k mono s16le off the wire onto the playback timeline. */
+    async playCascadePcm(req, reader) {
+      const generation = this.pcmGeneration;
+      let pending = new Uint8Array(0);
+      try {
+        for (;;) {
+          const step = await reader.read();
+          if (step.done || !this.cascadeReqs.has(req)) break;
+          const chunk = step.value;
+          const joined = new Uint8Array(pending.length + chunk.length);
+          joined.set(pending, 0);
+          joined.set(chunk, pending.length);
+          const even = joined.length - (joined.length % 2);  // s16le = 2 bytes/sample
+          pending = joined.slice(even);
+          if (even > 0) this.schedulePcm(joined.slice(0, even), generation);
+        }
+      } catch (e) {
+        // An aborted fetch rejects the reader — the barge-in already spoke.
+      }
+      this.cascadeReqs.delete(req);
+      if (this.cascadeReq === req) this.cascadeReq = null;
+    }
+
+    /** Schedule one chunk after the last — gapless, in arrival order. */
+    schedulePcm(bytes, generation) {
+      if (generation !== this.pcmGeneration) return;  // decoded before a barge-in
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      if (!Ctx) return;  // no playback surface — the transcript still reads
+      if (!this.pcmContext) {
+        this.pcmContext = new Ctx();
+        this.pcmNextTime = 0;
+      }
+      const ctx = this.pcmContext;
+      const samples = new Int16Array(bytes.buffer, bytes.byteOffset, bytes.length / 2);
+      const buffer = ctx.createBuffer(1, samples.length, 24000);
+      const channel = buffer.getChannelData(0);
+      for (let i = 0; i < samples.length; i++) channel[i] = samples[i] / 32768;
+      const source = ctx.createBufferSource();
+      source.buffer = buffer;
+      source.connect(ctx.destination);
+      const at = Math.max(ctx.currentTime || 0, this.pcmNextTime);
+      source.start(at);
+      this.pcmNextTime = at + buffer.duration;
+      this.pcmSources.push(source);
+      if (this.pcmSources.length > 512) this.pcmSources.splice(0, 256);
     }
 
     /**
@@ -589,15 +771,21 @@
         })
       ),
 
-      h("label", { className: "ht-field" }, "Voice",
-        h("select", {
-          className: "ht-select",
-          value: voice,
-          disabled: !ready || active || starting,
-          onChange: (e) => setVoice(e.target.value),
-        }, ((status && status.voices) || []).map((name) =>
-          h("option", { key: name, value: name }, name)))
-      ),
+      (status && status.voiceMode) === "cascade"
+        ? h("div", { className: "ht-field" },
+            h("div", { className: "ht-note" },
+              "Custom voice: the cascade speaks through ElevenLabs " +
+              "(TALK_ELEVENLABS_VOICE_ID on the server); the provider voice " +
+              "select sits out cascade sessions."))
+        : h("label", { className: "ht-field" }, "Voice",
+            h("select", {
+              className: "ht-select",
+              value: voice,
+              disabled: !ready || active || starting,
+              onChange: (e) => setVoice(e.target.value),
+            }, ((status && status.voices) || []).map((name) =>
+              h("option", { key: name, value: name }, name)))
+          ),
 
       live && h("div", { className: "ht-live" }, live),
       error && h("div", { className: "ht-error" }, error),

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -21,6 +21,11 @@ Three invariants this layer exists to hold:
   independent gate: ``TALK_DASHBOARD_TOKEN`` when set, loopback-only when it is
   not, and a refusal — never a pass — for a peer this process cannot identify.
 
+The cascade relay (``/cascade-tts``) extends the first invariant to the
+ElevenLabs key: the browser holds the provider socket and relays the model's
+TEXT deltas here, the server-side :class:`talk_cascade_voice.CascadeVoice`
+speaks them, and only PCM audio ever leaves the process.
+
 Out-of-process caveat: the dashboard imports this file into the WEB SERVER
 process, which has no bound plugin context. Agent-loop-only tools
 (``session_search``, in-loop ``delegate_task``) degrade to their announced
@@ -31,8 +36,12 @@ from __future__ import annotations
 
 import asyncio
 import hmac
+import json
+import logging
 import os
 import sys
+from collections.abc import AsyncIterator
+from contextlib import suppress
 from pathlib import Path
 
 #: The dashboard loads this module by path, so ``talk_*`` is not importable by
@@ -47,9 +56,11 @@ if str(_PLUGIN_ROOT) not in sys.path:
 import talk_apiserver  # noqa: E402
 import talk_auth  # noqa: E402
 import talk_capabilities  # noqa: E402
+import talk_cascade_voice  # noqa: E402
 import talk_config  # noqa: E402
 import talk_host  # noqa: E402
 import talk_identity  # noqa: E402
+import talk_realtime  # noqa: E402
 import talk_relay  # noqa: E402
 import talk_runs  # noqa: E402
 import talk_tools  # noqa: E402
@@ -57,6 +68,7 @@ import talk_wire  # noqa: E402
 
 try:
     from fastapi import APIRouter, HTTPException, Request
+    from fastapi.responses import StreamingResponse
 except ImportError:  # pragma: no cover - offline tests run without the dashboard deps
 
     class APIRouter:  # type: ignore[no-redef]
@@ -78,6 +90,17 @@ except ImportError:  # pragma: no cover - offline tests run without the dashboar
 
     class Request:  # type: ignore[no-redef]
         """Annotation target only — never instantiated on this path."""
+
+    class StreamingResponse:  # type: ignore[no-redef]
+        """The two attributes the route and offline tests touch, in fastapi's shape."""
+
+        def __init__(self, content, media_type=None) -> None:
+            self.body_iterator = content
+            self.media_type = media_type
+            self.status_code = 200
+
+
+_log = logging.getLogger(__name__)
 
 
 router = APIRouter()
@@ -190,8 +213,13 @@ def _warm_agent_lane() -> str:
     return talk_host.host().agent_lane()
 
 
-def _mint(auth_token: str, voice: str):
-    """Assemble instructions and mint. Blocking — called on a worker thread."""
+def _mint(auth_token: str, voice: str, *, text_output: bool = False):
+    """Assemble instructions and mint. Blocking — called on a worker thread.
+
+    ``text_output`` is the cascade lane: the minted session asks the provider
+    for TEXT output instead of synthesized audio, and the browser streams the
+    text deltas back through the cascade relay to be spoken server-side.
+    """
 
     tools = talk_tools.default_talk_tools()
     return talk_wire.mint_ephemeral_session(
@@ -202,7 +230,17 @@ def _mint(auth_token: str, voice: str):
             talk_host.host().identity_sections(), tools=tools, lane="dashboard"
         ),
         tools=tools,
+        text_output=text_output,
     )
+
+
+def _resolve_voice_mode() -> str:
+    """The configured voice mode for a mint — fail-closed, named on refusal."""
+
+    try:
+        return talk_config.voice_mode()
+    except talk_config.TalkConfigError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def _resolve_voice(requested) -> str:
@@ -244,6 +282,13 @@ async def talk_status(request: Request) -> dict:
         detail_suffix = f" (TALK_VOICE unusable: {exc})"
     else:
         detail_suffix = ""
+    try:
+        voice_mode = talk_config.voice_mode()
+    except talk_config.TalkConfigError as exc:
+        # Stay answerable: the tile reads as native and the mint refuses with
+        # the exact remediation when Start is pressed.
+        voice_mode = ""
+        detail_suffix += f" (TALK_VOICE_MODE unusable: {exc})"
     status = talk_auth.auth_status()
     return {
         "ok": True,
@@ -252,6 +297,7 @@ async def talk_status(request: Request) -> dict:
         "detail": f"{status.get('detail') or ''}{detail_suffix}",
         "model": talk_config.talk_model(),
         "voice": voice,
+        "voiceMode": voice_mode or "native",
         "voices": list(talk_config.OPENAI_REALTIME_VOICES),
         "version": talk_tools.plugin_version(),
         # Tri-state, not a bool: no plugin context is ever bound in the web
@@ -275,7 +321,20 @@ async def create_session(request: Request) -> dict:
 
     require_dashboard_auth(request)
     body = await _json_body(request)
-    voice = _resolve_voice(body.get("voice"))
+    voice_mode = _resolve_voice_mode()
+    text_output = voice_mode == "cascade"
+    if text_output:
+        # A cascade session has no provider voice to validate — the mint asks
+        # for text output and the relay speaks. The cascade config refuses
+        # HERE, before a single secret is spent on the mint, with the same
+        # rules and messages the terminal and Discord lanes get.
+        try:
+            talk_config.cascade_voice_config(talk_config.talk_provider())
+        except talk_config.TalkConfigError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        voice = ""
+    else:
+        voice = _resolve_voice(body.get("voice"))
     try:
         auth = talk_auth.resolve_auth()
     except talk_auth.TalkAuthError as exc:
@@ -288,6 +347,7 @@ async def create_session(request: Request) -> dict:
             _mint,
             auth.token,
             voice,
+            text_output=text_output,
         )
     except talk_wire.TalkWireError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -319,7 +379,15 @@ async def create_session(request: Request) -> dict:
         operator=f"dashboard:{auth.source}",
         profile=talk_config.agent_profile(),
     )
-    return {"ok": True, **descriptor.to_wire(), "authSource": auth.source}
+    return {
+        "ok": True,
+        **descriptor.to_wire(),
+        "authSource": auth.source,
+        # The tab switches its playback pipeline on this: native plays the
+        # provider's audio track; cascade relays text deltas to /cascade-tts
+        # and plays the PCM that comes back.
+        "voiceMode": voice_mode,
+    }
 
 
 @router.post("/tool")
@@ -370,6 +438,193 @@ async def run_tool(request: Request) -> dict:
     return {"ok": True, "output": output}
 
 
+# -- the cascade relay (custom voice on the browser lane) ---------------------
+
+#: The relay speaks the cascade's wire format straight back: PCM 24kHz mono
+#: s16le, chunked as it lands.
+CASCADE_PCM_MEDIA_TYPE = "application/octet-stream"
+
+#: One NDJSON line carries a delta (a few words) or a done (one whole answer).
+#: A line past this bound is not text the model wrote; it is a buggy or hostile
+#: client, and the feed aborts rather than buffering without limit.
+CASCADE_MAX_LINE_BYTES = 65_536
+
+#: Queue sentinels for the relay's drain loop: _PCM_END is the cascade's
+#: stream-settled hook for this response; _FEED_DONE is the browser's text
+#: stream ending (done, abort, or garbage — the state flag distinguishes).
+_PCM_END = object()
+_FEED_DONE = object()
+
+
+def _resolve_cascade_relay_config() -> tuple[str, str, str]:
+    """The cascade triple for one relay call — fail-closed, HTTP-shaped.
+
+    The browser only calls this route for a session minted with
+    ``voiceMode: "cascade"``, so a server no longer in cascade mode means the
+    config changed mid-session: a refusal (409), never a guess. A broken
+    cascade knob is a 400 carrying the same remediation the CLI would print.
+    """
+
+    if _resolve_voice_mode() != "cascade":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "cascade voice mode is not enabled on this server "
+                "(TALK_VOICE_MODE) — this session was not minted for the relay"
+            ),
+        )
+    try:
+        return talk_config.cascade_voice_config(talk_config.talk_provider())
+    except talk_config.TalkConfigError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _parse_cascade_line(raw: bytes) -> dict | None:
+    """One NDJSON line as a dict, or ``None`` when it is protocol garbage."""
+
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+async def _cascade_request_lines(request) -> AsyncIterator[dict | None]:
+    """Yield the request body's NDJSON objects as they arrive.
+
+    Yields ``None`` once — then stops — for a malformed or oversized line.
+    The caller treats that exactly like a client abort: the response's TTS is
+    cancelled, never half-spoken from garbage.
+    """
+
+    buffer = b""
+    async for chunk in request.stream():
+        buffer += chunk
+        while b"\n" in buffer:
+            raw, buffer = buffer.split(b"\n", 1)
+            line = raw.strip()
+            if not line:
+                continue
+            parsed = _parse_cascade_line(line)
+            if parsed is None:
+                yield None
+                return
+            yield parsed
+        if len(buffer) > CASCADE_MAX_LINE_BYTES:
+            yield None
+            return
+    tail = buffer.strip()
+    if tail:  # a final line without its trailing newline still counts
+        yield _parse_cascade_line(tail)
+
+
+def _relay_transcript(text: str, *, final: bool) -> talk_realtime.Transcript:
+    """The browser's relayed text in the cascade's provider-neutral shape."""
+
+    return talk_realtime.Transcript(
+        role=talk_realtime.TranscriptRole.ASSISTANT,
+        text=text,
+        final=final,
+        provenance=talk_realtime.TranscriptProvenance.OUTPUT_AUDIO,
+    )
+
+
+async def _cascade_pcm_stream(request, config: tuple[str, str, str]) -> AsyncIterator[bytes]:
+    """Feed one response's relayed text through CascadeVoice; yield its PCM.
+
+    A fresh CascadeVoice per request: one POST == one response's speech. The
+    feeder task and this drain loop run CONCURRENTLY — that overlap is the
+    sentence pipelining, PCM flowing back while the browser is still sending
+    the model's text. Only an explicit ``{"done": ...}`` line completes the
+    answer: a stream that ends without it (the browser aborted on barge-in,
+    or the socket tore) falls to ``aclose()``, which cancels the in-flight
+    TTS exactly like the terminal lane's barge-in — an interrupted answer
+    must not keep talking.
+    """
+
+    audio_queue: asyncio.Queue = asyncio.Queue()
+    api_key, voice_id, model = config
+    voice = talk_cascade_voice.CascadeVoice(
+        api_key=api_key,
+        voice_id=voice_id,
+        model=model,
+        on_audio=audio_queue.put_nowait,
+        on_error=lambda text: _log.warning("dashboard cascade relay: %s", text),
+        on_stream_end=lambda: audio_queue.put_nowait(_PCM_END),
+    )
+    voice.start()
+    state = {"completed": False, "speakable": False}
+
+    async def consume_request() -> None:
+        """Feed the cascade from the browser's NDJSON stream."""
+
+        try:
+            async for line in _cascade_request_lines(request):
+                if line is None:
+                    _log.warning(
+                        "dashboard cascade relay: malformed stream line — answer cancelled"
+                    )
+                    return
+                delta = line.get("delta")
+                if isinstance(delta, str) and delta:
+                    state["speakable"] = state["speakable"] or bool(delta.strip())
+                    voice.handle_event(_relay_transcript(delta, final=False))
+                    continue
+                done = line.get("done")
+                if isinstance(done, str):
+                    state["speakable"] = state["speakable"] or bool(done.strip())
+                    voice.handle_event(_relay_transcript(done, final=True))
+                    state["completed"] = True
+                    return
+                _log.warning(
+                    "dashboard cascade relay: unrecognized stream line — answer cancelled"
+                )
+                return
+        finally:
+            audio_queue.put_nowait(_FEED_DONE)
+
+    feeder = asyncio.create_task(consume_request())
+    try:
+        while True:
+            item = await audio_queue.get()
+            if item is _PCM_END:
+                break  # the response's TTS run settled, spoken or failed
+            if item is _FEED_DONE:
+                if not state["completed"]:
+                    break  # aborted: stop now; aclose() below silences the TTS
+                if not state["speakable"]:
+                    break  # a whitespace-only answer never starts a TTS run
+                continue  # text done, audio still landing — wait for _PCM_END
+            yield item
+    finally:
+        if not feeder.done():
+            feeder.cancel()
+            await asyncio.wait({feeder})
+        with suppress(Exception):  # TTS teardown must not mask the real exit
+            await voice.aclose()
+
+
+@router.post("/cascade-tts")
+async def cascade_tts(request: Request):
+    """Stream one assistant response's text through the cascade; PCM24k back.
+
+    The dashboard tab holds the provider socket (WebRTC), so the cascade on
+    this lane is a RELAY: the browser streams the model's own assistant text
+    deltas here as NDJSON (``{"delta": ...}`` lines and one terminal
+    ``{"done": ...}``), and this route runs them through the same CascadeVoice
+    the terminal and Discord lanes use, returning PCM as it lands. The
+    ElevenLabs key never leaves this process — it rides only the server-side
+    stream-input socket, behind the same dashboard gate as the mint.
+    """
+
+    require_dashboard_auth(request)
+    config = _resolve_cascade_relay_config()
+    return StreamingResponse(
+        _cascade_pcm_stream(request, config),
+        media_type=CASCADE_PCM_MEDIA_TYPE,
+    )
+
+
 @router.get("/runs")
 async def list_runs(request: Request) -> dict:
     """Background runs for the panel and the WORK_STARTED watcher.
@@ -388,10 +643,12 @@ async def list_runs(request: Request) -> dict:
 #: Every route in this plugin, for the guard-coverage invariant test. A new
 #: route that is not listed here (or not gated) fails that test rather than
 #: shipping open.
-ROUTE_HANDLERS = (talk_status, create_session, run_tool, list_runs)
+ROUTE_HANDLERS = (talk_status, create_session, run_tool, cascade_tts, list_runs)
 
 
 __all__ = [
+    "CASCADE_MAX_LINE_BYTES",
+    "CASCADE_PCM_MEDIA_TYPE",
     "DASHBOARD_TOKEN_ENV",
     "DASHBOARD_TOKEN_HEADER",
     "LOOPBACK_HOSTS",
@@ -399,6 +656,7 @@ __all__ = [
     "ROUTE_HANDLERS",
     "RUNS_LIMIT",
     "TOKEN_REQUIRED_MESSAGE",
+    "cascade_tts",
     "create_session",
     "dashboard_token",
     "list_runs",

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -194,6 +194,15 @@ all of them. Canonical source: `talk_config.py` and `talk_auth.py`.
 | `TALK_ELEVENLABS_VOICE_ID` | unset | Voice the cascade speaks with. **Required in cascade mode** — unset or blank refuses with remediation, because a cascade with no voice would have nothing to synthesize against and guessing at an account's voices would speak with a voice the operator did not choose. Voice ids are semi-public identifiers (printing them is fine; the KEY is the secret). Stock and cloned voices both work; cloning is done in ElevenLabs VoiceLab, not here. |
 | `TALK_ELEVENLABS_MODEL` | `eleven_flash_v2_5` | ElevenLabs TTS model for the cascade lane. `eleven_flash_v2_5` probed at ~490ms to first audio on PCM 24kHz (2026-08-28), which is the cascade's latency trade: roughly one extra half-second on the first sentence versus native; later sentences pipeline under playback. |
 
+Cascade mode applies to every Talk surface — terminal, Discord, and the
+dashboard tab share the same knobs and the same fail-closed resolution. On the
+dashboard the ElevenLabs key stays server-side: the tab relays the model's text
+deltas to `POST /api/plugins/hermes-talk/cascade-tts` (same
+`TALK_DASHBOARD_TOKEN` / loopback gate as the mint) and plays the PCM24k that
+streams back. One NDJSON `{"delta": ...}` line per text delta, one terminal
+`{"done": ...}` line per response; an aborted stream (barge-in, tab closed)
+cancels the answer's TTS rather than flushing it.
+
 ### Audio (terminal lane)
 
 | Variable | Default | Effect / failure mode |

--- a/talk_cascade_voice.py
+++ b/talk_cascade_voice.py
@@ -243,6 +243,9 @@ class CascadeVoice:
     for every provider-neutral event (synchronous, on the session loop),
     :meth:`aclose` at session teardown. ``on_audio`` is the SAME callable the
     relay uses for provider audio; ``on_error`` takes one human sentence.
+    ``on_stream_end`` is the relay-lane seam: a surface that streams one
+    response's PCM back to a client (the dashboard route) needs to know when
+    that response's TTS run settled; the CLI and Discord lanes never subscribe.
     """
 
     def __init__(
@@ -253,6 +256,7 @@ class CascadeVoice:
         model: str,
         on_audio: Callable[[bytes], None],
         on_error: Callable[[str], None],
+        on_stream_end: Callable[[], None] | None = None,
         aiohttp_module: Any = None,
         ws_connect: Callable[..., Any] | None = None,
         chunk_budget: int = CLAUSE_BUDGET_CHARS,
@@ -261,6 +265,7 @@ class CascadeVoice:
         self._url = stream_input_url(voice_id, model)
         self._on_audio = on_audio
         self._on_error = on_error
+        self._on_stream_end = on_stream_end
         self._aiohttp = aiohttp_module
         #: Test seam: an async callable (url, headers) -> fake socket. The real
         #: path opens an aiohttp session per stream.
@@ -451,14 +456,27 @@ class CascadeVoice:
         if task.cancelled():
             return
         exc = task.exception()
-        if exc is None:
+        if exc is not None:
+            self._drain_queue()
+            self._chunker.reset()
+            self._on_error(
+                f"cascade voice failed for that answer — staying text-only "
+                f"({type(exc).__name__})"
+            )
+        # One stream run == one response, so a settled task means that
+        # response's audio is done — in success or in failure (the error
+        # receipt above already fired). A CANCELLED task signals nothing:
+        # barge-in and teardown are known to whoever cancelled.
+        self._notify_stream_end()
+
+    def _notify_stream_end(self) -> None:
+        """Fire the relay-lane hook; a consumer bug must not kill the worker."""
+
+        callback = self._on_stream_end
+        if callback is None:
             return
-        self._drain_queue()
-        self._chunker.reset()
-        self._on_error(
-            f"cascade voice failed for that answer — staying text-only "
-            f"({type(exc).__name__})"
-        )
+        with contextlib.suppress(Exception):
+            callback()
 
     async def _stream(self, first_chunk: str) -> None:
         """One stream-input exchange: BOS, chunks, EOS, audio until isFinal."""

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -1093,24 +1093,12 @@ async def run_talk_session(
         # Cascade voice mode: the provider thinks in text, ElevenLabs speaks.
         # Resolved HERE, next to the provider pick, so every fail-closed knob
         # (mode, TTS provider, key, voice id) refuses before a single secret
-        # or socket is spent. Gated to OpenAI: it is the one provider whose
-        # text-output mode is wired and verified — grok/gemini text modes are
-        # unverified, and guessing would mute the call.
+        # or socket is spent. The rules live in talk_config.cascade_voice_config
+        # so every lane (terminal, Discord, dashboard) refuses identically.
         voice_mode = talk_config.voice_mode()
         cascade_config: tuple[str, str, str] | None = None
         if voice_mode == "cascade":
-            if provider != "openai":
-                raise talk_config.TalkConfigError(
-                    f"TALK_VOICE_MODE=cascade requires TALK_PROVIDER=openai, but "
-                    f"'{provider}' is configured — grok/gemini text-output modes are "
-                    "not wired into the cascade yet"
-                )
-            talk_config.cascade_tts()  # fail-closed; elevenlabs is the only value today
-            cascade_config = (
-                talk_config.resolve_elevenlabs_key(),
-                talk_config.elevenlabs_voice_id(),
-                talk_config.elevenlabs_model(),
-            )
+            cascade_config = talk_config.cascade_voice_config(provider)
     except (talk_config.TalkConfigError, talk_auth.TalkAuthError) as exc:
         print(f"talk: {exc}", file=sys.stderr)
         if host_execution_attachment is not None:

--- a/talk_config.py
+++ b/talk_config.py
@@ -649,6 +649,32 @@ def elevenlabs_model() -> str:
     )
 
 
+def cascade_voice_config(provider: str) -> tuple[str, str, str]:
+    """The resolved cascade TTS triple — (key, voice id, model). Fail-closed.
+
+    Every lane that opens a cascade session resolves through HERE so the
+    refusal rules — and their messages — exist exactly once: cascade requires
+    the openai provider (its text-output mode is the only one wired and
+    verified; guessing at grok/gemini text modes would mute the call), the TTS
+    knob validates, the key refuses set-but-blank, and the voice id is
+    required. Callers invoke this only after :func:`voice_mode` returned
+    ``cascade``, before a single secret or socket is spent.
+    """
+
+    if provider != "openai":
+        raise TalkConfigError(
+            f"TALK_VOICE_MODE=cascade requires TALK_PROVIDER=openai, but "
+            f"'{provider}' is configured — grok/gemini text-output modes are "
+            "not wired into the cascade yet"
+        )
+    cascade_tts()  # fail-closed; elevenlabs is the only value today
+    return (
+        resolve_elevenlabs_key(),
+        elevenlabs_voice_id(),
+        elevenlabs_model(),
+    )
+
+
 def agent_timeout_s() -> int:
     """Wall-clock budget for one detached background agent run.
 
@@ -842,6 +868,7 @@ __all__ = [
     "audio_input_device",
     "audio_output_device",
     "cascade_tts",
+    "cascade_voice_config",
     "detect_agent_profile",
     "discord_operator_user_ids",
     "elevenlabs_model",

--- a/tests/test_cascade_voice.py
+++ b/tests/test_cascade_voice.py
@@ -474,6 +474,101 @@ def test_stream_input_url_carries_identifiers_only():
 
 
 # ---------------------------------------------------------------------------
+# The stream-end hook (the dashboard relay lane's end-of-audio signal)
+# ---------------------------------------------------------------------------
+
+
+def test_stream_end_hook_fires_on_success_and_failure_but_not_barge_in():
+    asyncio.run(_stream_end_hook_semantics())
+
+
+async def _stream_end_hook_semantics():
+    ended: list[str] = []
+    harness = _Harness()
+    voice = cascade.CascadeVoice(
+        api_key=FAKE_KEY,
+        voice_id=FAKE_VOICE_ID,
+        model=talk_config.DEFAULT_ELEVENLABS_MODEL,
+        on_audio=harness.audio.append,
+        on_error=harness.errors.append,
+        on_stream_end=lambda: ended.append("end"),
+        aiohttp_module=aiohttp,
+        ws_connect=harness.connect,
+    )
+    voice.start()
+    try:
+        # Success: the hook fires once the terminal frame settles the run.
+        voice.handle_event(rt.ResponseStarted(response_id="resp_1"))
+        voice.handle_event(_delta("Clean answer. "))
+        voice.handle_event(_final(response_id="resp_1"))
+        await _wait_for(lambda: len(harness.connect.sockets) == 1)
+        ws = harness.connect.sockets[0]
+        ws.feed_audio(b"pcm")
+        ws.feed_final()
+        await _wait_for(lambda: ended == ["end"])
+        assert harness.audio == [b"pcm"]
+
+        # Failure: the error receipt fires first, then the hook — a relay
+        # draining a response stream must hear both, in that order.
+        voice.handle_event(rt.ResponseStarted(response_id="resp_2"))
+        voice.handle_event(_delta("Broken answer. ", response_id="resp_2"))
+        await _wait_for(lambda: len(harness.connect.sockets) == 2)
+        harness.connect.sockets[1].feed({"error": "upstream said no"})
+        await _wait_for(lambda: len(harness.errors) == 1)
+        await _wait_for(lambda: ended == ["end", "end"])
+
+        # Barge-in: a CANCELLED run fires nothing — whoever aborted knows.
+        voice.handle_event(rt.ResponseStarted(response_id="resp_3"))
+        voice.handle_event(_delta("Interrupted answer. ", response_id="resp_3"))
+        await _wait_for(lambda: len(harness.connect.sockets) == 3)
+        voice.handle_event(rt.SpeechStarted(input_id="in_1", offset_ms=0))
+        await _wait_for(lambda: harness.connect.sockets[2].closed)
+        await asyncio.sleep(0.05)
+        assert ended == ["end", "end"]
+    finally:
+        await voice.aclose()
+
+
+def test_stream_end_hook_consumer_failure_does_not_kill_the_worker():
+    asyncio.run(_stream_end_hook_consumer_failure())
+
+
+async def _stream_end_hook_consumer_failure():
+    harness = _Harness()
+
+    def broken_hook() -> None:
+        raise RuntimeError("consumer bug")
+
+    voice = cascade.CascadeVoice(
+        api_key=FAKE_KEY,
+        voice_id=FAKE_VOICE_ID,
+        model=talk_config.DEFAULT_ELEVENLABS_MODEL,
+        on_audio=harness.audio.append,
+        on_error=harness.errors.append,
+        on_stream_end=broken_hook,
+        aiohttp_module=aiohttp,
+        ws_connect=harness.connect,
+    )
+    voice.start()
+    try:
+        for index in (1, 2):
+            response_id = f"resp_{index}"
+            voice.handle_event(rt.ResponseStarted(response_id=response_id))
+            voice.handle_event(_delta("Still speaking. ", response_id=response_id))
+            voice.handle_event(_final(response_id=response_id))
+            await _wait_for(lambda index=index: len(harness.connect.sockets) == index)
+            ws = harness.connect.sockets[index - 1]
+            ws.feed_audio(f"pcm-{index}".encode())
+            ws.feed_final()
+            await _wait_for(lambda ws=ws: ws.closed)
+        # The hook raised on BOTH runs; the worker survived to speak again.
+        assert harness.audio == [b"pcm-1", b"pcm-2"]
+        assert harness.errors == []
+    finally:
+        await voice.aclose()
+
+
+# ---------------------------------------------------------------------------
 # Fail-closed config lanes
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dashboard_cascade.py
+++ b/tests/test_dashboard_cascade.py
@@ -1,0 +1,480 @@
+"""Dashboard cascade relay — the browser lane's custom voice, server-side only.
+
+The tab holds the provider socket (WebRTC) and relays the model's TEXT deltas
+to ``POST /cascade-tts``; the route runs them through the same CascadeVoice
+the terminal and Discord lanes use and streams PCM24k back. What is proved
+here, offline: the gate never fails open, the ElevenLabs key never leaves the
+process, only an explicit ``done`` completes an answer (an aborted stream is
+a barge-in, not a flush), a malformed line cancels rather than half-speaks,
+and the mint flips the session to text output only in cascade mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import types
+
+import aiohttp
+import pytest
+from test_dashboard_api import api, serialized
+
+import talk_cascade_voice
+import talk_config
+
+#: A credential shaped like the real thing, so a leak is greppable rather than
+#: a subtle substring match.
+FAKE_KEY = "fake-elevenlabs-key-for-tests"
+FAKE_VOICE_ID = "fakeVoiceId0001"
+
+
+@pytest.fixture(autouse=True)
+def _cascade_env(monkeypatch, tmp_path):
+    """Cascade configured, dashboard token unset, real operator keys scrubbed."""
+
+    monkeypatch.delenv(api.DASHBOARD_TOKEN_ENV, raising=False)
+    monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+    monkeypatch.delenv("TALK_PROVIDER", raising=False)
+    monkeypatch.setenv("TALK_VOICE_MODE", "cascade")
+    monkeypatch.setenv("TALK_ELEVENLABS_API_KEY", FAKE_KEY)
+    monkeypatch.setenv("TALK_ELEVENLABS_VOICE_ID", FAKE_VOICE_ID)
+    monkeypatch.setenv("TALK_OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
+
+
+class _FakeClient:
+    def __init__(self, host: str) -> None:
+        self.host = host
+
+
+class StreamRequest:
+    """A request whose body is a scripted NDJSON byte stream.
+
+    ``hold`` gates the abort point: with it set, the stream pauses after
+    ``chunks`` until the test releases it, then yields ``tail`` (empty for a
+    plain EOF). Without it a fake stream would EOF instantly — the abort would
+    beat the TTS dial and the test would prove nothing about mid-stream
+    cancellation.
+    """
+
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        tail: list[bytes] | None = None,
+        hold=None,
+        headers=None,
+        host="127.0.0.1",
+    ) -> None:
+        self.headers = {k.lower(): v for k, v in (headers or {}).items()}
+        self.client = _FakeClient(host) if host is not None else None
+        self._chunks = list(chunks)
+        self._tail = list(tail or [])
+        self._hold = hold
+
+    async def stream(self):
+        for chunk in self._chunks:
+            yield chunk
+        if self._hold is not None:
+            await self._hold.wait()
+        for chunk in self._tail:
+            yield chunk
+
+
+class JsonRequest:
+    """The mint/status shape: headers, peer, and an awaitable JSON body."""
+
+    def __init__(self, body=None, *, headers=None, host="127.0.0.1") -> None:
+        self.headers = {k.lower(): v for k, v in (headers or {}).items()}
+        self.client = _FakeClient(host)
+        self._body = body if body is not None else {}
+
+    async def json(self):
+        return self._body
+
+
+def ndjson(*lines: dict) -> list[bytes]:
+    """One chunk per line — the shape the browser's writer produces."""
+
+    return [(json.dumps(line) + "\n").encode() for line in lines]
+
+
+class _FakeTtsWs:
+    """A scripted ElevenLabs stream-input socket: records sends, yields frames."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.incoming: asyncio.Queue = asyncio.Queue()
+        self.closed = False
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        item = await self.incoming.get()
+        if item is StopAsyncIteration:
+            raise StopAsyncIteration
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def feed(self, frame: dict) -> None:
+        message = types.SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data=json.dumps(frame))
+        self.incoming.put_nowait(message)
+
+    def feed_audio(self, pcm: bytes) -> None:
+        self.feed({"audio": base64.b64encode(pcm).decode("ascii")})
+
+    def feed_final(self) -> None:
+        self.feed({"isFinal": True})
+
+
+class _FakeTtsModule:
+    """The two aiohttp members the cascade touches, with scripted sockets."""
+
+    WSMsgType = aiohttp.WSMsgType
+
+    def __init__(self) -> None:
+        self.dials: list[dict] = []
+        self.sockets: list[_FakeTtsWs] = []
+
+    def ClientSession(self):
+        module = self
+
+        class _Session:
+            async def ws_connect(self, url, headers=None, timeout=None):
+                ws = _FakeTtsWs()
+                module.dials.append({"url": url, "headers": headers})
+                module.sockets.append(ws)
+                return ws
+
+            async def close(self) -> None:
+                pass
+
+        return _Session()
+
+
+@pytest.fixture
+def tts(monkeypatch):
+    """Patch the cascade's ElevenLabs dial; return the scripted-module recorder."""
+
+    module = _FakeTtsModule()
+    monkeypatch.setattr(talk_cascade_voice, "_import_aiohttp", lambda: module)
+    return module
+
+
+async def _wait_for(condition, timeout: float = 2.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not condition():
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError("condition never became true")
+        await asyncio.sleep(0)
+
+
+async def _collect(response) -> bytes:
+    out = b""
+    async for chunk in response.body_iterator:
+        out += chunk
+    return out
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# -- the gate -----------------------------------------------------------------
+
+
+def test_cascade_route_refuses_a_remote_peer_without_a_token():
+    with pytest.raises(api.HTTPException) as excinfo:
+        _run(api.cascade_tts(StreamRequest([], host="203.0.113.9")))
+
+    assert excinfo.value.status_code == 403
+
+
+def test_cascade_route_demands_the_configured_token(monkeypatch):
+    monkeypatch.setenv(api.DASHBOARD_TOKEN_ENV, "s3cret")
+
+    with pytest.raises(api.HTTPException) as excinfo:
+        _run(api.cascade_tts(StreamRequest([])))
+
+    assert excinfo.value.status_code == 401
+
+
+# -- fail-closed config -------------------------------------------------------
+
+
+def test_cascade_route_refuses_when_the_server_is_not_in_cascade_mode(monkeypatch):
+    monkeypatch.delenv("TALK_VOICE_MODE", raising=False)
+
+    with pytest.raises(api.HTTPException) as excinfo:
+        _run(api.cascade_tts(StreamRequest([], headers={}, host="127.0.0.1")))
+
+    assert excinfo.value.status_code == 409
+    assert "TALK_VOICE_MODE" in str(excinfo.value.detail)
+
+
+def test_cascade_route_refuses_a_broken_knob_before_dialing(monkeypatch, tts):
+    monkeypatch.delenv("TALK_ELEVENLABS_VOICE_ID", raising=False)
+
+    with pytest.raises(api.HTTPException) as excinfo:
+        _run(api.cascade_tts(StreamRequest(ndjson({"delta": "hi"}))))
+
+    assert excinfo.value.status_code == 400
+    assert "TALK_ELEVENLABS_VOICE_ID" in str(excinfo.value.detail)
+    assert tts.dials == []  # refused before a secret or socket was spent
+
+
+def test_cascade_route_refuses_a_non_openai_provider(monkeypatch, tts):
+    monkeypatch.setenv("TALK_PROVIDER", "grok")
+
+    with pytest.raises(api.HTTPException) as excinfo:
+        _run(api.cascade_tts(StreamRequest(ndjson({"delta": "hi"}))))
+
+    assert excinfo.value.status_code == 400
+    assert "grok" in str(excinfo.value.detail)
+    assert tts.dials == []
+
+
+# -- the stream lifecycle -----------------------------------------------------
+
+
+def test_deltas_stream_through_the_cascade_and_pcm_comes_back(tts):
+    pcm_one = b"\x01\x02" * 480
+    pcm_two = b"\x03\x04" * 480
+
+    async def scenario():
+        body = ndjson(
+            {"delta": "First sentence. "},
+            {"delta": "Second one. "},
+            {"done": "First sentence. Second one."},
+        )
+        response = await api.cascade_tts(StreamRequest(body))
+        assert response.media_type == api.CASCADE_PCM_MEDIA_TYPE
+
+        async def script_upstream():
+            await _wait_for(lambda: len(tts.sockets) == 1)
+            ws = tts.sockets[0]
+            await _wait_for(lambda: len(ws.sent) == 4)  # BOS, two chunks, EOS
+            ws.feed_audio(pcm_one)
+            ws.feed_audio(pcm_two)
+            ws.feed_final()
+
+        upstream = asyncio.create_task(script_upstream())
+        collected = await _collect(response)
+        await upstream
+
+        ws = tts.sockets[0]
+        assert [m.get("text") for m in ws.sent] == [
+            " ",
+            "First sentence.",
+            "Second one.",
+            "",
+        ]
+        # The key rode the xi-api-key header only — never the URL, and never
+        # the response: the browser sees PCM bytes and nothing else.
+        assert tts.dials[0]["headers"] == {"xi-api-key": FAKE_KEY}
+        assert FAKE_KEY not in tts.dials[0]["url"]
+        assert FAKE_KEY.encode() not in collected
+        assert collected == pcm_one + pcm_two
+
+    _run(scenario())
+
+
+def test_an_aborted_stream_cancels_the_tts_instead_of_flushing(tts):
+    """EOF without `done` is a barge-in: the interrupted answer dies quietly."""
+
+    async def scenario():
+        hold = asyncio.Event()
+        body = ndjson({"delta": "An answer the operator talks over. "})
+        response = await api.cascade_tts(StreamRequest(body, hold=hold))
+        collected = bytearray()
+
+        async def drain():
+            async for chunk in response.body_iterator:
+                collected.extend(chunk)
+
+        drainer = asyncio.create_task(drain())
+        await _wait_for(lambda: len(tts.sockets) == 1)
+        ws = tts.sockets[0]
+        await _wait_for(lambda: len(ws.sent) == 2)  # BOS + chunk, never EOS
+        pcm = b"\x00\x01" * 240
+        ws.feed_audio(pcm)
+        await _wait_for(lambda: bytes(collected) == pcm)
+
+        hold.set()  # the barge-in: the request stream ends with no `done`
+        await asyncio.wait_for(drainer, 2)
+
+        assert ws.closed, "the aborted response's TTS stream was left open"
+        assert len(ws.sent) == 2, "EOS went out for an interrupted answer"
+        # Audio emitted before the abort point was already on the wire; the
+        # rest of the answer never left the TTS socket.
+        assert bytes(collected) == pcm
+
+    _run(scenario())
+
+
+def test_a_malformed_line_cancels_the_answer_and_logs_one_receipt(tts, caplog):
+    async def scenario():
+        hold = asyncio.Event()
+        body = ndjson({"delta": "Half an answer. "})
+        tail = [
+            b"this is not json\n",
+            b'{"delta": "tail that must never be spoken. "}\n',
+            b'{"done": "Half an answer."}\n',
+        ]
+        with caplog.at_level("WARNING", logger="hermes_dashboard_plugin_hermes_talk"):
+            response = await api.cascade_tts(StreamRequest(body, tail=tail, hold=hold))
+            collected = bytearray()
+
+            async def drain():
+                async for chunk in response.body_iterator:
+                    collected.extend(chunk)
+
+            drainer = asyncio.create_task(drain())
+            await _wait_for(lambda: len(tts.sockets) == 1)
+            ws = tts.sockets[0]
+            await _wait_for(lambda: len(ws.sent) == 2)
+            pcm = b"\x01\x00" * 240
+            ws.feed_audio(pcm)
+            await _wait_for(lambda: bytes(collected) == pcm)
+
+            hold.set()  # now the garbage line arrives
+            await asyncio.wait_for(drainer, 2)
+
+            assert ws.closed
+            assert len(ws.sent) == 2, "the tail after the malformed line was spoken"
+            assert bytes(collected) == pcm  # audio up to the break, then end
+
+    _run(scenario())
+    assert any("malformed" in record.getMessage() for record in caplog.records)
+
+
+def test_an_oversized_line_is_malformed_input(tts, caplog):
+    body = [b'{"delta": "' + b"x" * (api.CASCADE_MAX_LINE_BYTES + 16) + b'"}']
+
+    async def scenario():
+        with caplog.at_level("WARNING", logger="hermes_dashboard_plugin_hermes_talk"):
+            response = await api.cascade_tts(StreamRequest(body))
+            return await _collect(response)
+
+    collected = _run(scenario())
+
+    assert collected == b""
+    assert tts.dials == []  # nothing speakable ever reached the cascade
+
+
+def test_a_whitespace_only_answer_closes_without_dialing(tts):
+    async def scenario():
+        body = ndjson({"done": "   "})
+        response = await api.cascade_tts(StreamRequest(body))
+        return await _collect(response)
+
+    assert _run(scenario()) == b""
+    assert tts.dials == []
+
+
+def test_a_tts_failure_ends_the_stream_without_an_http_error(tts):
+    """Upstream TTS trouble degrades the answer to text-only — never a 5xx."""
+
+    async def scenario():
+        body = ndjson({"delta": "This answer loses its voice. "}, {"done": "x"})
+        response = await api.cascade_tts(StreamRequest(body))
+
+        async def watch():
+            await _wait_for(lambda: len(tts.sockets) == 1)
+            tts.sockets[0].feed({"error": "upstream said no"})
+
+        watcher = asyncio.create_task(watch())
+        collected = await _collect(response)
+        await watcher
+        return collected
+
+    assert _run(scenario()) == b""  # zero audio, clean end — text stays on screen
+
+
+# -- the mint's cascade shape ---------------------------------------------------
+
+
+@pytest.fixture
+def minted(monkeypatch):
+    """Replace the ONE network call, and record the session it was handed."""
+
+    seen: dict = {}
+
+    def fake_post(auth_token: str, session: dict) -> dict:
+        seen["auth_token"] = auth_token
+        seen["session"] = session
+        return {"value": "ek_dashboard_cascade_test", "expires_at": 1_700_000_000}
+
+    import talk_wire
+
+    monkeypatch.setattr(talk_wire, "post_client_secret", fake_post)
+    return seen
+
+
+def test_cascade_mint_requests_text_output_and_names_the_mode(minted):
+    body = _run(api.create_session(JsonRequest()))
+
+    assert body["ok"] is True
+    assert body["voiceMode"] == "cascade"
+    assert body["voice"] == ""  # no provider voice exists in text-output mode
+    session = minted["session"]
+    assert session["output_modalities"] == ["text"]
+    assert "output" not in session["audio"]
+    # Listening is untouched: input audio, VAD, and transcription all stay.
+    assert session["audio"]["input"]["turn_detection"]["type"] == "server_vad"
+    # The cascade key was resolved but never left the process.
+    assert FAKE_KEY not in serialized(body)
+    assert FAKE_KEY not in serialized(session)
+
+
+def test_cascade_mint_ignores_the_provider_voice_param(minted):
+    """The select is disabled in cascade mode; a stale voice must not 400."""
+
+    body = _run(api.create_session(JsonRequest({"voice": "gilbert"})))
+
+    assert body["ok"] is True
+    assert body["voiceMode"] == "cascade"
+
+
+def test_cascade_mint_refuses_broken_config_before_spending_a_secret(minted, monkeypatch):
+    monkeypatch.delenv("TALK_ELEVENLABS_API_KEY", raising=False)
+
+    with pytest.raises(api.HTTPException) as excinfo:
+        _run(api.create_session(JsonRequest()))
+
+    assert excinfo.value.status_code == 400
+    assert "TALK_ELEVENLABS_API_KEY" in str(excinfo.value.detail)
+    assert minted == {}  # no ephemeral secret was spent on a refused config
+
+
+def test_native_mint_is_untouched_by_the_cascade_knob(minted, monkeypatch):
+    monkeypatch.delenv("TALK_VOICE_MODE", raising=False)
+
+    body = _run(api.create_session(JsonRequest()))
+
+    assert body["voiceMode"] == "native"
+    assert "output_modalities" not in minted["session"]
+    assert minted["session"]["audio"]["output"] == {"voice": talk_config.DEFAULT_TALK_VOICE}
+
+
+def test_status_reports_the_voice_mode():
+    body = _run(api.talk_status(JsonRequest()))
+    assert body["voiceMode"] == "cascade"
+    assert FAKE_KEY not in serialized(body)
+
+
+def test_status_defaults_to_native(monkeypatch):
+    monkeypatch.delenv("TALK_VOICE_MODE", raising=False)
+
+    body = _run(api.talk_status(JsonRequest()))
+    assert body["voiceMode"] == "native"

--- a/tests/test_dashboard_js.py
+++ b/tests/test_dashboard_js.py
@@ -90,3 +90,171 @@ const waitFor = async (predicate, timeoutMs = 1000) => {
         check=False,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_dashboard_cascade_relays_text_and_plays_pcm_until_barge_in():
+    """The cascade transport: NDJSON out, PCM onto the AudioContext, abort kills both."""
+
+    script = r"""
+const fs = require("fs");
+const vm = require("vm");
+const source = fs.readFileSync(process.argv[1], "utf8");
+const posted = [];      // NDJSON lines the transport wrote into request bodies
+const fetches = [];     // every cascade fetch: {signal, bodyLines}
+const scheduled = [];   // AudioBufferSourceNodes started on the fake context
+const stopped = [];     // sources stop()ed (barge-in / teardown)
+
+class FakeAudioContext {
+  constructor() { this.currentTime = 0; this.destination = {}; }
+  createBuffer(channels, length, sampleRate) {
+    if (channels !== 1 || sampleRate !== 24000) throw new Error("wrong PCM shape");
+    const data = new Float32Array(length);
+    return { duration: length / sampleRate, getChannelData: (i) => data };
+  }
+  createBufferSource() {
+    const node = {
+      buffer: null,
+      startedAt: -1,
+      connect() {},
+      start(at) { this.startedAt = at; scheduled.push(this); },
+      stop() { stopped.push(this); },
+    };
+    return node;
+  }
+  close() { return Promise.resolve(); }
+}
+
+// One scripted fetch per POST: capture the request stream, answer with a
+// response body the test drives later.
+const pendingResponses = [];
+const fetchStub = (url, opts) => {
+  const entry = { url, opts, aborted: false, lines: posted };
+  opts.signal.addEventListener("abort", () => { entry.aborted = true; });
+  fetches.push(entry);
+  (async () => {
+    const reader = opts.body.getReader();
+    for (;;) {
+      const step = await reader.read();
+      if (step.done) break;
+      const text = new TextDecoder().decode(step.value);
+      text.split("\n").filter((line) => line).forEach((line) => {
+        posted.push(JSON.parse(line));
+      });
+    }
+  })().catch(() => {});
+  return new Promise((resolve) => pendingResponses.push(resolve));
+};
+
+const window = {
+  __HERMES_TALK_TEST_HOOK__: true,
+  __HERMES_PLUGINS__: { register() {} },
+  __HERMES_PLUGIN_SDK__: {
+    React: { createElement() {} },
+    hooks: { useState() {}, useEffect() {}, useRef() {}, useCallback() {} },
+    components: {},
+  },
+  sessionStorage: { getItem() { return ""; } },
+  setTimeout,
+  clearTimeout,
+  AudioContext: FakeAudioContext,
+};
+const context = {
+  window, setTimeout, clearTimeout, AbortController, ReadableStream,
+  TextDecoder, TextEncoder, Uint8Array, Int16Array, Float32Array, JSON, console,
+  fetch: fetchStub, Promise,
+};
+vm.runInNewContext(source, context, { filename: "index.js" });
+const Transport = window.__HERMES_TALK_TEST__.TalkTransport;
+const waitFor = async (predicate, timeoutMs = 1000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("timed out waiting for cascade transport");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+};
+const respond = (pcmChunks) => {
+  const stream = new ReadableStream({
+    start(controller) {
+      pcmChunks.forEach((pcm) => controller.enqueue(pcm));
+      controller.close();
+    },
+  });
+  pendingResponses.shift()({ ok: true, body: stream });
+};
+(async () => {
+  const transcripts = [];
+  const transport = new Transport(
+    { voiceMode: "cascade" },
+    {
+      onStatus() {},
+      onError() {},
+      onTranscript: (role, text, final) => transcripts.push({ role, text, final }),
+    },
+  );
+  transport.channel = { readyState: "open", send() {} };
+
+  // Text deltas caption AND relay; the done line closes the request side.
+  const send = (event) => transport.handleEvent(JSON.stringify(event));
+  send({ type: "response.created", response: { id: "r1" } });
+  send({ type: "response.output_text.delta", delta: "Hello " });
+  send({ type: "response.output_text.delta", delta: "dashboard. " });
+  send({ type: "response.output_text.done", text: "Hello dashboard." });
+  await waitFor(() => fetches.length === 1);
+  const relayUrl = "/api/plugins/hermes-talk/cascade-tts";
+  if (fetches[0].url !== relayUrl) throw new Error("wrong relay url: " + fetches[0].url);
+  if (fetches[0].opts.duplex !== "half") throw new Error("relay must stream duplex");
+  await waitFor(() => posted.length === 3);
+  if (JSON.stringify(posted) !== JSON.stringify([
+    { delta: "Hello " }, { delta: "dashboard. " }, { done: "Hello dashboard." },
+  ])) throw new Error("wrong NDJSON relay: " + JSON.stringify(posted));
+  const finalCaption = transcripts.some(
+    (t) => t.role === "assistant" && t.final && t.text === "Hello dashboard.",
+  );
+  if (!finalCaption) throw new Error("final caption missing: " + JSON.stringify(transcripts));
+
+  // The PCM answer plays through the AudioContext at 24kHz mono.
+  const pcm = new Uint8Array(960);  // one 20ms frame of 24k mono s16le
+  pcm[0] = 7;
+  // Split mid-SAMPLE (odd byte): carrying the straggler is the transport's job.
+  respond([pcm.slice(0, 501), pcm.slice(501)]);
+  await waitFor(() => scheduled.length === 2);
+  const totalSamples = scheduled[0].buffer.getChannelData(0).length +
+    scheduled[1].buffer.getChannelData(0).length;
+  if (totalSamples !== 480) throw new Error("wrong sample count: " + totalSamples);
+  // Gapless: the second buffer starts exactly where the first ends.
+  const expectedStart = scheduled[0].startedAt + scheduled[0].buffer.duration;
+  if (Math.abs(scheduled[1].startedAt - expectedStart) > 1e-9) {
+    throw new Error("PCM playback is not gapless");
+  }
+
+  // Barge-in: the next fetch is aborted and every scheduled source stops.
+  send({ type: "response.created", response: { id: "r2" } });
+  send({ type: "response.output_text.delta", delta: "Second answer. " });
+  await waitFor(() => fetches.length === 2);
+  send({ type: "input_audio_buffer.speech_started" });
+  if (!fetches[1].aborted) throw new Error("barge-in did not abort the relay fetch");
+  if (stopped.length < 1) throw new Error("barge-in did not stop scheduled playback");
+
+  // A native session never touches the relay.
+  const native = new Transport(
+    { voiceMode: "native" },
+    { onStatus() {}, onError() {}, onTranscript() {} },
+  );
+  native.channel = { readyState: "open", send() {} };
+  native.handleEvent(
+    JSON.stringify({ type: "response.output_text.delta", delta: "ignored " }),
+  );
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  if (fetches.length !== 2) throw new Error("native mode dialed the cascade relay");
+  process.exit(0);
+})().catch((error) => { console.error(error); process.exit(1); });
+"""
+    completed = run(
+        ["node", "-e", script, str(DASHBOARD_JS)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/tests/test_discord_cascade.py
+++ b/tests/test_discord_cascade.py
@@ -1,0 +1,361 @@
+"""Discord lane cascade wiring — the voice channel speaks ElevenLabs PCM.
+
+The Discord lane enters the SAME ``run_talk_session`` the terminal uses
+(``talk_discord.start_session`` passes ``audio=DiscordAudio(...),
+lane="discord"``), so the cascade wiring shipped for the terminal — fail-closed
+config, ``SessionSetup(text_output=True)``, observe-before-relay, ``aclose()``
+at teardown — already covers the room by construction. What could still break
+silently is the ROOM side, and that is what this file proves end to end:
+
+- cascade PCM24k lands on the host's player source through the real
+  ``DiscordAudio.queue_playback`` conversion (24k mono -> 48k stereo),
+- a barge-in aborts the in-flight TTS stream and drains the channel's queue,
+- teardown leaves no cascade task running,
+- a non-OpenAI provider refuses before the voice channel is touched, and
+- native mode never dials ElevenLabs.
+
+No network, no real keys: the ElevenLabs leg is a scripted fake socket behind
+the ``talk_cascade_voice._import_aiohttp`` seam, the provider is the
+provider-neutral offline fake, and the voice channel is the wired fake host
+from ``test_discord``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import types
+
+import aiohttp
+import fake_realtime as fr
+import pytest
+from test_discord import _tone, _wired_host
+from test_fake_provider_session import FakeProviderSession
+
+import talk_cascade_voice
+import talk_cli
+import talk_discord
+import talk_realtime as rt
+
+FAKE_KEY = "fake-elevenlabs-key-for-tests"
+FAKE_VOICE_ID = "fakeVoiceId0001"
+
+
+@pytest.fixture(autouse=True)
+def _offline_discord(monkeypatch, tmp_path):
+    """Offline session plumbing plus a hermetic cascade env on a keyed box."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
+    for name in (
+        "TALK_ELEVENLABS_API_KEY",
+        "ELEVENLABS_API_KEY",
+        "TALK_ELEVENLABS_VOICE_ID",
+        "TALK_VOICE_MODE",
+        "TALK_CASCADE_TTS",
+        "TALK_ELEVENLABS_MODEL",
+        "TALK_PROVIDER",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    host = types.SimpleNamespace(
+        resolve_auth=lambda: types.SimpleNamespace(token="token", source="fake-auth"),
+        identity_sections=lambda: {},
+    )
+    monkeypatch.setattr(talk_cli.talk_host, "host", lambda: host)
+    monkeypatch.setattr(talk_cli.talk_apiserver, "warm_in_background", lambda: None)
+    monkeypatch.setattr(talk_cli.talk_lifecycle, "attach_session", lambda *_args: None)
+    monkeypatch.setattr(talk_cli.talk_lifecycle, "detach_session", lambda: None)
+    monkeypatch.setattr(talk_cli.talk_progress, "attach_session", lambda *_args: None)
+    monkeypatch.setattr(talk_cli.talk_progress, "detach_session", lambda: None)
+    monkeypatch.setattr(talk_cli.talk_steer, "set_landed_notifier", lambda _value: None)
+    yield
+    talk_discord.reset_for_tests()
+
+
+def _cascade_env(monkeypatch) -> None:
+    monkeypatch.setenv("TALK_VOICE_MODE", "cascade")
+    monkeypatch.setenv("TALK_ELEVENLABS_API_KEY", FAKE_KEY)
+    monkeypatch.setenv("TALK_ELEVENLABS_VOICE_ID", FAKE_VOICE_ID)
+
+
+async def _wait_for(condition, timeout: float = 2.0) -> None:
+    """Poll the loop until ``condition`` holds; fail the test if it never does."""
+
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not condition():
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError("condition never became true")
+        await asyncio.sleep(0)
+
+
+class _FakeTtsWs:
+    """A scripted ElevenLabs stream-input socket: records sends, yields frames."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.incoming: asyncio.Queue = asyncio.Queue()
+        self.closed = False
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        item = await self.incoming.get()
+        if item is StopAsyncIteration:
+            raise StopAsyncIteration
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    async def close(self) -> None:
+        self.closed = True
+
+    # -- test scripting -------------------------------------------------------
+
+    def feed(self, frame: dict) -> None:
+        message = types.SimpleNamespace(
+            type=aiohttp.WSMsgType.TEXT, data=json.dumps(frame)
+        )
+        self.incoming.put_nowait(message)
+
+    def feed_audio(self, pcm: bytes) -> None:
+        self.feed({"audio": base64.b64encode(pcm).decode("ascii")})
+
+    def feed_final(self) -> None:
+        self.feed({"isFinal": True})
+
+
+class _FakeTtsModule:
+    """The two aiohttp members the cascade touches, with scripted sockets.
+
+    ``WSMsgType`` stays the REAL enum so the reader's frame-type checks run
+    unchanged; ``ClientSession`` hands out fake sockets and records each dial.
+    """
+
+    WSMsgType = aiohttp.WSMsgType
+
+    def __init__(self) -> None:
+        self.dials: list[dict] = []
+        self.sockets: list[_FakeTtsWs] = []
+
+    def ClientSession(self):
+        module = self
+
+        class _Session:
+            async def ws_connect(self, url, headers=None, timeout=None):
+                ws = _FakeTtsWs()
+                module.dials.append({"url": url, "headers": headers})
+                module.sockets.append(ws)
+                return ws
+
+            async def close(self) -> None:
+                pass
+
+        return _Session()
+
+
+class _HeldProvider(FakeProviderSession):
+    """Terminate only once ``until`` says the cascade leg has settled.
+
+    A plain FakeProviderSession ends the moment its scripted events drain,
+    which would tear the session down before the TTS stream finished speaking.
+    The wait is bounded (~5s), so a broken cascade fails the assertions instead
+    of hanging the suite.
+    """
+
+    def __init__(self, events, *, until) -> None:
+        super().__init__(events)
+        self._until = until
+
+    async def __anext__(self):
+        if not self.events and not self._terminal_emitted and not self._until():
+            for _ in range(500):
+                await asyncio.sleep(0.01)
+                if self.events or self._until():
+                    break
+        return await super().__anext__()
+
+
+def _no_leaked_tasks() -> None:
+    current = asyncio.current_task()
+    leaked = [task for task in asyncio.all_tasks() if task is not current and not task.done()]
+    assert leaked == [], f"session teardown left tasks running: {leaked}"
+
+
+def test_cascade_pcm_reaches_the_voice_channel_through_real_discord_audio(monkeypatch):
+    async def scenario():
+        _connection, _receiver, vc, _adapter = _wired_host(monkeypatch)
+        _cascade_env(monkeypatch)
+        tts = _FakeTtsModule()
+        monkeypatch.setattr(talk_cascade_voice, "_import_aiohttp", lambda: tts)
+
+        audio = talk_discord.DiscordAudio(7)
+        fake = _HeldProvider(
+            [
+                rt.SessionReady(session_id="session-1"),
+                rt.ResponseStarted(response_id="resp-1"),
+                fr.rt_transcript_delta("Hello Discord. ", response_id="resp-1"),
+                fr.rt_transcript_done("Hello Discord.", response_id="resp-1"),
+                rt.ResponseFinished(response_id="resp-1"),
+            ],
+            until=lambda: bool(tts.sockets) and tts.sockets[0].closed,
+        )
+        task = asyncio.create_task(
+            talk_cli.run_talk_session(
+                audio=audio, session_factory=lambda _auth: fake, lane="discord"
+            )
+        )
+        await _wait_for(lambda: vc.playing is not None)
+        source = vc.playing  # the host's player source; survives audio.stop()
+        await _wait_for(lambda: len(tts.sockets) == 1)
+        ws = tts.sockets[0]
+        await _wait_for(lambda: len(ws.sent) == 3)
+        # BOS, the one sentence chunk, EOS — and the key rode only the header.
+        assert ws.sent[1] == {"text": "Hello Discord.", "try_trigger_generation": True}
+        assert ws.sent[2] == {"text": ""}
+        assert tts.dials[0]["headers"] == {"xi-api-key": FAKE_KEY}
+        assert FAKE_KEY not in tts.dials[0]["url"]
+
+        # One 20 ms session-rate frame (480 samples of a 440 Hz tone).
+        pcm24 = _tone(480, rate=24_000)
+        ws.feed_audio(pcm24)
+        ws.feed_final()
+        result = await asyncio.wait_for(task, 3)
+
+        assert result == 0
+        # The provider session opened in text-output mode....
+        assert fake.setup.text_output is True
+        # ...and the cascade's PCM took the relay's exact path into the room:
+        # the same 24k mono -> 48k stereo conversion, one Discord frame out.
+        frame = source.read()
+        expected, _carry = talk_discord.session_to_discord(pcm24)
+        assert frame == expected
+        assert len(frame) == talk_discord.DISCORD_FRAME_BYTES
+        assert frame != talk_discord.SILENCE_FRAME
+        # Nothing else was ever queued — the next read is synthesized silence.
+        assert source.read() == talk_discord.SILENCE_FRAME
+        _no_leaked_tasks()  # aclose() stopped the cascade worker at teardown
+
+    asyncio.run(scenario())
+
+
+def test_barge_in_aborts_the_tts_stream_and_drains_the_channel(monkeypatch):
+    async def scenario():
+        _connection, _receiver, vc, _adapter = _wired_host(monkeypatch)
+        _cascade_env(monkeypatch)
+        tts = _FakeTtsModule()
+        monkeypatch.setattr(talk_cascade_voice, "_import_aiohttp", lambda: tts)
+
+        audio = talk_discord.DiscordAudio(7)
+        fake = _HeldProvider(
+            [
+                rt.SessionReady(session_id="session-1"),
+                rt.ResponseStarted(response_id="resp-1"),
+                fr.rt_transcript_delta("A long answer begins. ", response_id="resp-1"),
+            ],
+            until=lambda: bool(tts.sockets) and tts.sockets[0].closed,
+        )
+        task = asyncio.create_task(
+            talk_cli.run_talk_session(
+                audio=audio, session_factory=lambda _auth: fake, lane="discord"
+            )
+        )
+        await _wait_for(lambda: vc.playing is not None)
+        source = vc.playing
+        await _wait_for(lambda: len(tts.sockets) == 1)
+        ws = tts.sockets[0]
+        await _wait_for(lambda: len(ws.sent) == 2)  # BOS + first chunk, no EOS
+
+        # Cascade audio is queued for the room when the operator starts talking.
+        ws.feed_audio(_tone(480, rate=24_000))
+        await _wait_for(lambda: source._frames.qsize() >= 1)  # the player's queue
+        fake.events.append(rt.SpeechStarted(input_id="in-1", offset_ms=0))
+        fake.events.append(rt.ResponseFinished(response_id="resp-1"))
+        result = await asyncio.wait_for(task, 3)
+
+        assert result == 0
+        # The in-flight TTS stream died: no EOS went out, and nothing more may
+        # arrive from it (a cancelled sentence never speaks).
+        assert ws.closed
+        assert len(ws.sent) == 2
+        # The relay drained the channel in the same step: the queued frame is
+        # gone and the room hears only synthesized silence.
+        assert source.read() == talk_discord.SILENCE_FRAME
+        _no_leaked_tasks()
+
+    asyncio.run(scenario())
+
+
+def test_cascade_on_discord_refuses_a_non_openai_provider_before_the_channel(
+    monkeypatch, capsys
+):
+    async def scenario():
+        connection, _receiver, vc, _adapter = _wired_host(monkeypatch)
+        original = list(connection.callbacks)
+        monkeypatch.setenv("TALK_PROVIDER", "grok")
+        monkeypatch.setenv("XAI_API_KEY", "fake-xai-key")
+        _cascade_env(monkeypatch)
+        tts = _FakeTtsModule()
+        monkeypatch.setattr(talk_cascade_voice, "_import_aiohttp", lambda: tts)
+
+        audio = talk_discord.DiscordAudio(7)
+        result = await talk_cli.run_talk_session(
+            audio=audio, session_factory=lambda _auth: FakeProviderSession(), lane="discord"
+        )
+
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "grok" in err
+        assert "openai" in err
+        # The refusal fired before a secret was spent or the room was touched:
+        # no ElevenLabs dial, no tapped receiver, no player takeover.
+        assert tts.dials == []
+        assert list(connection.callbacks) == original
+        assert vc.playing is None
+        _no_leaked_tasks()
+
+    asyncio.run(scenario())
+
+
+def test_native_mode_discord_never_dials_elevenlabs(monkeypatch):
+    """TALK_VOICE_MODE unset: the room behaves exactly as before the cascade."""
+
+    async def scenario():
+        _connection, _receiver, vc, _adapter = _wired_host(monkeypatch)
+        tts = _FakeTtsModule()
+        monkeypatch.setattr(talk_cascade_voice, "_import_aiohttp", lambda: tts)
+        # Capture the player source at handoff — teardown clears vc.playing.
+        played_sources = []
+        real_play = vc.play
+        vc.play = lambda source: (played_sources.append(source), real_play(source))[1]
+
+        audio = talk_discord.DiscordAudio(7)
+        pcm24 = _tone(480, rate=24_000)
+        fake = FakeProviderSession(
+            [
+                rt.SessionReady(session_id="session-1"),
+                rt.ResponseStarted(response_id="resp-1"),
+                fr.rt_audio(pcm24, response_id="resp-1"),
+                fr.rt_transcript_done("Hello Discord.", response_id="resp-1"),
+                rt.ResponseFinished(response_id="resp-1"),
+            ]
+        )
+        result = await talk_cli.run_talk_session(
+            audio=audio, session_factory=lambda _auth: fake, lane="discord"
+        )
+
+        assert result == 0
+        assert fake.setup.text_output is False
+        # Provider audio took the same conversion path, and no TTS socket opened.
+        # (The relay queues provider audio synchronously inside event handling.)
+        expected, _carry = talk_discord.session_to_discord(pcm24)
+        assert played_sources, "the room never got a player source"
+        assert played_sources[0].read() == expected
+        assert tts.dials == []
+        _no_leaked_tasks()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## What

Takes the 0.13.0 custom-voice cascade (ElevenLabs streaming TTS, cloned voices) from terminal-only to every surface.

**Discord — proof, not wiring.** The lane already inherited the cascade by construction (`talk_discord.start_session` enters the shared `talk_cli.run_talk_session` with `DiscordAudio`). This PR pins the seams where a difference could silently break it: 24k→48k conversion through the real DiscordAudio surface, barge-in abort + drain, teardown, fail-closed provider gate. Mutation-checked: killing `cascade.handle_event` in the shared session fails these tests.

**Dashboard — server-side relay, key never leaves the process.** New `POST /api/plugins/hermes-talk/cascade-tts`: the browser streams the model's own text deltas as NDJSON; the route runs them through the same CascadeVoice and streams PCM24k back. Behind the existing `require_dashboard_auth` gate; the ElevenLabs key rides only the server-side `xi-api-key` header. Session mint sets `output_modalities: ["text"]` in cascade mode — no WebRTC surgery. The JS plays gapless PCM through an AudioContext with a playback generation fence (a chunk decoded before a barge-in never schedules after it), holds in-flight streams in a set (tool-call continuations can stream while the prior answer drains), and hides the provider-voice select in cascade sessions.

Feeder and drain run concurrently — a sequential first cut consumed the whole request before yielding PCM, which would have killed sentence pipelining; caught and rewritten. EOF without an explicit `done` (browser barge-in abort) or a malformed/oversized NDJSON line cancels the TTS: an interrupted answer never speaks.

## Tests / CI

- 25 new tests: Discord surface proof, relay auth gate (no token/remote = 403), NDJSON malformed/EOF-cancel paths, a Node test driving the real dashboard bundle (caught strings-vs-Uint8Array before a browser ever could), cascade hook tests.
- Suite: **1248 passed, 8 skipped** (pre-existing env gates), ruff clean, scanner traps respected.
- Not claimed: no live ElevenLabs/OpenAI call in tests (scripted fakes); the browser path is proven in Node against the real bundle, not a live browser — operator acceptance call covers it.

## Docs

README cascade surface table (terminal/Discord/dashboard), OPERATING relay contract note, CHANGELOG 0.14.0 (Unreleased). No new knobs — all lanes share `TALK_VOICE_MODE` + the ElevenLabs trio.