### PR TITLE
feat(desktop): add renderer-owned Realtime Talk transport

### DIFF
--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -213,15 +213,16 @@ def _warm_agent_lane() -> str:
     return talk_host.host().agent_lane()
 
 
-def _mint(auth_token: str, voice: str, *, text_output: bool = False):
-    """Assemble instructions and mint. Blocking — called on a worker thread.
+def _mint(
+    auth_token: str,
+    voice: str,
+    *,
+    text_output: bool = False,
+    desktop_relay: bool = False,
+):
+    """Assemble instructions and mint. Blocking — called on a worker thread."""
 
-    ``text_output`` is the cascade lane: the minted session asks the provider
-    for TEXT output instead of synthesized audio, and the browser streams the
-    text deltas back through the cascade relay to be spoken server-side.
-    """
-
-    tools = talk_tools.default_talk_tools()
+    tools = [] if desktop_relay else talk_tools.default_talk_tools()
     return talk_wire.mint_ephemeral_session(
         auth_token=auth_token,
         model=talk_config.talk_model(),
@@ -230,11 +231,10 @@ def _mint(auth_token: str, voice: str, *, text_output: bool = False):
             talk_host.host().identity_sections(),
             tools=tools,
             lane="dashboard",
-            # The session route already paid for the catalog warm, so the
-            # live-catalog section reads a warm snapshot here.
-            capabilities=talk_capabilities.instruction_section(),
+            capabilities=(None if desktop_relay else talk_capabilities.instruction_section()),
         ),
         tools=tools,
+        automatic_response=not desktop_relay,
         text_output=text_output,
     )
 
@@ -326,7 +326,13 @@ async def create_session(request: Request) -> dict:
 
     require_dashboard_auth(request)
     body = await _json_body(request)
+    requested_mode = body.get("mode")
+    if requested_mode not in (None, "desktop-relay"):
+        raise HTTPException(status_code=400, detail="unsupported session mode")
+    desktop_relay = requested_mode == "desktop-relay"
     voice_mode = _resolve_voice_mode()
+    if desktop_relay and voice_mode != "native":
+        raise HTTPException(status_code=400, detail="desktop-relay requires native voice mode")
     text_output = voice_mode == "cascade"
     if text_output:
         # A cascade session has no provider voice to validate — the mint asks
@@ -353,6 +359,7 @@ async def create_session(request: Request) -> dict:
             auth.token,
             voice,
             text_output=text_output,
+            desktop_relay=desktop_relay,
         )
     except talk_wire.TalkWireError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -392,6 +399,7 @@ async def create_session(request: Request) -> dict:
         # provider's audio track; cascade relays text deltas to /cascade-tts
         # and plays the PCM that comes back.
         "voiceMode": voice_mode,
+        "mode": requested_mode or "dashboard",
     }
 
 

--- a/desktop/plugin.js
+++ b/desktop/plugin.js
@@ -1,0 +1,395 @@
+import { atom, Button, cn, haptic, host, icons, Tip, useComposerVoiceController, useValue } from '@hermes/plugin-sdk'
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
+
+const TIMEOUT_MS = 30_000
+const RENDER_INSTRUCTIONS =
+  "Speak the sole user input verbatim. Add, remove, or paraphrase nothing. Do not preface or explain."
+const IDLE = Object.freeze({ phase: 'idle', status: 'Realtime Talk', muted: false, error: '' })
+const $talk = atom(IDLE)
+
+let pluginContext = null
+let transport = null
+let startGeneration = 0
+let activeController = null
+const releasedControllers = new WeakSet()
+
+function errorText(error) {
+  if (error instanceof Error && error.message) return error.message
+  if (error && typeof error === 'object' && typeof error.detail === 'string') return error.detail
+  return String(error || 'Realtime Talk failed.')
+}
+
+function releaseController(controller = activeController) {
+  if (!controller || releasedControllers.has(controller)) return
+  if (activeController === controller) activeController = null
+  releasedControllers.add(controller)
+  controller.release?.()
+}
+
+function clearTransport(instance) {
+  if (transport === instance) transport = null
+}
+
+function cleanupStaleStart(instance, controller) {
+  instance.stop()
+  clearTransport(instance)
+  releaseController(controller)
+}
+
+function stopTalk() {
+  startGeneration += 1
+  transport?.stop()
+  transport = null
+  releaseController()
+  $talk.set(IDLE)
+}
+
+async function startTalk(voiceController) {
+  if (transport || $talk.get().phase === 'starting') {
+    stopTalk()
+    return
+  }
+
+  const generation = ++startGeneration
+  $talk.set({ ...IDLE, phase: 'starting', status: 'Connecting…' })
+  let lease = null
+  try {
+    if (!pluginContext) throw new Error('Realtime Talk plugin is not ready.')
+    if (typeof RTCPeerConnection === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      throw new Error('Realtime audio is not supported by this Desktop build.')
+    }
+
+    lease = await voiceController?.acquire()
+    if (!lease) throw new Error('The microphone is unavailable.')
+    if (generation !== startGeneration) {
+      releaseController(lease)
+      return
+    }
+    activeController = lease
+
+    const session = await pluginContext.rest('/session', {
+      method: 'POST',
+      body: { mode: 'desktop-relay' },
+      timeoutMs: TIMEOUT_MS
+    })
+    if (generation !== startGeneration) {
+      releaseController(lease)
+      return
+    }
+    if (!session?.clientSecret || !session?.offerUrl || session.mode !== 'desktop-relay') {
+      throw new Error('The backend does not support canonical Desktop Realtime Talk.')
+    }
+
+    const next = new DesktopTalkTransport(session, voiceController, {
+      onState: status => $talk.set({ ...$talk.get(), phase: 'active', status, error: '' }),
+      onError: message => {
+        host.notifyError(new Error(message), 'Realtime Talk stopped')
+        stopTalk()
+      }
+    })
+    transport = next
+    await next.start()
+    if (generation !== startGeneration) {
+      cleanupStaleStart(next, lease)
+      return
+    }
+    $talk.set({ ...$talk.get(), phase: 'active', status: 'Listening…', error: '' })
+  } catch (error) {
+    if (generation !== startGeneration) {
+      releaseController(lease)
+      return
+    }
+    transport?.stop()
+    transport = null
+    releaseController(lease)
+    $talk.set({ ...IDLE, phase: 'error', status: 'Realtime unavailable', error: errorText(error) })
+    host.notifyError(error, 'Realtime Talk unavailable')
+  }
+}
+
+function toggleMute() {
+  if (!transport) return
+  const muted = !transport.muted
+  transport.setMuted(muted)
+  $talk.set({ ...$talk.get(), muted, status: muted ? 'Muted' : 'Listening…' })
+}
+
+class DesktopTalkTransport {
+  constructor(session, controller, callbacks) {
+    this.session = session
+    this.controller = controller
+    this.callbacks = callbacks
+    this.peer = null
+    this.channel = null
+    this.media = null
+    this.audio = null
+    this.offerAbort = null
+    this.unsubscribeAssistant = null
+    this.closed = false
+    this.muted = false
+    this.responseActive = false
+    this.playbackActive = false
+    this.responseId = null
+    this.latestSpeechItemId = null
+    this.waitingForAssistant = false
+    this.baselineAssistantId = null
+    this.lastSpokenAssistantId = null
+    this.turnGeneration = 0
+    this.pendingText = null
+    this.turnPump = null
+    this.activeTurnGeneration = null
+    this.interruptPromise = null
+    this.channelOpenPromise = null
+  }
+
+  async start() {
+    const peer = new RTCPeerConnection()
+    this.peer = peer
+    const audio = document.createElement('audio')
+    audio.autoplay = true
+    audio.style.display = 'none'
+    document.body.appendChild(audio)
+    this.audio = audio
+    peer.addEventListener('track', event => {
+      if (this.audio && event.streams[0]) this.audio.srcObject = event.streams[0]
+    })
+    peer.addEventListener('connectionstatechange', () => {
+      if (!this.closed && ['failed', 'closed'].includes(peer.connectionState)) {
+        this.callbacks.onError('Realtime connection closed.')
+      }
+    })
+
+    const media = await navigator.mediaDevices.getUserMedia({
+      audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true }
+    })
+    if (this.closed) {
+      media.getTracks().forEach(track => track.stop())
+      return
+    }
+    this.media = media
+    media.getAudioTracks().forEach(track => peer.addTrack(track, media))
+
+    const channel = peer.createDataChannel('oai-events')
+    this.channel = channel
+    this.channelOpenPromise = new Promise((resolve, reject) => {
+      const timer = window.setTimeout(() => reject(new Error('Realtime event channel did not open.')), TIMEOUT_MS)
+      channel.addEventListener('open', () => {
+        window.clearTimeout(timer)
+        this.callbacks.onState('Listening…')
+        resolve()
+      }, { once: true })
+      channel.addEventListener('close', () => {
+        window.clearTimeout(timer)
+        if (!this.closed) reject(new Error('Realtime event channel closed during setup.'))
+      }, { once: true })
+    })
+    channel.addEventListener('message', event => this.handleEvent(event.data))
+    channel.addEventListener('close', () => {
+      if (!this.closed) this.callbacks.onError('Realtime event channel closed.')
+    })
+    this.unsubscribeAssistant = this.controller.subscribeAssistant(response => this.handleAssistantResponse(response))
+
+    const offer = await peer.createOffer()
+    await peer.setLocalDescription(offer)
+    const answer = await this.postOffer(offer)
+    if (this.closed) return
+    await peer.setRemoteDescription({ type: 'answer', sdp: answer })
+    await this.channelOpenPromise
+  }
+
+  async postOffer(offer) {
+    const controller = new AbortController()
+    this.offerAbort = controller
+    const timer = window.setTimeout(() => controller.abort(), TIMEOUT_MS)
+    try {
+      const response = await fetch(this.session.offerUrl, {
+        method: 'POST', body: offer.sdp,
+        headers: { Authorization: `Bearer ${this.session.clientSecret}`, 'Content-Type': 'application/sdp' },
+        signal: controller.signal
+      })
+      if (!response.ok) throw new Error(`Realtime WebRTC setup failed (${response.status}).`)
+      return response.text()
+    } finally {
+      window.clearTimeout(timer)
+      if (this.offerAbort === controller) this.offerAbort = null
+    }
+  }
+
+  stop() {
+    if (this.closed) return
+    this.closed = true
+    this.turnGeneration += 1
+    this.pendingText = null
+    this.offerAbort?.abort()
+    this.offerAbort = null
+    this.unsubscribeAssistant?.()
+    this.unsubscribeAssistant = null
+    this.channel?.close()
+    this.channel = null
+    this.peer?.close()
+    this.peer = null
+    this.media?.getTracks().forEach(track => track.stop())
+    this.media = null
+    if (this.audio) {
+      this.audio.srcObject = null
+      this.audio.remove()
+    }
+    this.audio = null
+  }
+
+  setMuted(muted) {
+    this.muted = muted
+    this.media?.getAudioTracks().forEach(track => { track.enabled = !muted })
+  }
+
+  send(payload) {
+    if (this.closed || this.channel?.readyState !== 'open') return false
+    this.channel.send(JSON.stringify(payload))
+    return true
+  }
+
+  handleEvent(data) {
+    if (this.closed) return
+    let event
+    try { event = JSON.parse(String(data)) } catch { return }
+    switch (event.type) {
+      case 'conversation.item.input_audio_transcription.completed': {
+        const text = typeof event.transcript === 'string' ? event.transcript.trim() : ''
+        if (event.item_id && event.item_id !== this.latestSpeechItemId) break
+        if (text) void this.submitText(text)
+        break
+      }
+      case 'input_audio_buffer.speech_started':
+        this.latestSpeechItemId = event.item_id || null
+        this.turnGeneration += 1
+        this.pendingText = null
+        this.waitingForAssistant = false
+        this.activeTurnGeneration = null
+        this.callbacks.onState('Listening…')
+        if (this.responseActive && this.responseId) this.send({ type: 'response.cancel', response_id: this.responseId })
+        if (this.playbackActive) {
+          this.send({ type: 'output_audio_buffer.clear' })
+        }
+        if (!this.interruptPromise) {
+          this.interruptPromise = Promise.resolve(this.controller.interrupt()).finally(() => { this.interruptPromise = null })
+        }
+        break
+      case 'input_audio_buffer.speech_stopped': this.callbacks.onState('Transcribing…'); break
+      case 'response.created':
+        this.responseActive = true
+        this.responseId = event.response?.id || null
+        this.callbacks.onState('Speaking…')
+        break
+      case 'response.done':
+        this.responseActive = false
+        this.callbacks.onState('Listening…')
+        break
+      case 'output_audio_buffer.started': this.playbackActive = true; break
+      case 'output_audio_buffer.stopped':
+      case 'output_audio_buffer.cleared':
+        this.playbackActive = false
+        this.responseId = null
+        break
+      case 'error': {
+        const detail = String(event.error?.message || event.error?.code || event.error?.type || '')
+        if (!detail.toLowerCase().includes('no active response')) this.callbacks.onError(detail ? `Realtime error: ${detail}` : 'Realtime error.')
+        break
+      }
+      default: break
+    }
+  }
+
+  submitText(text) {
+    const generation = ++this.turnGeneration
+    this.pendingText = { generation, text }
+    this.turnPump ||= this.drainText().finally(() => { this.turnPump = null })
+    return this.turnPump
+  }
+
+  async drainText() {
+    while (!this.closed && this.pendingText) {
+      const turn = this.pendingText
+      this.pendingText = null
+      await this.submitPendingText(turn)
+    }
+  }
+
+  async submitPendingText(turn) {
+    try {
+      this.callbacks.onState('Thinking…')
+      if (this.interruptPromise) await this.interruptPromise.catch(() => undefined)
+      if (this.closed || turn.generation !== this.turnGeneration) return
+      this.baselineAssistantId = this.controller.latestAssistant()?.id || null
+      this.waitingForAssistant = true
+      this.activeTurnGeneration = turn.generation
+      if (!this.controller.submitText(turn.text)) {
+        this.waitingForAssistant = false
+        this.activeTurnGeneration = null
+      }
+    } catch (error) {
+      if (turn.generation === this.activeTurnGeneration) {
+        this.waitingForAssistant = false
+        this.activeTurnGeneration = null
+      }
+      this.callbacks.onError(`Hermes turn failed: ${errorText(error)}`)
+    }
+  }
+
+  handleAssistantResponse(response) {
+    if (this.closed || !this.waitingForAssistant || !response || response.pending || !response.text) return
+    if (this.activeTurnGeneration !== this.turnGeneration) return
+    if (response.id && (response.id === this.baselineAssistantId || response.id === this.lastSpokenAssistantId)) return
+    this.waitingForAssistant = false
+    this.activeTurnGeneration = null
+    if (response.id) this.lastSpokenAssistantId = response.id
+    this.speak(response.text, response.id)
+  }
+
+  speak(text, correlation) {
+    if (!this.send({
+      type: 'response.create', event_id: `desktop-talk-${crypto.randomUUID()}`,
+      response: {
+        conversation: 'none', metadata: { correlation },
+        input: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text }] }],
+        instructions: RENDER_INSTRUCTIONS, output_modalities: ['audio'],
+        audio: { output: { voice: this.session.voice } }, tools: [], tool_choice: 'none'
+      }
+    })) this.callbacks.onError('Realtime event channel is not open.')
+  }
+}
+
+function TalkPrimary({ disabled }) {
+  const controller = useComposerVoiceController()
+  const state = useValue($talk)
+  const active = state.phase === 'active'
+  const starting = state.phase === 'starting'
+  const Icon = starting ? icons.Loader2 : active ? icons.Square : icons.AudioLines
+  return jsxs(Fragment, { children: [
+    active && jsx(Tip, { label: state.muted ? 'Unmute Realtime Talk' : 'Mute Realtime Talk', children: jsx(Button, {
+      'aria-label': state.muted ? 'Unmute Realtime Talk' : 'Mute Realtime Talk', className: 'size-(--control-size) shrink-0', disabled,
+      onClick: () => { haptic('open'); toggleMute() }, size: 'icon', type: 'button', variant: state.muted ? 'secondary' : 'ghost',
+      children: jsx(state.muted ? icons.MicOff : icons.Mic, { className: 'size-3.5' })
+    }) }),
+    jsx(Tip, { label: active ? `Stop Realtime Talk — ${state.status}` : state.error || 'Start Realtime Talk', children: jsx(Button, {
+      'aria-label': active ? 'Stop Realtime Talk' : 'Start Realtime Talk', className: cn('size-(--control-size) shrink-0', state.phase === 'error' && 'text-destructive'), disabled: disabled || starting,
+      onClick: () => { haptic('open'); if (active) stopTalk(); else void startTalk(controller) }, size: 'icon', type: 'button',
+      children: jsx(Icon, { className: cn('size-3.5', starting && 'animate-spin', active && 'fill-current') })
+    }) })
+  ] })
+}
+
+const plugin = {
+  id: 'hermes-talk', name: 'Hermes Realtime Talk',
+  description: 'Canonical Hermes conversations with local full-duplex Realtime audio.', defaultEnabled: false,
+  register(ctx) {
+    pluginContext = ctx
+    ctx.register({
+      id: 'realtime-talk', area: 'composer.actions', title: 'Realtime Talk', order: 10,
+      data: { label: 'Realtime Talk', start: startTalk, render: props => jsx(TalkPrimary, props) }
+    })
+    ctx.onDispose(() => { stopTalk(); pluginContext = null })
+  }
+}
+
+export { DesktopTalkTransport }
+export default plugin

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -143,6 +143,23 @@ def test_mint_returns_the_ephemeral_secret_and_the_session_shape(minted):
     assert minted["auth_token"] == RAW_KEY
 
 
+def test_desktop_relay_mint_is_renderer_only(minted):
+    body = call(api.create_session, FakeRequest(body={"mode": "desktop-relay"}))
+
+    assert body["mode"] == "desktop-relay"
+    session = minted["session"]
+    assert session["audio"]["input"]["turn_detection"]["create_response"] is False
+    assert "tools" not in session
+    assert "tool_choice" not in session
+
+
+def test_unknown_session_mode_is_rejected(minted):
+    with pytest.raises(api.HTTPException) as excinfo:
+        call(api.create_session, FakeRequest(body={"mode": "other"}))
+
+    assert excinfo.value.status_code == 400
+
+
 def test_mint_response_contains_no_raw_credential(minted):
     body = call(api.create_session, FakeRequest(body={}))
     blob = serialized(body)

--- a/tests/test_desktop_plugin.py
+++ b/tests/test_desktop_plugin.py
@@ -1,0 +1,110 @@
+"""Desktop Realtime Talk plugin contract regressions."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_JS = ROOT / "desktop" / "plugin.js"
+
+
+def source() -> str:
+    return PLUGIN_JS.read_text(encoding="utf-8")
+
+
+def test_desktop_plugin_uses_only_runtime_supported_imports():
+    imported = re.findall(r"^import .*? from ['\"]([^'\"]+)['\"]", source(), re.MULTILINE)
+
+    assert imported == ["@hermes/plugin-sdk", "react/jsx-runtime"]
+
+
+def test_desktop_plugin_is_opt_in_and_uses_canonical_relay_mode():
+    text = source()
+
+    assert "defaultEnabled: false" in text
+    assert "area: 'composer.actions'" in text
+    assert "body: { mode: 'desktop-relay' }" in text
+    assert "this.controller.acquire" not in text
+    assert "lease = await voiceController?.acquire()" in text
+    assert "const next = new DesktopTalkTransport(session, voiceController, {" in text
+    assert "this.controller.submitText(turn.text)" in text
+    assert "this.controller.subscribeAssistant" in text
+    assert "context.fallback" not in text
+    assert "isTurnBusy" not in text
+    assert "acquireLease" not in text
+
+
+def test_desktop_plugin_mounts_through_the_host_data_render_contract():
+    text = source()
+
+    assert "renderPrimary" not in text
+    assert (
+        "data: { label: 'Realtime Talk', start: startTalk, "
+        "render: props => jsx(TalkPrimary, props) }"
+        in text
+    )
+    assert "useComposerVoiceController" in text
+    assert "const controller = useComposerVoiceController()" in text
+    assert "startTalk(controller)" in text
+
+
+def test_desktop_plugin_keeps_secrets_ephemeral_and_out_of_storage():
+    text = source()
+
+    assert "clientSecret" in text
+    assert "Authorization:" in text
+    assert "localStorage" not in text
+    assert "sessionStorage" not in text
+    assert ".storage" not in text
+    assert "console.log" not in text
+
+
+def test_desktop_plugin_waits_for_useful_channel_and_cleans_up_media():
+    text = source()
+
+    assert "await this.channelOpenPromise" in text
+    assert "this.offerAbort?.abort()" in text
+    assert "this.unsubscribeAssistant?.()" in text
+    assert "this.channel?.close()" in text
+    assert "this.peer?.close()" in text
+    assert "this.media?.getTracks().forEach(track => track.stop())" in text
+    assert "this.audio.remove()" in text
+
+
+def test_desktop_plugin_fails_closed_on_microphone_acquisition_and_releases_controller():
+    text = source()
+
+    assert "lease = await voiceController?.acquire()" in text
+    assert "if (!lease) throw new Error('The microphone is unavailable.')" in text
+    assert "activeController = lease" in text
+    assert "function releaseController" in text
+    assert "controller.release?.()" in text
+    assert "releaseController(lease)" in text
+    stop_talk = text[text.index("function stopTalk") : text.index("async function startTalk")]
+    start_error = text[text.index("} catch (error)") : text.index("function toggleMute")]
+    assert "releaseController()" in stop_talk
+    assert "releaseController(lease)" in start_error
+    assert "clearTransport(instance)" in text
+    assert "cleanupStaleStart(next, lease)" in text
+    assert "ctx.onDispose(() => { stopTalk(); pluginContext = null })" in text
+
+
+def test_desktop_plugin_subscribes_to_canonical_assistant_responses_and_unsubscribes_on_stop():
+    text = source()
+
+    assert "this.controller.subscribeAssistant(response =>" in text
+    assert "this.handleAssistantResponse(response)" in text
+    assert "this.unsubscribeAssistant?.()" in text
+    assert "this.activeTurnGeneration !== this.turnGeneration" in text
+
+
+def test_desktop_relay_never_exposes_realtime_tools_or_auto_answering():
+    text = source()
+
+    assert "tools: []" in text
+    assert "tool_choice: 'none'" in text
+    assert "Speak the sole user input verbatim" in text
+    assert "event.item_id !== this.latestSpeechItemId" in text
+    assert "response_id: this.responseId" in text
+    assert "output_audio_buffer.clear" in text

--- a/tests/test_desktop_turn_interruptions.py
+++ b/tests/test_desktop_turn_interruptions.py
@@ -1,0 +1,254 @@
+"""Behavior regressions for Desktop Realtime Talk interruption ordering."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import cast
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_JS = ROOT / "desktop" / "plugin.js"
+
+
+def _transport_source() -> str:
+    source = PLUGIN_JS.read_text(encoding="utf-8")
+    start = source.index("class DesktopTalkTransport")
+    end = source.index("function TalkPrimary", start)
+    return source[start:end]
+
+
+def _run_transport_scenario(body: str) -> dict[str, object]:
+    script = f"""
+const OFFER_TIMEOUT_MS = 30_000
+const INTERRUPT_SETTLE_TIMEOUT_MS = 5_000
+const RENDER_INSTRUCTIONS = 'render'
+globalThis.window = {{ setTimeout, clearTimeout }}
+{_transport_source()}
+{body}
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_latest_interruption_wins_when_transcripts_complete_out_of_order():
+    result = _run_transport_scenario(
+        """
+let busy = true
+const submitted = []
+const states = []
+const errors = []
+const controller = {
+  latestAssistant: () => ({ id: 'assistant-a', pending: false, text: 'A' }),
+  interrupt: async () => undefined,
+  submitText: text => {
+    submitted.push(text)
+    busy = true
+    return true
+  }
+}
+const transport = new DesktopTalkTransport(
+  { voice: 'cedar' },
+  controller,
+  { onState: state => states.push(state), onError: error => errors.push(error) }
+)
+
+transport.handleEvent(JSON.stringify({
+  type: 'input_audio_buffer.speech_started', item_id: 'input-b'
+}))
+transport.handleEvent(JSON.stringify({
+  type: 'input_audio_buffer.speech_started', item_id: 'input-c'
+}))
+transport.handleEvent(JSON.stringify({
+  type: 'conversation.item.input_audio_transcription.completed',
+  item_id: 'input-b',
+  transcript: 'older interruption B'
+}))
+transport.handleEvent(JSON.stringify({
+  type: 'conversation.item.input_audio_transcription.completed',
+  item_id: 'input-c',
+  transcript: 'latest interruption C'
+}))
+
+busy = false
+await new Promise(resolve => setTimeout(resolve, 250))
+transport.stop()
+console.log(JSON.stringify({ submitted, states, errors }))
+"""
+    )
+
+    assert result["submitted"] == ["latest interruption C"]
+    assert result["errors"] == []
+
+
+def test_new_speech_invalidates_a_waiting_assistant_response():
+    result = _run_transport_scenario(
+        """
+let currentAssistant = { id: 'assistant-a', pending: false, text: 'A' }
+const sent = []
+const controller = {
+  latestAssistant: () => currentAssistant,
+  interrupt: async () => undefined,
+  submitText: () => true
+}
+const transport = new DesktopTalkTransport(
+  { voice: 'cedar' },
+  controller,
+  { onState: () => undefined, onError: () => undefined }
+)
+transport.channel = {
+  readyState: 'open',
+  send: payload => sent.push(JSON.parse(payload)),
+  close: () => undefined
+}
+
+await transport.submitText('turn B', 'input-b')
+transport.handleEvent(JSON.stringify({
+  type: 'input_audio_buffer.speech_started', item_id: 'input-c'
+}))
+transport.handleAssistantResponse({ id: 'assistant-b', pending: false, text: 'stale answer B' })
+
+transport.stop()
+console.log(JSON.stringify({
+  responseCreates: sent.filter(event => event.type === 'response.create')
+}))
+"""
+    )
+
+    assert result["responseCreates"] == []
+
+
+def test_idless_assistant_snapshot_is_rendered_once_for_the_current_turn():
+    result = _run_transport_scenario(
+        """
+const sent = []
+const controller = {
+  latestAssistant: () => ({ pending: false }),
+  interrupt: async () => undefined,
+  submitText: () => true,
+  subscribeAssistant: () => () => undefined
+}
+const transport = new DesktopTalkTransport(
+  { voice: 'cedar' },
+  controller,
+  { onState: () => undefined, onError: error => { throw new Error(error) } }
+)
+transport.channel = {
+  readyState: 'open',
+  send: payload => sent.push(JSON.parse(payload)),
+  close: () => undefined
+}
+await transport.submitText('without an id')
+transport.handleAssistantResponse({ pending: false, text: 'assistant without an id' })
+transport.stop()
+console.log(JSON.stringify({
+  responseCreates: sent.filter(event => event.type === 'response.create')
+}))
+"""
+    )
+
+    response_creates = cast(list[dict], result["responseCreates"])
+    assert [event["response"]["input"][0]["content"][0]["text"] for event in response_creates] == [
+        "assistant without an id"
+    ]
+
+
+def test_barge_in_cancels_the_named_renderer_response_and_audio_buffer():
+    result = _run_transport_scenario(
+        """
+const sent = []
+const controller = {
+  latestAssistant: () => ({ id: 'assistant-a' }),
+  interrupt: async () => undefined,
+  submitText: () => true,
+  subscribeAssistant: () => () => undefined
+}
+const transport = new DesktopTalkTransport(
+  { voice: 'cedar' },
+  controller,
+  { onState: () => undefined, onError: () => undefined }
+)
+transport.channel = {
+  readyState: 'open',
+  send: payload => sent.push(JSON.parse(payload)),
+  close: () => undefined
+}
+transport.handleEvent(JSON.stringify({
+  type: 'response.created', response: { id: 'renderer-response-1' }
+}))
+transport.handleEvent(JSON.stringify({
+  type: 'output_audio_buffer.started', response_id: 'renderer-response-1'
+}))
+transport.handleEvent(JSON.stringify({
+  type: 'input_audio_buffer.speech_started', item_id: 'input-b'
+}))
+transport.stop()
+console.log(JSON.stringify({ sent }))
+"""
+    )
+
+    sent = cast(list[dict], result["sent"])
+    assert {event["type"] for event in sent} == {
+        "response.cancel",
+        "output_audio_buffer.clear",
+    }
+    cancel = next(event for event in sent if event["type"] == "response.cancel")
+    assert cancel["response_id"] == "renderer-response-1"
+
+
+def test_rejected_submit_clears_pending_turn_and_allows_the_next_turn():
+    result = _run_transport_scenario(
+        """
+const submitted = []
+const sent = []
+const controller = {
+  latestAssistant: () => ({ id: 'assistant-a', pending: false, text: 'A' }),
+  interrupt: async () => undefined,
+  submitText: text => {
+    submitted.push(text)
+    return submitted.length > 1
+  },
+  subscribeAssistant: () => () => undefined
+}
+const transport = new DesktopTalkTransport(
+  { voice: 'cedar' },
+  controller,
+  { onState: () => undefined, onError: error => { throw new Error(error) } }
+)
+transport.channel = {
+  readyState: 'open',
+  send: payload => sent.push(JSON.parse(payload)),
+  close: () => undefined
+}
+
+await transport.submitText('rejected turn')
+const afterReject = {
+  waitingForAssistant: transport.waitingForAssistant,
+  activeTurnGeneration: transport.activeTurnGeneration
+}
+
+await transport.submitText('accepted turn')
+transport.handleAssistantResponse({ id: 'assistant-b', pending: false, text: 'accepted answer' })
+transport.stop()
+console.log(JSON.stringify({
+  submitted,
+  afterReject,
+  responseCreates: sent.filter(event => event.type === 'response.create')
+}))
+"""
+    )
+
+    assert result["submitted"] == ["rejected turn", "accepted turn"]
+    assert result["afterReject"] == {
+        "waitingForAssistant": False,
+        "activeTurnGeneration": None,
+    }
+    response_creates = cast(list[dict], result["responseCreates"])
+    assert [event["response"]["input"][0]["content"][0]["text"] for event in response_creates] == [
+        "accepted answer"
+    ]


### PR DESCRIPTION
## Summary

Adds an opt-in Desktop Realtime Talk transport that keeps Hermes Core as the single chat authority while using a provider Realtime session only for low-latency speech input and playback.

This advances #44 and depends on the narrow Hermes Desktop composer ownership contract in https://github.com/NousResearch/hermes-agent/pull/100666.

## Problem

The plugin's existing Desktop flow cannot safely take microphone ownership while the built-in wake listener is active. It also cannot submit finalized speech or observe the canonical assistant response through a supported renderer contract.

Using the relay's normal automatic-response mode would create a second answer authority: the provider could answer the user directly, independently of Hermes chat, and could receive a provider tool catalog that the renderer transport does not need.

## Design

The change is split into two reviewable commits inside this PR:

1. **Renderer-only session minting**
   - adds a route-authorized `desktop-relay` session mode;
   - mints provider sessions with `automatic_response=false`;
   - sends an empty provider tool catalog;
   - preserves the existing route authorization and leaves other Talk surfaces unchanged.

2. **Desktop controller lifecycle**
   - mounts through the existing `composer.actions` render contribution;
   - acquires/releases the Core voice lease and respects stale-session fencing;
   - sends finalized user speech through the canonical composer submit path;
   - waits for the canonical Hermes assistant snapshot before requesting provider audio;
   - handles barge-in with the active provider `response_id` and clears local/provider audio buffers;
   - ignores stale transcripts and stale assistant snapshots across restart/navigation;
   - disposes subscriptions and media resources on stop, failure, and unmount;
   - treats a rejected Core submission as an explicit failure instead of waiting forever;
   - exposes a one-click retry after startup or runtime failure.

Core owns microphone/wake/composer coordination. The plugin owns provider session minting, WebRTC, audio playback, interruption, and UI state.

## Security and authority boundary

- no provider credentials are stored in the renderer;
- the existing backend route authorization remains in force;
- renderer-only minting disables provider automatic responses;
- renderer-only minting exposes no provider tools;
- the provider voices only the already-authoritative Hermes assistant text;
- no private operational files or local paths are included.

## Testing

Focused Desktop behavior:

- `tests/test_desktop_plugin.py` — 6/6 passed;
- `tests/test_desktop_turn_interruptions.py` — 7/7 passed;
- includes the rejected-submit regression.

Broader local validation:

- plugin suite with the single known macOS path-literal test deselected — 1333 passed, 16 skipped;
- the excluded pre-existing test rejects the substring `private`, which is also present in the standard macOS temporary-directory root; it is unrelated to this change;
- Ruff — passed;
- `node --check desktop/plugin.js` — passed;
- `uv build` — passed;
- `git diff --check` — passed.

## Manual validation still required

A live microphone/WebRTC canary requires a Hermes Desktop build containing the Core dependency and explicit microphone permission. It should cover:

1. start and stop;
2. one spoken turn returning one canonical Hermes answer;
3. barge-in during playback;
4. navigation during an in-flight turn;
5. provider/session failure followed by one-click restart.

No live service, installed plugin, credentials, or user configuration was modified while preparing this PR.

## Related

- Advances #44
- Depends on https://github.com/NousResearch/hermes-agent/pull/100666
- Hermes RFC context: `NousResearch/hermes-agent#77111`
