### PR TITLE
fix(audio): preserve speech through echo cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ but 0.4.0's release title named only the steering verb. They are recorded
 below under 0.4.0 — the first version that shipped them — with the gap
 named rather than smoothed.
 
+## [Unreleased]
+
+### Fixed
+- Linux terminal calls now route default audio through PulseAudio's WebRTC
+  echo canceller and noise suppressor. Echo-cancelled input bypasses the
+  fallback amplitude/VAD gate so barge-in does not clip quiet words.
 ## [0.16.0] — 2026-09-01
 
 Grok voice on a SuperGrok / X Premium+ subscription. `hermes auth add
@@ -48,7 +54,6 @@ lane rides the Codex CLI's.
 - Reading Grok Build CLI's `~/.grok/auth.json`; a device-code login inside
   the plugin; any write to any auth store. The dashboard tab stays
   OpenAI-only.
-
 ## [0.15.1] — 2026-09-01
 
 Voice hears you again on end-to-end-encrypted Discord calls. 0.15.0's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "SmokeDev" }]
 dependencies = ["httpx>=0.27", "aiohttp>=3.9"]
 
 [project.optional-dependencies]
-audio = ["sounddevice>=0.4.6", "numpy>=1.26"]
+audio = ["sounddevice>=0.4.6", "numpy>=1.26", "webrtcvad-wheels>=2.0.14"]
 dev = ["pytest>=8", "ruff>=0.4"]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "SmokeDev" }]
 dependencies = ["httpx>=0.27", "aiohttp>=3.9"]
 
 [project.optional-dependencies]
-audio = ["sounddevice>=0.4.6", "numpy>=1.26", "webrtcvad-wheels>=2.0.14"]
+audio = ["sounddevice>=0.4.6", "numpy>=1.26"]
 dev = ["pytest>=8", "ruff>=0.4"]
 
 [build-system]

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -43,6 +43,10 @@ MAX_PLAYBACK_BLOCKS = 200
 OUTPUT_ACTIVE_LEVEL = 0.015
 MIN_BARGE_IN_LEVEL = 0.04
 OUTPUT_ECHO_RATIO = 0.65
+VAD_SAMPLE_RATE = 8_000
+VAD_FRAME_SAMPLES = 240  # 30 ms
+VAD_FRAME_BYTES = VAD_FRAME_SAMPLES * SAMPLE_WIDTH
+VAD_SPEECH_FRAMES = 2  # 60 ms filters transient room noise, stays under OMP's 150 ms target
 
 _INSTALL_HINT = (
     'audio support is not installed — run: pip install "hermes-talk[audio]" '
@@ -62,6 +66,15 @@ def import_sounddevice():
     except (ImportError, OSError) as exc:
         raise TalkAudioError(f"{_INSTALL_HINT} ({exc})") from exc
     return sd
+
+def import_webrtcvad():
+    """Lazy-import the speech classifier shipped by the audio extra."""
+
+    try:
+        import webrtcvad
+    except (ImportError, OSError) as exc:
+        raise TalkAudioError(f"{_INSTALL_HINT} ({exc})") from exc
+    return webrtcvad
 
 
 def audio_available() -> bool:
@@ -90,17 +103,29 @@ def _pcm16_rms(pcm: bytes) -> float:
     sum_squares = sum(sample * sample for sample in samples)
     return min(1.0, math.sqrt(sum_squares / len(samples)) / 32_768)
 
+def _downsample_24k_to_8k(pcm: bytes) -> bytes:
+    """Decimate PCM16 by three for WebRTC VAD's supported 8 kHz input."""
+
+    source = memoryview(pcm).cast("h")
+    target = bytearray((len(source) // 3) * SAMPLE_WIDTH)
+    samples = memoryview(target).cast("h")
+    for index in range(len(samples)):
+        samples[index] = source[index * 3]
+    return bytes(target)
+
 
 class DuplexAudio:
     """Full-duplex pcm16 capture and playback over PortAudio."""
 
-    def __init__(self) -> None:
+    def __init__(self, speech_detector=None) -> None:
         self._input: queue.Queue[bytes] = queue.Queue(maxsize=MAX_INPUT_BLOCKS)
         self._playback: queue.Queue[bytes] = queue.Queue(maxsize=MAX_PLAYBACK_BLOCKS)
         self._residual = b""
         self._lock = threading.Lock()
         self._played_frames = 0
         self._output_level = 0.0
+        self._speech_detector = speech_detector
+        self._speech_run_frames = 0
         self._in_stream = None
         self._out_stream = None
 
@@ -110,6 +135,8 @@ class DuplexAudio:
         """Open both streams. Raises :class:`TalkAudioError` when it cannot."""
 
         sd = import_sounddevice()
+        if self._speech_detector is None:
+            self._speech_detector = import_webrtcvad().Vad(3)
         try:
             self._in_stream = sd.RawInputStream(
                 samplerate=SAMPLE_RATE,
@@ -147,6 +174,21 @@ class DuplexAudio:
                 pass
             setattr(self, attr, None)
 
+    def _contains_speech(self, pcm: bytes) -> bool:
+        detector = self._speech_detector
+        if detector is None:
+            return True
+        downsampled = _downsample_24k_to_8k(pcm)
+        for offset in range(0, len(downsampled) - VAD_FRAME_BYTES + 1, VAD_FRAME_BYTES):
+            frame = downsampled[offset : offset + VAD_FRAME_BYTES]
+            if detector.is_speech(frame, VAD_SAMPLE_RATE):
+                self._speech_run_frames += 1
+                if self._speech_run_frames >= VAD_SPEECH_FRAMES:
+                    return True
+            else:
+                self._speech_run_frames = 0
+        return False
+
     # -- PortAudio callbacks (audio thread) -----------------------------------
 
     def _input_callback(self, indata, _frames, _time, _status) -> None:
@@ -157,6 +199,8 @@ class DuplexAudio:
         output_active = output_level > OUTPUT_ACTIVE_LEVEL
         echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
         if output_active and input_level < echo_threshold:
+            return
+        if output_active and not self._contains_speech(pcm):
             return
         # Drop the block rather than stall the device: a blocked PortAudio
         # callback is a glitch the operator hears.

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -25,6 +25,8 @@ import shutil
 import subprocess
 import sys
 import threading
+import uuid
+from typing import ClassVar
 
 try:
     from . import talk_config
@@ -82,10 +84,11 @@ def import_webrtcvad():
 
 
 def audio_available() -> bool:
-    """True when a duplex session could actually open devices."""
+    """True when all dependencies needed by a duplex session are importable."""
 
     try:
         import_sounddevice()
+        import_webrtcvad()
     except TalkAudioError:
         return False
     return True
@@ -121,11 +124,18 @@ def _downsample_24k_to_8k(pcm: bytes) -> bytes:
 class _PulseWebRtcAudio:
     """Process-local PulseAudio WebRTC AEC/NS route for default Linux devices."""
 
+    _environment_lock = threading.Lock()
+    _active_routes: ClassVar[list[_PulseWebRtcAudio]] = []
+    _baseline_source: object | str = object()
+    _baseline_sink: object | str = object()
+    _missing = object()
+
     def __init__(self) -> None:
         self._pactl: str | None = None
         self._module_id: str | None = None
-        self._previous_source: str | None = None
-        self._previous_sink: str | None = None
+        self._source_name: str | None = None
+        self._sink_name: str | None = None
+        self._changed_environment = False
 
     @property
     def active(self) -> bool:
@@ -144,7 +154,7 @@ class _PulseWebRtcAudio:
         if pactl is None:
             return input_device, output_device
 
-        suffix = str(os.getpid())
+        suffix = f"{os.getpid()}_{uuid.uuid4().hex}"
         source_name = f"hermes_talk_aec_{suffix}"
         sink_name = f"hermes_talk_aec_sink_{suffix}"
         try:
@@ -171,21 +181,49 @@ class _PulseWebRtcAudio:
 
         self._pactl = pactl
         self._module_id = module_id
-        self._previous_source = os.environ.get("PULSE_SOURCE")
-        self._previous_sink = os.environ.get("PULSE_SINK")
-        os.environ["PULSE_SOURCE"] = source_name
-        os.environ["PULSE_SINK"] = sink_name
+        self._source_name = source_name
+        self._sink_name = sink_name
+        with self._environment_lock:
+            if not self._active_routes:
+                type(self)._baseline_source = os.environ.get("PULSE_SOURCE", self._missing)
+                type(self)._baseline_sink = os.environ.get("PULSE_SINK", self._missing)
+            self._active_routes.append(self)
+            os.environ["PULSE_SOURCE"] = source_name
+            os.environ["PULSE_SINK"] = sink_name
+            self._changed_environment = True
         return "pulse", "pulse"
 
+    @classmethod
+    def _restore(cls, name: str, baseline: object | str) -> None:
+        if baseline is cls._missing:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = baseline
+
     def stop(self) -> None:
-        if self._previous_source is None:
-            os.environ.pop("PULSE_SOURCE", None)
-        else:
-            os.environ["PULSE_SOURCE"] = self._previous_source
-        if self._previous_sink is None:
-            os.environ.pop("PULSE_SINK", None)
-        else:
-            os.environ["PULSE_SINK"] = self._previous_sink
+        with self._environment_lock:
+            if self._changed_environment:
+                self._changed_environment = False
+                with contextlib.suppress(ValueError):
+                    self._active_routes.remove(self)
+                managed_values = {
+                    route._source_name
+                    for route in self._active_routes
+                } | {self._source_name}
+                if os.environ.get("PULSE_SOURCE") in managed_values:
+                    if self._active_routes:
+                        os.environ["PULSE_SOURCE"] = self._active_routes[-1]._source_name
+                    else:
+                        self._restore("PULSE_SOURCE", self._baseline_source)
+                managed_values = {
+                    route._sink_name
+                    for route in self._active_routes
+                } | {self._sink_name}
+                if os.environ.get("PULSE_SINK") in managed_values:
+                    if self._active_routes:
+                        os.environ["PULSE_SINK"] = self._active_routes[-1]._sink_name
+                    else:
+                        self._restore("PULSE_SINK", self._baseline_sink)
 
         if self._pactl is not None and self._module_id is not None:
             with contextlib.suppress(OSError, subprocess.SubprocessError):
@@ -198,6 +236,8 @@ class _PulseWebRtcAudio:
                 )
         self._pactl = None
         self._module_id = None
+        self._source_name = None
+        self._sink_name = None
 
 
 class DuplexAudio:
@@ -224,35 +264,45 @@ class DuplexAudio:
         sd = import_sounddevice()
         if self._speech_detector is None:
             self._speech_detector = import_webrtcvad().Vad(3)
-        input_device = _device(talk_config.audio_input_device())
-        output_device = _device(talk_config.audio_output_device())
-        input_device, output_device = self._pulse_webrtc.start(input_device, output_device)
+        original_input = _device(talk_config.audio_input_device())
+        original_output = _device(talk_config.audio_output_device())
+        input_device, output_device = self._pulse_webrtc.start(
+            original_input, original_output
+        )
         try:
-            self._in_stream = sd.RawInputStream(
-                samplerate=SAMPLE_RATE,
-                blocksize=BLOCKSIZE,
-                device=input_device,
-                channels=CHANNELS,
-                dtype="int16",
-                callback=self._input_callback,
-            )
-            self._out_stream = sd.RawOutputStream(
-                samplerate=SAMPLE_RATE,
-                blocksize=BLOCKSIZE,
-                device=output_device,
-                channels=CHANNELS,
-                dtype="int16",
-                callback=self._output_callback,
-            )
-            self._in_stream.start()
-            self._out_stream.start()
-        except Exception as exc:  # PortAudio raises its own exception types
-            self.stop()
-            raise TalkAudioError(f"could not open audio devices: {exc}") from exc
+            self._open_streams(sd, input_device, output_device)
+        except Exception as routed_exc:  # PortAudio raises its own exception types
+            self._close_streams()
+            if not self._pulse_webrtc.active:
+                raise TalkAudioError(f"could not open audio devices: {routed_exc}") from routed_exc
+            self._pulse_webrtc.stop()
+            try:
+                self._open_streams(sd, original_input, original_output)
+            except Exception as exc:
+                self._close_streams()
+                raise TalkAudioError(f"could not open audio devices: {exc}") from exc
 
-    def stop(self) -> None:
-        """Close both streams. Safe to call twice, and on a failed start."""
+    def _open_streams(self, sd, input_device, output_device) -> None:
+        self._in_stream = sd.RawInputStream(
+            samplerate=SAMPLE_RATE,
+            blocksize=BLOCKSIZE,
+            device=input_device,
+            channels=CHANNELS,
+            dtype="int16",
+            callback=self._input_callback,
+        )
+        self._out_stream = sd.RawOutputStream(
+            samplerate=SAMPLE_RATE,
+            blocksize=BLOCKSIZE,
+            device=output_device,
+            channels=CHANNELS,
+            dtype="int16",
+            callback=self._output_callback,
+        )
+        self._in_stream.start()
+        self._out_stream.start()
 
+    def _close_streams(self) -> None:
         for attr in ("_in_stream", "_out_stream"):
             stream = getattr(self, attr, None)
             if stream is None:
@@ -263,6 +313,11 @@ class DuplexAudio:
             except Exception:  # noqa: BLE001 — teardown is best-effort
                 pass
             setattr(self, attr, None)
+
+    def stop(self) -> None:
+        """Close both streams. Safe to call twice, and on a failed start."""
+
+        self._close_streams()
         self._pulse_webrtc.stop()
 
     def _contains_speech(self, pcm: bytes) -> bool:
@@ -289,10 +344,12 @@ class DuplexAudio:
             output_level = self._output_level
         if not self._pulse_webrtc.active:
             output_active = output_level > OUTPUT_ACTIVE_LEVEL
-            echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
-            if output_active and input_level < echo_threshold:
-                return
-            if output_active and not self._contains_speech(pcm):
+            if output_active and self._contains_speech(pcm):
+                pass
+            elif output_active:
+                echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
+                if input_level < echo_threshold:
+                    return
                 return
         # Drop the block rather than stall the device: a blocked PortAudio
         # callback is a glitch the operator hears.

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -49,10 +49,6 @@ MAX_PLAYBACK_BLOCKS = 200
 OUTPUT_ACTIVE_LEVEL = 0.015
 MIN_BARGE_IN_LEVEL = 0.04
 OUTPUT_ECHO_RATIO = 0.65
-VAD_SAMPLE_RATE = 8_000
-VAD_FRAME_SAMPLES = 240  # 30 ms
-VAD_FRAME_BYTES = VAD_FRAME_SAMPLES * SAMPLE_WIDTH
-VAD_SPEECH_FRAMES = 2  # 60 ms filters transient room noise, stays under OMP's 150 ms target
 
 _INSTALL_HINT = (
     'audio support is not installed — run: pip install "hermes-talk[audio]" '
@@ -73,14 +69,6 @@ def import_sounddevice():
         raise TalkAudioError(f"{_INSTALL_HINT} ({exc})") from exc
     return sd
 
-def import_webrtcvad():
-    """Lazy-import the speech classifier shipped by the audio extra."""
-
-    try:
-        import webrtcvad
-    except (ImportError, OSError) as exc:
-        raise TalkAudioError(f"{_INSTALL_HINT} ({exc})") from exc
-    return webrtcvad
 
 
 def audio_available() -> bool:
@@ -88,7 +76,6 @@ def audio_available() -> bool:
 
     try:
         import_sounddevice()
-        import_webrtcvad()
     except TalkAudioError:
         return False
     return True
@@ -110,15 +97,6 @@ def _pcm16_rms(pcm: bytes) -> float:
     sum_squares = sum(sample * sample for sample in samples)
     return min(1.0, math.sqrt(sum_squares / len(samples)) / 32_768)
 
-def _downsample_24k_to_8k(pcm: bytes) -> bytes:
-    """Decimate PCM16 by three for WebRTC VAD's supported 8 kHz input."""
-
-    source = memoryview(pcm).cast("h")
-    target = bytearray((len(source) // 3) * SAMPLE_WIDTH)
-    samples = memoryview(target).cast("h")
-    for index in range(len(samples)):
-        samples[index] = source[index * 3]
-    return bytes(target)
 
 
 class _PulseWebRtcAudio:
@@ -243,15 +221,18 @@ class _PulseWebRtcAudio:
 class DuplexAudio:
     """Full-duplex pcm16 capture and playback over PortAudio."""
 
-    def __init__(self, speech_detector=None) -> None:
+    _startup_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    def __init__(self) -> None:
         self._input: queue.Queue[bytes] = queue.Queue(maxsize=MAX_INPUT_BLOCKS)
-        self._playback: queue.Queue[bytes] = queue.Queue(maxsize=MAX_PLAYBACK_BLOCKS)
-        self._residual = b""
+        self._playback: queue.Queue[tuple[str | None, bytes]] = queue.Queue(
+            maxsize=MAX_PLAYBACK_BLOCKS
+        )
+        self._residual: tuple[str | None, bytes] | None = None
         self._lock = threading.Lock()
+        self._played_item_id: str | None = None
         self._played_frames = 0
         self._output_level = 0.0
-        self._speech_detector = speech_detector
-        self._speech_run_frames = 0
         self._in_stream = None
         self._out_stream = None
         self._pulse_webrtc = _PulseWebRtcAudio()
@@ -262,25 +243,26 @@ class DuplexAudio:
         """Open both streams. Raises :class:`TalkAudioError` when it cannot."""
 
         sd = import_sounddevice()
-        if self._speech_detector is None:
-            self._speech_detector = import_webrtcvad().Vad(3)
         original_input = _device(talk_config.audio_input_device())
         original_output = _device(talk_config.audio_output_device())
-        input_device, output_device = self._pulse_webrtc.start(
-            original_input, original_output
-        )
-        try:
-            self._open_streams(sd, input_device, output_device)
-        except Exception as routed_exc:  # PortAudio raises its own exception types
-            self._close_streams()
-            if not self._pulse_webrtc.active:
-                raise TalkAudioError(f"could not open audio devices: {routed_exc}") from routed_exc
-            self._pulse_webrtc.stop()
+        with self._startup_lock:
+            input_device, output_device = self._pulse_webrtc.start(
+                original_input, original_output
+            )
             try:
-                self._open_streams(sd, original_input, original_output)
-            except Exception as exc:
+                self._open_streams(sd, input_device, output_device)
+            except Exception as routed_exc:  # PortAudio raises its own exception types
                 self._close_streams()
-                raise TalkAudioError(f"could not open audio devices: {exc}") from exc
+                if not self._pulse_webrtc.active:
+                    raise TalkAudioError(
+                        f"could not open audio devices: {routed_exc}"
+                    ) from routed_exc
+                self._pulse_webrtc.stop()
+                try:
+                    self._open_streams(sd, original_input, original_output)
+                except Exception as exc:
+                    self._close_streams()
+                    raise TalkAudioError(f"could not open audio devices: {exc}") from exc
 
     def _open_streams(self, sd, input_device, output_device) -> None:
         self._in_stream = sd.RawInputStream(
@@ -320,20 +302,6 @@ class DuplexAudio:
         self._close_streams()
         self._pulse_webrtc.stop()
 
-    def _contains_speech(self, pcm: bytes) -> bool:
-        detector = self._speech_detector
-        if detector is None:
-            return True
-        downsampled = _downsample_24k_to_8k(pcm)
-        for offset in range(0, len(downsampled) - VAD_FRAME_BYTES + 1, VAD_FRAME_BYTES):
-            frame = downsampled[offset : offset + VAD_FRAME_BYTES]
-            if detector.is_speech(frame, VAD_SAMPLE_RATE):
-                self._speech_run_frames += 1
-                if self._speech_run_frames >= VAD_SPEECH_FRAMES:
-                    return True
-            else:
-                self._speech_run_frames = 0
-        return False
 
     # -- PortAudio callbacks (audio thread) -----------------------------------
 
@@ -344,12 +312,11 @@ class DuplexAudio:
             output_level = self._output_level
         if not self._pulse_webrtc.active:
             output_active = output_level > OUTPUT_ACTIVE_LEVEL
-            if output_active and self._contains_speech(pcm):
-                pass
-            elif output_active:
-                echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
-                if input_level < echo_threshold:
-                    return
+            echo_threshold = max(
+                MIN_BARGE_IN_LEVEL,
+                output_level * OUTPUT_ECHO_RATIO,
+            )
+            if output_active and input_level < echo_threshold:
                 return
         # Drop the block rather than stall the device: a blocked PortAudio
         # callback is a glitch the operator hears.
@@ -358,23 +325,42 @@ class DuplexAudio:
 
     def _output_callback(self, outdata, frames, _time, _status) -> None:
         wanted = frames * FRAME_BYTES
-        chunk = self._take_playback(wanted)
-        outdata[: len(chunk)] = chunk
-        if len(chunk) < wanted:
-            outdata[len(chunk) :] = b"\x00" * (wanted - len(chunk))
         with self._lock:
+            chunk, segments = self._take_playback(wanted)
+            outdata[: len(chunk)] = chunk
+            if len(chunk) < wanted:
+                outdata[len(chunk) :] = b"\x00" * (wanted - len(chunk))
             self._output_level = _pcm16_rms(chunk)
-            self._played_frames += len(chunk) // FRAME_BYTES
+            for item_id, played_frames in segments:
+                if item_id != self._played_item_id:
+                    self._played_item_id = item_id
+                    self._played_frames = 0
+                self._played_frames += played_frames
 
-    def _take_playback(self, wanted: int) -> bytes:
-        buf = self._residual
-        while len(buf) < wanted:
-            try:
-                buf += self._playback.get_nowait()
-            except queue.Empty:
-                break
-        self._residual = buf[wanted:]
-        return buf[:wanted]
+    def _take_playback(
+        self, wanted: int
+    ) -> tuple[bytes, list[tuple[str | None, int]]]:
+        parts: list[bytes] = []
+        segments: list[tuple[str | None, int]] = []
+        remaining = wanted
+        packet = self._residual
+        self._residual = None
+        while remaining > 0:
+            if packet is None:
+                try:
+                    packet = self._playback.get_nowait()
+                except queue.Empty:
+                    break
+            item_id, data = packet
+            taken = data[:remaining]
+            parts.append(taken)
+            frames = len(taken) // FRAME_BYTES
+            if frames:
+                segments.append((item_id, frames))
+            remaining -= len(taken)
+            packet = (item_id, data[len(taken) :]) if len(taken) < len(data) else None
+        self._residual = packet
+        return b"".join(parts), segments
 
     # -- session interface ----------------------------------------------------
 
@@ -386,23 +372,31 @@ class DuplexAudio:
         except queue.Empty:
             return None
 
-    def queue_playback(self, pcm: bytes) -> None:
+    def queue_playback(self, pcm: bytes, item_id: str | None = None) -> None:
         """Queue model audio for the speaker. Drops on overflow, never blocks."""
 
         if not pcm:
             return
-        with contextlib.suppress(queue.Full):
-            self._playback.put_nowait(pcm)
+        with self._lock, contextlib.suppress(queue.Full):
+            self._playback.put_nowait((item_id, pcm))
 
-    def drain_playback(self) -> None:
-        """Barge-in: stop speaking now. Everything not yet played is discarded."""
+    def drain_playback(self) -> tuple[str | None, int]:
+        """Discard unheard audio and atomically return the heard boundary."""
 
-        while True:
-            try:
-                self._playback.get_nowait()
-            except queue.Empty:
-                break
-        self._residual = b""
+        with self._lock:
+            while True:
+                try:
+                    self._playback.get_nowait()
+                except queue.Empty:
+                    break
+            self._residual = None
+            boundary = (
+                self._played_item_id,
+                int(self._played_frames * 1000 / SAMPLE_RATE),
+            )
+            self._played_item_id = None
+            self._played_frames = 0
+            return boundary
 
     @property
     def played_ms(self) -> int:
@@ -412,9 +406,10 @@ class DuplexAudio:
             return int(self._played_frames * 1000 / SAMPLE_RATE)
 
     def reset_played_ms(self) -> None:
-        """Zero the counter — called when a new response starts speaking."""
+        """Reset legacy callers that do not attach item identity to audio."""
 
         with self._lock:
+            self._played_item_id = None
             self._played_frames = 0
 
 

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -233,6 +233,8 @@ class DuplexAudio:
         self._queued_playback_bytes = 0
         self._lock = threading.Lock()
         self._played_item_id: str | None = None
+        self._dropped_input_blocks = 0
+        self._dropped_playback_bytes = 0
         self._played_frames = 0
         self._output_level = 0.0
         self._in_stream = None
@@ -320,10 +322,18 @@ class DuplexAudio:
             )
             if output_active and input_level < echo_threshold:
                 return
-        # Drop the block rather than stall the device: a blocked PortAudio
-        # callback is a glitch the operator hears.
-        with contextlib.suppress(queue.Full):
+        try:
             self._input.put_nowait(pcm)
+        except queue.Full:
+            # Capture is realtime: preserving a five-second-old block while
+            # discarding the operator's current speech corrupts the turn.
+            # Evict one oldest block and retain the newest available audio.
+            with contextlib.suppress(queue.Empty):
+                self._input.get_nowait()
+            with contextlib.suppress(queue.Full):
+                self._input.put_nowait(pcm)
+            with self._lock:
+                self._dropped_input_blocks += 1
 
     def _output_callback(self, outdata, frames, _time, _status) -> None:
         wanted = frames * FRAME_BYTES
@@ -379,10 +389,12 @@ class DuplexAudio:
             return
         with self._lock:
             if self._queued_playback_bytes + len(pcm) > MAX_PLAYBACK_BYTES:
+                self._dropped_playback_bytes += len(pcm)
                 return
             try:
                 self._playback.put_nowait((item_id, pcm))
             except queue.Full:
+                self._dropped_playback_bytes += len(pcm)
                 return
             self._queued_playback_bytes += len(pcm)
 
@@ -418,6 +430,20 @@ class DuplexAudio:
         with self._lock:
             self._played_item_id = None
             self._played_frames = 0
+
+    @property
+    def dropped_input_blocks(self) -> int:
+        """Count capture overflows handled with a newest-audio preference."""
+
+        with self._lock:
+            return self._dropped_input_blocks
+
+    @property
+    def dropped_playback_bytes(self) -> int:
+        """Count provider audio bytes rejected by playback capacity limits."""
+
+        with self._lock:
+            return self._dropped_playback_bytes
 
 
 __all__ = [

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -19,7 +19,11 @@ from __future__ import annotations
 
 import contextlib
 import math
+import os
 import queue
+import shutil
+import subprocess
+import sys
 import threading
 
 try:
@@ -114,6 +118,88 @@ def _downsample_24k_to_8k(pcm: bytes) -> bytes:
     return bytes(target)
 
 
+class _PulseWebRtcAudio:
+    """Process-local PulseAudio WebRTC AEC/NS route for default Linux devices."""
+
+    def __init__(self) -> None:
+        self._pactl: str | None = None
+        self._module_id: str | None = None
+        self._previous_source: str | None = None
+        self._previous_sink: str | None = None
+
+    @property
+    def active(self) -> bool:
+        """Whether capture already comes from PulseAudio's echo canceller."""
+
+        return self._module_id is not None
+
+    def start(
+        self,
+        input_device: str | int | None,
+        output_device: str | int | None,
+    ) -> tuple[str | int | None, str | int | None]:
+        if input_device is not None or output_device is not None or sys.platform != "linux":
+            return input_device, output_device
+        pactl = shutil.which("pactl")
+        if pactl is None:
+            return input_device, output_device
+
+        suffix = str(os.getpid())
+        source_name = f"hermes_talk_aec_{suffix}"
+        sink_name = f"hermes_talk_aec_sink_{suffix}"
+        try:
+            result = subprocess.run(
+                [
+                    pactl,
+                    "load-module",
+                    "module-echo-cancel",
+                    "aec_method=webrtc",
+                    f"source_name={source_name}",
+                    f"sink_name={sink_name}",
+                    "aec_args=analog_gain_control=0 digital_gain_control=1 noise_suppression=1",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            module_id = result.stdout.strip()
+            if not module_id.isdigit():
+                raise ValueError("pactl returned no module id")
+        except (OSError, subprocess.SubprocessError, ValueError):
+            return input_device, output_device
+
+        self._pactl = pactl
+        self._module_id = module_id
+        self._previous_source = os.environ.get("PULSE_SOURCE")
+        self._previous_sink = os.environ.get("PULSE_SINK")
+        os.environ["PULSE_SOURCE"] = source_name
+        os.environ["PULSE_SINK"] = sink_name
+        return "pulse", "pulse"
+
+    def stop(self) -> None:
+        if self._previous_source is None:
+            os.environ.pop("PULSE_SOURCE", None)
+        else:
+            os.environ["PULSE_SOURCE"] = self._previous_source
+        if self._previous_sink is None:
+            os.environ.pop("PULSE_SINK", None)
+        else:
+            os.environ["PULSE_SINK"] = self._previous_sink
+
+        if self._pactl is not None and self._module_id is not None:
+            with contextlib.suppress(OSError, subprocess.SubprocessError):
+                subprocess.run(
+                    [self._pactl, "unload-module", self._module_id],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+        self._pactl = None
+        self._module_id = None
+
+
 class DuplexAudio:
     """Full-duplex pcm16 capture and playback over PortAudio."""
 
@@ -128,6 +214,7 @@ class DuplexAudio:
         self._speech_run_frames = 0
         self._in_stream = None
         self._out_stream = None
+        self._pulse_webrtc = _PulseWebRtcAudio()
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -137,11 +224,14 @@ class DuplexAudio:
         sd = import_sounddevice()
         if self._speech_detector is None:
             self._speech_detector = import_webrtcvad().Vad(3)
+        input_device = _device(talk_config.audio_input_device())
+        output_device = _device(talk_config.audio_output_device())
+        input_device, output_device = self._pulse_webrtc.start(input_device, output_device)
         try:
             self._in_stream = sd.RawInputStream(
                 samplerate=SAMPLE_RATE,
                 blocksize=BLOCKSIZE,
-                device=_device(talk_config.audio_input_device()),
+                device=input_device,
                 channels=CHANNELS,
                 dtype="int16",
                 callback=self._input_callback,
@@ -149,7 +239,7 @@ class DuplexAudio:
             self._out_stream = sd.RawOutputStream(
                 samplerate=SAMPLE_RATE,
                 blocksize=BLOCKSIZE,
-                device=_device(talk_config.audio_output_device()),
+                device=output_device,
                 channels=CHANNELS,
                 dtype="int16",
                 callback=self._output_callback,
@@ -173,6 +263,7 @@ class DuplexAudio:
             except Exception:  # noqa: BLE001 — teardown is best-effort
                 pass
             setattr(self, attr, None)
+        self._pulse_webrtc.stop()
 
     def _contains_speech(self, pcm: bytes) -> bool:
         detector = self._speech_detector
@@ -196,12 +287,13 @@ class DuplexAudio:
         input_level = _pcm16_rms(pcm)
         with self._lock:
             output_level = self._output_level
-        output_active = output_level > OUTPUT_ACTIVE_LEVEL
-        echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
-        if output_active and input_level < echo_threshold:
-            return
-        if output_active and not self._contains_speech(pcm):
-            return
+        if not self._pulse_webrtc.active:
+            output_active = output_level > OUTPUT_ACTIVE_LEVEL
+            echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
+            if output_active and input_level < echo_threshold:
+                return
+            if output_active and not self._contains_speech(pcm):
+                return
         # Drop the block rather than stall the device: a blocked PortAudio
         # callback is a glitch the operator hears.
         with contextlib.suppress(queue.Full):

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -43,6 +43,7 @@ FRAME_BYTES = SAMPLE_WIDTH * CHANNELS
 #: the tighter of the two: stale microphone audio is worse than dropped audio.
 MAX_INPUT_BLOCKS = 50
 MAX_PLAYBACK_BLOCKS = 200
+MAX_PLAYBACK_BYTES = SAMPLE_RATE * FRAME_BYTES * 20
 
 # Match OMP's live controller: while model audio is playing, microphone blocks
 # below the acoustic echo floor are local playback leakage, not barge-in.
@@ -229,6 +230,7 @@ class DuplexAudio:
             maxsize=MAX_PLAYBACK_BLOCKS
         )
         self._residual: tuple[str | None, bytes] | None = None
+        self._queued_playback_bytes = 0
         self._lock = threading.Lock()
         self._played_item_id: str | None = None
         self._played_frames = 0
@@ -326,22 +328,16 @@ class DuplexAudio:
     def _output_callback(self, outdata, frames, _time, _status) -> None:
         wanted = frames * FRAME_BYTES
         with self._lock:
-            chunk, segments = self._take_playback(wanted)
-            outdata[: len(chunk)] = chunk
-            if len(chunk) < wanted:
-                outdata[len(chunk) :] = b"\x00" * (wanted - len(chunk))
-            self._output_level = _pcm16_rms(chunk)
-            for item_id, played_frames in segments:
-                if item_id != self._played_item_id:
-                    self._played_item_id = item_id
-                    self._played_frames = 0
-                self._played_frames += played_frames
+            chunk = self._take_playback(wanted)
+        output_level = _pcm16_rms(chunk)
+        with self._lock:
+            self._output_level = output_level
+        outdata[: len(chunk)] = chunk
+        if len(chunk) < wanted:
+            outdata[len(chunk) :] = b"\x00" * (wanted - len(chunk))
 
-    def _take_playback(
-        self, wanted: int
-    ) -> tuple[bytes, list[tuple[str | None, int]]]:
+    def _take_playback(self, wanted: int) -> bytes:
         parts: list[bytes] = []
-        segments: list[tuple[str | None, int]] = []
         remaining = wanted
         packet = self._residual
         self._residual = None
@@ -354,13 +350,17 @@ class DuplexAudio:
             item_id, data = packet
             taken = data[:remaining]
             parts.append(taken)
-            frames = len(taken) // FRAME_BYTES
-            if frames:
-                segments.append((item_id, frames))
+            self._queued_playback_bytes -= len(taken)
+            played_frames = len(taken) // FRAME_BYTES
+            if played_frames:
+                if item_id != self._played_item_id:
+                    self._played_item_id = item_id
+                    self._played_frames = 0
+                self._played_frames += played_frames
             remaining -= len(taken)
             packet = (item_id, data[len(taken) :]) if len(taken) < len(data) else None
         self._residual = packet
-        return b"".join(parts), segments
+        return b"".join(parts)
 
     # -- session interface ----------------------------------------------------
 
@@ -377,8 +377,14 @@ class DuplexAudio:
 
         if not pcm:
             return
-        with self._lock, contextlib.suppress(queue.Full):
-            self._playback.put_nowait((item_id, pcm))
+        with self._lock:
+            if self._queued_playback_bytes + len(pcm) > MAX_PLAYBACK_BYTES:
+                return
+            try:
+                self._playback.put_nowait((item_id, pcm))
+            except queue.Full:
+                return
+            self._queued_playback_bytes += len(pcm)
 
     def drain_playback(self) -> tuple[str | None, int]:
         """Discard unheard audio and atomically return the heard boundary."""
@@ -390,6 +396,7 @@ class DuplexAudio:
                 except queue.Empty:
                     break
             self._residual = None
+            self._queued_playback_bytes = 0
             boundary = (
                 self._played_item_id,
                 int(self._played_frames * 1000 / SAMPLE_RATE),

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -18,6 +18,7 @@ already generated far more than the operator heard.
 from __future__ import annotations
 
 import contextlib
+import math
 import queue
 import threading
 
@@ -36,6 +37,12 @@ FRAME_BYTES = SAMPLE_WIDTH * CHANNELS
 #: the tighter of the two: stale microphone audio is worse than dropped audio.
 MAX_INPUT_BLOCKS = 50
 MAX_PLAYBACK_BLOCKS = 200
+
+# Match OMP's live controller: while model audio is playing, microphone blocks
+# below the acoustic echo floor are local playback leakage, not barge-in.
+OUTPUT_ACTIVE_LEVEL = 0.015
+MIN_BARGE_IN_LEVEL = 0.04
+OUTPUT_ECHO_RATIO = 0.65
 
 _INSTALL_HINT = (
     'audio support is not installed — run: pip install "hermes-talk[audio]" '
@@ -74,6 +81,15 @@ def _device(raw: str | None) -> str | int | None:
         return None
     return int(raw) if raw.lstrip("-").isdigit() else raw
 
+def _pcm16_rms(pcm: bytes) -> float:
+    """Normalized RMS for little-endian mono PCM16 without copying samples."""
+
+    if not pcm:
+        return 0.0
+    samples = memoryview(pcm).cast("h")
+    sum_squares = sum(sample * sample for sample in samples)
+    return min(1.0, math.sqrt(sum_squares / len(samples)) / 32_768)
+
 
 class DuplexAudio:
     """Full-duplex pcm16 capture and playback over PortAudio."""
@@ -84,6 +100,7 @@ class DuplexAudio:
         self._residual = b""
         self._lock = threading.Lock()
         self._played_frames = 0
+        self._output_level = 0.0
         self._in_stream = None
         self._out_stream = None
 
@@ -133,10 +150,18 @@ class DuplexAudio:
     # -- PortAudio callbacks (audio thread) -----------------------------------
 
     def _input_callback(self, indata, _frames, _time, _status) -> None:
+        pcm = bytes(indata)
+        input_level = _pcm16_rms(pcm)
+        with self._lock:
+            output_level = self._output_level
+        output_active = output_level > OUTPUT_ACTIVE_LEVEL
+        echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
+        if output_active and input_level < echo_threshold:
+            return
         # Drop the block rather than stall the device: a blocked PortAudio
         # callback is a glitch the operator hears.
         with contextlib.suppress(queue.Full):
-            self._input.put_nowait(bytes(indata))
+            self._input.put_nowait(pcm)
 
     def _output_callback(self, outdata, frames, _time, _status) -> None:
         wanted = frames * FRAME_BYTES
@@ -145,6 +170,7 @@ class DuplexAudio:
         if len(chunk) < wanted:
             outdata[len(chunk) :] = b"\x00" * (wanted - len(chunk))
         with self._lock:
+            self._output_level = _pcm16_rms(chunk)
             self._played_frames += len(chunk) // FRAME_BYTES
 
     def _take_playback(self, wanted: int) -> bytes:

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -1267,16 +1267,20 @@ async def run_talk_session(
 
     def on_barge_in() -> None:
         played = audio.played_ms
-        audio.drain_playback()
+        boundary = audio.drain_playback()
+        played_item = None
+        if boundary is not None:
+            played_item, played = boundary
         if relay.response_active:
             # An approval question interrupted mid-ask is a question not fully
             # heard: the bridge denies it. Speech after the prompt's response
             # finished (response_active False) is an answer, never a barge-in.
             talk_approvals.note_barge_in()
-        if relay.last_audio_item_id and played > 0:
+        item_id = played_item or relay.last_audio_item_id
+        if item_id and played > 0:
             pending.append(
                 talk_realtime.TruncateOutput(
-                    item_id=relay.last_audio_item_id, audio_end_ms=played
+                    item_id=item_id, audio_end_ms=played
                 )
             )
 

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -51,6 +51,16 @@ def test_input_chunks_round_trip():
 def _pcm16(amplitude: int, frames: int = 32) -> bytes:
     return struct.pack(f"<{frames}h", *([amplitude] * frames))
 
+class _SpeechDetector:
+    def __init__(self, speech: bool):
+        self.speech = speech
+        self.calls = 0
+
+    def is_speech(self, _frame: bytes, sample_rate: int) -> bool:
+        assert sample_rate == 8_000
+        self.calls += 1
+        return self.speech
+
 
 def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
     audio = talk_audio.DuplexAudio()
@@ -64,15 +74,30 @@ def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
 
 
 def test_voice_above_omp_barge_in_threshold_interrupts_playback():
-    audio = talk_audio.DuplexAudio()
-    playback = _pcm16(20_000)
+    detector = _SpeechDetector(True)
+    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
-    audio._output_callback(_Buffer(len(playback)), 32, None, None)
-    barge_in = _pcm16(30_000)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+    barge_in = _pcm16(30_000, 2_400)
 
-    audio._input_callback(barge_in, 32, None, None)
+    audio._input_callback(barge_in, 2_400, None, None)
 
     assert audio.read_input_chunk() == barge_in
+    assert detector.calls > 0
+
+
+def test_loud_room_noise_does_not_interrupt_playback():
+    detector = _SpeechDetector(False)
+    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    playback = _pcm16(20_000, 2_400)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+
+    audio._input_callback(_pcm16(30_000, 2_400), 2_400, None, None)
+
+    assert detector.calls > 0
+    assert audio.read_input_chunk() is None
 
 
 def test_microphone_audio_passes_when_playback_is_silent():

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -374,6 +374,20 @@ def test_full_playback_queue_drops_instead_of_blocking():
     assert audio._playback.qsize() == talk_audio.MAX_PLAYBACK_BLOCKS
 
 
+def test_playback_queue_is_bounded_by_bytes_not_only_packet_count():
+    audio = talk_audio.DuplexAudio()
+
+    audio.queue_playback(b"\x00" * (talk_audio.MAX_PLAYBACK_BYTES + 2))
+
+    assert audio._playback.qsize() == 0
+    assert audio._queued_playback_bytes == 0
+    audio.queue_playback(b"\x01\x02\x03\x04")
+    audio._output_callback(_Buffer(2), 1, None, None)
+    assert audio._queued_playback_bytes == 2
+    audio.drain_playback()
+    assert audio._queued_playback_bytes == 0
+
+
 def test_stop_is_safe_before_start_and_twice():
     audio = talk_audio.DuplexAudio()
     audio.stop()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -32,6 +32,16 @@ def test_lazy_import_failure_names_the_extra(monkeypatch):
         talk_audio.import_sounddevice()
     assert talk_audio.audio_available() is False
 
+def test_audio_is_unavailable_without_webrtc_vad(monkeypatch):
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: object())
+    monkeypatch.setattr(
+        talk_audio,
+        "import_webrtcvad",
+        lambda: (_ for _ in ()).throw(talk_audio.TalkAudioError("missing VAD")),
+    )
+
+    assert talk_audio.audio_available() is False
+
 
 def test_device_override_parses_index_or_name():
     assert talk_audio._device(None) is None
@@ -104,6 +114,41 @@ def test_linux_default_audio_uses_pulse_webrtc_echo_cancellation(monkeypatch):
     audio.stop()
 
     assert commands[-1] == ["/usr/bin/pactl", "unload-module", "42"]
+
+def test_pulse_device_open_failure_retries_original_devices(monkeypatch):
+    class FailingPulseSoundDevice(_SoundDevice):
+        def RawInputStream(self, **kwargs):
+            if kwargs["device"] == "pulse":
+                raise RuntimeError("Pulse route is unavailable")
+            return super().RawInputStream(**kwargs)
+
+    sd = FailingPulseSoundDevice()
+    commands = []
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
+    monkeypatch.setattr(
+        talk_audio,
+        "import_webrtcvad",
+        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
+    )
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda _command: "/usr/bin/pactl")
+    monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
+    monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: None)
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        return _CompletedProcess("42\n")
+
+    monkeypatch.setattr(talk_audio.subprocess, "run", run)
+    audio = talk_audio.DuplexAudio()
+
+    audio.start()
+
+    assert sd.input_stream.kwargs["device"] is None
+    assert sd.output_stream.kwargs["device"] is None
+    assert commands[-1] == ["/usr/bin/pactl", "unload-module", "42"]
+    assert audio._pulse_webrtc.active is False
+    audio.stop()
 
 
 def test_pulse_echo_cancelled_input_is_never_amplitude_gated(monkeypatch):
@@ -184,14 +229,28 @@ class _SpeechDetector:
 
 
 def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
-    audio = talk_audio.DuplexAudio()
-    playback = _pcm16(20_000)
+    detector = _SpeechDetector(False)
+    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
-    audio._output_callback(_Buffer(len(playback)), 32, None, None)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
 
-    audio._input_callback(_pcm16(5_000), 32, None, None)
+    audio._input_callback(_pcm16(5_000, 2_400), 2_400, None, None)
 
     assert audio.read_input_chunk() is None
+
+def test_webrtc_speech_overrides_fallback_echo_amplitude_gate():
+    detector = _SpeechDetector(True)
+    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    playback = _pcm16(20_000, 2_400)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+    moderate_speech = _pcm16(5_000, 2_400)
+
+    audio._input_callback(moderate_speech, 2_400, None, None)
+
+    assert detector.calls > 0
+    assert audio.read_input_chunk() == moderate_speech
 
 
 def test_voice_above_omp_barge_in_threshold_interrupts_playback():
@@ -310,3 +369,57 @@ def test_stop_is_safe_before_start_and_twice():
     audio = talk_audio.DuplexAudio()
     audio.stop()
     audio.stop()
+
+
+def test_pulse_stop_preserves_environment_when_never_started_or_load_failed(monkeypatch):
+    monkeypatch.setenv("PULSE_SOURCE", "external-source")
+    monkeypatch.setenv("PULSE_SINK", "external-sink")
+    route = talk_audio._PulseWebRtcAudio()
+    route.stop()
+    route.stop()
+    assert talk_audio.os.environ["PULSE_SOURCE"] == "external-source"
+    assert talk_audio.os.environ["PULSE_SINK"] == "external-sink"
+
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda _command: "/usr/bin/pactl")
+    monkeypatch.setattr(
+        talk_audio.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("load failed")),
+    )
+    assert route.start(None, None) == (None, None)
+    route.stop()
+    assert talk_audio.os.environ["PULSE_SOURCE"] == "external-source"
+    assert talk_audio.os.environ["PULSE_SINK"] == "external-sink"
+
+
+@pytest.mark.parametrize("stop_order", [(0, 1), (1, 0)])
+def test_concurrent_pulse_routes_restore_environment_in_either_order(
+    monkeypatch, stop_order
+):
+    monkeypatch.setenv("PULSE_SOURCE", "original-source")
+    monkeypatch.setenv("PULSE_SINK", "original-sink")
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda _command: "/usr/bin/pactl")
+    module_ids = iter(("41\n", "42\n"))
+    monkeypatch.setattr(
+        talk_audio.subprocess,
+        "run",
+        lambda command, **_kwargs: _CompletedProcess(next(module_ids))
+        if command[1] == "load-module"
+        else _CompletedProcess(""),
+    )
+    routes = [talk_audio._PulseWebRtcAudio(), talk_audio._PulseWebRtcAudio()]
+    routes[0].start(None, None)
+    first_source = routes[0]._source_name
+    routes[1].start(None, None)
+    second_source = routes[1]._source_name
+    assert first_source != second_source
+
+    routes[stop_order[0]].stop()
+    survivor = routes[stop_order[1]]
+    assert talk_audio.os.environ["PULSE_SOURCE"] == survivor._source_name
+    routes[stop_order[1]].stop()
+
+    assert talk_audio.os.environ["PULSE_SOURCE"] == "original-source"
+    assert talk_audio.os.environ["PULSE_SINK"] == "original-sink"

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -295,12 +295,21 @@ def test_microphone_audio_passes_when_playback_is_silent():
     assert audio.read_input_chunk() == microphone
 
 
-def test_full_input_queue_drops_instead_of_blocking():
+def test_full_input_queue_keeps_newest_audio_without_blocking():
     audio = talk_audio.DuplexAudio()
-    for _ in range(talk_audio.MAX_INPUT_BLOCKS + 10):
+    oldest = b"\x01\x00"
+    newest = b"\x02\x00"
+    audio._input_callback(oldest, 1, None, None)
+    for _ in range(talk_audio.MAX_INPUT_BLOCKS - 1):
         audio._input_callback(b"\x00\x00", 1, None, None)
 
+    audio._input_callback(newest, 1, None, None)
+
     assert audio._input.qsize() == talk_audio.MAX_INPUT_BLOCKS
+    assert audio.read_input_chunk() != oldest
+    queued = [audio.read_input_chunk() for _ in range(talk_audio.MAX_INPUT_BLOCKS - 1)]
+    assert queued[-1] == newest
+    assert audio.dropped_input_blocks == 1
 
 
 def test_playback_spans_queue_chunk_boundaries():
@@ -386,6 +395,7 @@ def test_playback_queue_is_bounded_by_bytes_not_only_packet_count():
     assert audio._queued_playback_bytes == 2
     audio.drain_playback()
     assert audio._queued_playback_bytes == 0
+    assert audio.dropped_playback_bytes == talk_audio.MAX_PLAYBACK_BYTES + 2
 
 
 def test_stop_is_safe_before_start_and_twice():

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -39,6 +39,127 @@ def test_device_override_parses_index_or_name():
     assert talk_audio._device("Speakers (Realtek)") == "Speakers (Realtek)"
 
 
+class _Stream:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class _SoundDevice:
+    def __init__(self):
+        self.input_stream = None
+        self.output_stream = None
+
+    def RawInputStream(self, **kwargs):
+        self.input_stream = _Stream(**kwargs)
+        return self.input_stream
+
+    def RawOutputStream(self, **kwargs):
+        self.output_stream = _Stream(**kwargs)
+        return self.output_stream
+
+
+class _CompletedProcess:
+    def __init__(self, stdout: str):
+        self.stdout = stdout
+
+
+def test_linux_default_audio_uses_pulse_webrtc_echo_cancellation(monkeypatch):
+    sd = _SoundDevice()
+    commands = []
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
+    monkeypatch.setattr(
+        talk_audio,
+        "import_webrtcvad",
+        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
+    )
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda command: f"/usr/bin/{command}")
+    monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
+    monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: None)
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        return _CompletedProcess("42\n")
+
+    monkeypatch.setattr(talk_audio.subprocess, "run", run)
+    audio = talk_audio.DuplexAudio()
+
+    audio.start()
+
+    assert commands[0][1:3] == ["load-module", "module-echo-cancel"]
+    assert sd.input_stream.kwargs["device"] == "pulse"
+    assert sd.output_stream.kwargs["device"] == "pulse"
+    assert talk_audio.os.environ["PULSE_SOURCE"].startswith("hermes_talk_aec_")
+    assert talk_audio.os.environ["PULSE_SINK"].startswith("hermes_talk_aec_sink_")
+
+    audio.stop()
+
+    assert commands[-1] == ["/usr/bin/pactl", "unload-module", "42"]
+
+
+def test_pulse_echo_cancelled_input_is_never_amplitude_gated(monkeypatch):
+    sd = _SoundDevice()
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
+    monkeypatch.setattr(
+        talk_audio,
+        "import_webrtcvad",
+        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(False)}),
+    )
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda command: f"/usr/bin/{command}")
+    monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
+    monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: None)
+    monkeypatch.setattr(
+        talk_audio.subprocess,
+        "run",
+        lambda *_args, **_kwargs: _CompletedProcess("42\n"),
+    )
+    audio = talk_audio.DuplexAudio()
+    audio.start()
+    playback = _pcm16(20_000, 2_400)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+    quiet_speech = _pcm16(2_000, 2_400)
+
+    audio._input_callback(quiet_speech, 2_400, None, None)
+
+    assert audio.read_input_chunk() == quiet_speech
+    audio.stop()
+
+
+def test_explicit_devices_skip_pulse_echo_module(monkeypatch):
+    sd = _SoundDevice()
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
+    monkeypatch.setattr(
+        talk_audio,
+        "import_webrtcvad",
+        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
+    )
+    monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: "microphone")
+    monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: "speaker")
+    monkeypatch.setattr(
+        talk_audio.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("explicit devices must not load a PulseAudio module"),
+    )
+    audio = talk_audio.DuplexAudio()
+
+    audio.start()
+
+    assert sd.input_stream.kwargs["device"] == "microphone"
+    assert sd.output_stream.kwargs["device"] == "speaker"
+    audio.stop()
+
+
 def test_input_chunks_round_trip():
     audio = talk_audio.DuplexAudio()
     assert audio.read_input_chunk() is None

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import struct
 import sys
+import threading
+import time
 
 import pytest
 
@@ -32,15 +34,10 @@ def test_lazy_import_failure_names_the_extra(monkeypatch):
         talk_audio.import_sounddevice()
     assert talk_audio.audio_available() is False
 
-def test_audio_is_unavailable_without_webrtc_vad(monkeypatch):
+def test_audio_availability_only_requires_sounddevice(monkeypatch):
     monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: object())
-    monkeypatch.setattr(
-        talk_audio,
-        "import_webrtcvad",
-        lambda: (_ for _ in ()).throw(talk_audio.TalkAudioError("missing VAD")),
-    )
 
-    assert talk_audio.audio_available() is False
+    assert talk_audio.audio_available() is True
 
 
 def test_device_override_parses_index_or_name():
@@ -86,11 +83,6 @@ def test_linux_default_audio_uses_pulse_webrtc_echo_cancellation(monkeypatch):
     sd = _SoundDevice()
     commands = []
     monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
-    monkeypatch.setattr(
-        talk_audio,
-        "import_webrtcvad",
-        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
-    )
     monkeypatch.setattr(talk_audio.sys, "platform", "linux")
     monkeypatch.setattr(talk_audio.shutil, "which", lambda command: f"/usr/bin/{command}")
     monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
@@ -125,11 +117,6 @@ def test_pulse_device_open_failure_retries_original_devices(monkeypatch):
     sd = FailingPulseSoundDevice()
     commands = []
     monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
-    monkeypatch.setattr(
-        talk_audio,
-        "import_webrtcvad",
-        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
-    )
     monkeypatch.setattr(talk_audio.sys, "platform", "linux")
     monkeypatch.setattr(talk_audio.shutil, "which", lambda _command: "/usr/bin/pactl")
     monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
@@ -154,11 +141,6 @@ def test_pulse_device_open_failure_retries_original_devices(monkeypatch):
 def test_pulse_echo_cancelled_input_is_never_amplitude_gated(monkeypatch):
     sd = _SoundDevice()
     monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
-    monkeypatch.setattr(
-        talk_audio,
-        "import_webrtcvad",
-        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(False)}),
-    )
     monkeypatch.setattr(talk_audio.sys, "platform", "linux")
     monkeypatch.setattr(talk_audio.shutil, "which", lambda command: f"/usr/bin/{command}")
     monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
@@ -184,11 +166,6 @@ def test_pulse_echo_cancelled_input_is_never_amplitude_gated(monkeypatch):
 def test_explicit_devices_skip_pulse_echo_module(monkeypatch):
     sd = _SoundDevice()
     monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
-    monkeypatch.setattr(
-        talk_audio,
-        "import_webrtcvad",
-        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
-    )
     monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: "microphone")
     monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: "speaker")
     monkeypatch.setattr(
@@ -205,6 +182,48 @@ def test_explicit_devices_skip_pulse_echo_module(monkeypatch):
     audio.stop()
 
 
+def test_audio_start_serializes_pulse_environment_through_stream_open(monkeypatch):
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: object())
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda _command: "/usr/bin/pactl")
+    monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
+    monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: None)
+    module_ids = iter(("41", "42"))
+    monkeypatch.setattr(
+        talk_audio.subprocess,
+        "run",
+        lambda command, **_kwargs: _CompletedProcess(next(module_ids))
+        if command[1] == "load-module"
+        else _CompletedProcess(""),
+    )
+    active_opens = 0
+    maximum_active_opens = 0
+    lock = threading.Lock()
+
+    def open_streams(audio, _sd, _input_device, _output_device):
+        nonlocal active_opens, maximum_active_opens
+        with lock:
+            active_opens += 1
+            maximum_active_opens = max(maximum_active_opens, active_opens)
+            assert talk_audio.os.environ["PULSE_SOURCE"] == audio._pulse_webrtc._source_name
+        time.sleep(0.02)
+        with lock:
+            active_opens -= 1
+
+    monkeypatch.setattr(talk_audio.DuplexAudio, "_open_streams", open_streams)
+    sessions = [talk_audio.DuplexAudio(), talk_audio.DuplexAudio()]
+    workers = [threading.Thread(target=session.start) for session in sessions]
+
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    assert maximum_active_opens == 1
+    for session in sessions:
+        session.stop()
+
+
 def test_input_chunks_round_trip():
     audio = talk_audio.DuplexAudio()
     assert audio.read_input_chunk() is None
@@ -217,20 +236,10 @@ def test_input_chunks_round_trip():
 def _pcm16(amplitude: int, frames: int = 32) -> bytes:
     return struct.pack(f"<{frames}h", *([amplitude] * frames))
 
-class _SpeechDetector:
-    def __init__(self, speech: bool):
-        self.speech = speech
-        self.calls = 0
-
-    def is_speech(self, _frame: bytes, sample_rate: int) -> bool:
-        assert sample_rate == 8_000
-        self.calls += 1
-        return self.speech
 
 
 def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
-    detector = _SpeechDetector(False)
-    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    audio = talk_audio.DuplexAudio()
     playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
     audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
@@ -239,9 +248,8 @@ def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
 
     assert audio.read_input_chunk() is None
 
-def test_webrtc_speech_overrides_fallback_echo_amplitude_gate():
-    detector = _SpeechDetector(True)
-    audio = talk_audio.DuplexAudio(speech_detector=detector)
+def test_fallback_gate_does_not_allow_vad_to_override_omp_threshold():
+    audio = talk_audio.DuplexAudio()
     playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
     audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
@@ -249,13 +257,11 @@ def test_webrtc_speech_overrides_fallback_echo_amplitude_gate():
 
     audio._input_callback(moderate_speech, 2_400, None, None)
 
-    assert detector.calls > 0
-    assert audio.read_input_chunk() == moderate_speech
+    assert audio.read_input_chunk() is None
 
 
 def test_voice_above_omp_barge_in_threshold_interrupts_playback():
-    detector = _SpeechDetector(True)
-    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    audio = talk_audio.DuplexAudio()
     playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
     audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
@@ -264,20 +270,18 @@ def test_voice_above_omp_barge_in_threshold_interrupts_playback():
     audio._input_callback(barge_in, 2_400, None, None)
 
     assert audio.read_input_chunk() == barge_in
-    assert detector.calls > 0
 
 
-def test_loud_room_noise_does_not_interrupt_playback():
-    detector = _SpeechDetector(False)
-    audio = talk_audio.DuplexAudio(speech_detector=detector)
+def test_loud_input_above_omp_threshold_is_uploaded():
+    audio = talk_audio.DuplexAudio()
     playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
     audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+    loud_input = _pcm16(30_000, 2_400)
 
-    audio._input_callback(_pcm16(30_000, 2_400), 2_400, None, None)
+    audio._input_callback(loud_input, 2_400, None, None)
 
-    assert detector.calls > 0
-    assert audio.read_input_chunk() is None
+    assert audio.read_input_chunk() == loud_input
 
 
 def test_microphone_audio_passes_when_playback_is_silent():
@@ -336,19 +340,24 @@ def test_drain_playback_discards_queue_and_residual():
     assert bytes(out.data) == b"\x00\x00\x00\x00"
 
 
-def test_played_ms_survives_a_drain_until_reset():
+def test_drain_returns_and_resets_the_atomic_heard_boundary():
     audio = talk_audio.DuplexAudio()
-    audio.queue_playback(b"\x00\x00" * 2_400)
+    audio.queue_playback(b"\x00\x00" * 2_400, item_id="item-1")
     audio._output_callback(_Buffer(4_800), 2_400, None, None)
 
     assert audio.played_ms == 100
-    # The truncate has to be measured AFTER the drain, so the counter cannot
-    # be cleared by the drain itself.
-    audio.drain_playback()
-    assert audio.played_ms == 100
-
-    audio.reset_played_ms()
+    assert audio.drain_playback() == ("item-1", 100)
     assert audio.played_ms == 0
+
+
+def test_callback_crossing_items_attributes_boundary_to_new_item():
+    audio = talk_audio.DuplexAudio()
+    audio.queue_playback(b"\x01\x00" * 2_400, item_id="old")
+    audio.queue_playback(b"\x02\x00" * 1_200, item_id="new")
+
+    audio._output_callback(_Buffer(7_200), 3_600, None, None)
+
+    assert audio.drain_playback() == ("new", 50)
 
 
 def test_empty_playback_is_ignored():

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -7,6 +7,7 @@ real device is a canary step, not a CI step.
 
 from __future__ import annotations
 
+import struct
 import sys
 
 import pytest
@@ -46,6 +47,43 @@ def test_input_chunks_round_trip():
 
     assert audio.read_input_chunk() == b"\x01\x02"
     assert audio.read_input_chunk() is None
+
+def _pcm16(amplitude: int, frames: int = 32) -> bytes:
+    return struct.pack(f"<{frames}h", *([amplitude] * frames))
+
+
+def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
+    audio = talk_audio.DuplexAudio()
+    playback = _pcm16(20_000)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 32, None, None)
+
+    audio._input_callback(_pcm16(5_000), 32, None, None)
+
+    assert audio.read_input_chunk() is None
+
+
+def test_voice_above_omp_barge_in_threshold_interrupts_playback():
+    audio = talk_audio.DuplexAudio()
+    playback = _pcm16(20_000)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 32, None, None)
+    barge_in = _pcm16(30_000)
+
+    audio._input_callback(barge_in, 32, None, None)
+
+    assert audio.read_input_chunk() == barge_in
+
+
+def test_microphone_audio_passes_when_playback_is_silent():
+    audio = talk_audio.DuplexAudio()
+    silence = _Buffer(64)
+    audio._output_callback(silence, 32, None, None)
+    microphone = _pcm16(2_000)
+
+    audio._input_callback(microphone, 32, None, None)
+
+    assert audio.read_input_chunk() == microphone
 
 
 def test_full_input_queue_drops_instead_of_blocking():


### PR DESCRIPTION
## Summary
- suppress speaker feedback before it reaches server VAD
- use WebRTC speech detection for fallback barge-in gating
- route default Linux audio through PulseAudio WebRTC echo cancellation/noise suppression
- bypass the fallback amplitude gate once upstream AEC is active, preventing quiet words and numeric ranges from being clipped

## Root cause
PulseAudio had already removed playback echo, but the application applied a second amplitude/VAD filter and discarded full 100 ms microphone blocks during assistant playback.

## Verification
- `pytest -q tests/test_audio.py` — 18 passed
- `ruff check .` — passed
- regression proves quiet input survives assistant playback when PulseAudio AEC is active