### PR TITLE
release: hermes-talk 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ but 0.4.0's release title named only the steering verb. They are recorded
 below under 0.4.0 — the first version that shipped them — with the gap
 named rather than smoothed.
 
-## 0.14.0 (Unreleased)
+## [0.14.0] — 2026-08-28
 
 The custom-voice cascade leaves the terminal: Discord rooms and the dashboard
 tab speak through ElevenLabs too.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-talk"
-version = "0.13.0"
+version = "0.14.0"
 description = "Realtime speech-to-speech voice for Hermes Agent — OpenAI, xAI Grok, or Gemini Live — duplex talk with live tool calling."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release 0.14.0: cascade voice on Discord + dashboard lanes (#77).

- pyproject 0.13.0 -> 0.14.0
- CHANGELOG finalized with date

On merge: tag v0.14.0 triggers publish.yml (OIDC -> PyPI).