### PR TITLE
feat(core): adopt Hermes realtime voice contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,18 @@ named rather than smoothed.
 
 ## [Unreleased]
 
+### Added
+- `hermes-talk` now implements the provider/session contract from Hermes
+  #95147. The plugin owns OpenAI transport while Hermes's coordinator owns
+  tool dispatch, heard-audio truncation, cancellation, and transcript memory.
+  Terminal sessions emit `listening`, `solving`, and `composing` lifecycle
+  phases for the TUI orb without introducing another core transport.
+
 ### Fixed
 - Linux terminal calls now route default audio through PulseAudio's WebRTC
-  echo canceller and noise suppressor. Echo-cancelled input bypasses the
-  fallback amplitude/VAD gate so barge-in does not clip quiet words.
+  echo canceller and noise suppressor. The fallback path matches OMP's
+  output-relative amplitude gate, and heard-audio boundaries are captured
+  atomically with playback drain.
 ## [0.16.0] — 2026-09-01
 
 Grok voice on a SuperGrok / X Premium+ subscription. `hermes auth add

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ but 0.4.0's release title named only the steering verb. They are recorded
 below under 0.4.0 — the first version that shipped them — with the gap
 named rather than smoothed.
 
+## [Unreleased]
+
+### Fixed
+- Linux terminal calls now route default audio through PulseAudio's WebRTC
+  echo canceller and noise suppressor. Echo-cancelled input bypasses the
+  fallback amplitude/VAD gate so barge-in does not clip quiet words.
 ## [0.16.0] — 2026-09-01
 
 Grok voice on a SuperGrok / X Premium+ subscription. `hermes auth add
@@ -48,7 +54,6 @@ lane rides the Codex CLI's.
 - Reading Grok Build CLI's `~/.grok/auth.json`; a device-code login inside
   the plugin; any write to any auth store. The dashboard tab stays
   OpenAI-only.
-
 ## [0.15.1] — 2026-09-01
 
 Voice hears you again on end-to-end-encrypted Discord calls. 0.15.0's

--- a/__init__.py
+++ b/__init__.py
@@ -93,7 +93,7 @@ def _attempt_registration(
 
 
 def _attempt_boolean_registration(ctx, method_name: str, surface: str, receipt: str, *args) -> None:
-    """Record exact acceptance for host registries with boolean receipts."""
+    """Record acceptance for boolean and handle-returning host registries."""
 
     method = getattr(ctx, method_name, None)
     if not callable(method):
@@ -104,7 +104,9 @@ def _attempt_boolean_registration(ctx, method_name: str, surface: str, receipt: 
     except Exception as exc:  # noqa: BLE001 - isolate optional registration
         _record(surface, receipt, exc)
         return
-    REGISTRATION_RECEIPTS[receipt] = "registered" if accepted is True else "rejected"
+    REGISTRATION_RECEIPTS[receipt] = (
+        "registered" if accepted is not None and accepted is not False else "rejected"
+    )
 
 
 def _register_talk_command(ctx) -> None:
@@ -212,13 +214,16 @@ def register(ctx) -> None:
     REGISTRATION_RECEIPTS.clear()
     talk_host.bind_ctx(ctx)
 
-    if talk_core_realtime.core_provider_available():
+    if (
+        talk_core_realtime.core_provider_available()
+        and talk_core_realtime.configured_core_provider_supported()
+    ):
         _attempt_boolean_registration(
             ctx,
             "register_realtime_voice_provider",
             "realtime voice provider",
             "realtime_voice_provider",
-            talk_core_realtime.TalkOpenAIRealtimeProvider(),
+            talk_core_realtime.configured_core_provider(),
         )
     else:
         _unsupported("realtime voice provider", "realtime_voice_provider")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ py-modules = [
   "talk_progress",
   "talk_realtime",
   "talk_openai_realtime",
+  "talk_gemini_auth",
   "talk_grok_auth",
   "talk_grok_realtime",
   "talk_gemini_realtime",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ py-modules = [
   "talk_grok_realtime",
   "talk_gemini_realtime",
   "talk_core_realtime",
+  "talk_core_cli",
+  "talk_core_realtime_contract",
   "talk_core_session",
   "talk_discord",
   "talk_relay",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "SmokeDev" }]
 dependencies = ["httpx>=0.27", "aiohttp>=3.9"]
 
 [project.optional-dependencies]
-audio = ["sounddevice>=0.4.6", "numpy>=1.26"]
+audio = ["sounddevice>=0.4.6", "numpy>=1.26", "webrtcvad-wheels>=2.0.14"]
 dev = ["pytest>=8", "ruff>=0.4"]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "SmokeDev" }]
 dependencies = ["httpx>=0.27", "aiohttp>=3.9"]
 
 [project.optional-dependencies]
-audio = ["sounddevice>=0.4.6", "numpy>=1.26", "webrtcvad-wheels>=2.0.14"]
+audio = ["sounddevice>=0.4.6", "numpy>=1.26"]
 dev = ["pytest>=8", "ruff>=0.4"]
 
 [build-system]

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -43,6 +43,10 @@ MAX_PLAYBACK_BLOCKS = 200
 OUTPUT_ACTIVE_LEVEL = 0.015
 MIN_BARGE_IN_LEVEL = 0.04
 OUTPUT_ECHO_RATIO = 0.65
+VAD_SAMPLE_RATE = 8_000
+VAD_FRAME_SAMPLES = 240  # 30 ms
+VAD_FRAME_BYTES = VAD_FRAME_SAMPLES * SAMPLE_WIDTH
+VAD_SPEECH_FRAMES = 2  # 60 ms filters transient room noise, stays under OMP's 150 ms target
 
 _INSTALL_HINT = (
     'audio support is not installed — run: pip install "hermes-talk[audio]" '
@@ -62,6 +66,15 @@ def import_sounddevice():
     except (ImportError, OSError) as exc:
         raise TalkAudioError(f"{_INSTALL_HINT} ({exc})") from exc
     return sd
+
+def import_webrtcvad():
+    """Lazy-import the speech classifier shipped by the audio extra."""
+
+    try:
+        import webrtcvad
+    except (ImportError, OSError) as exc:
+        raise TalkAudioError(f"{_INSTALL_HINT} ({exc})") from exc
+    return webrtcvad
 
 
 def audio_available() -> bool:
@@ -90,17 +103,29 @@ def _pcm16_rms(pcm: bytes) -> float:
     sum_squares = sum(sample * sample for sample in samples)
     return min(1.0, math.sqrt(sum_squares / len(samples)) / 32_768)
 
+def _downsample_24k_to_8k(pcm: bytes) -> bytes:
+    """Decimate PCM16 by three for WebRTC VAD's supported 8 kHz input."""
+
+    source = memoryview(pcm).cast("h")
+    target = bytearray((len(source) // 3) * SAMPLE_WIDTH)
+    samples = memoryview(target).cast("h")
+    for index in range(len(samples)):
+        samples[index] = source[index * 3]
+    return bytes(target)
+
 
 class DuplexAudio:
     """Full-duplex pcm16 capture and playback over PortAudio."""
 
-    def __init__(self) -> None:
+    def __init__(self, speech_detector=None) -> None:
         self._input: queue.Queue[bytes] = queue.Queue(maxsize=MAX_INPUT_BLOCKS)
         self._playback: queue.Queue[bytes] = queue.Queue(maxsize=MAX_PLAYBACK_BLOCKS)
         self._residual = b""
         self._lock = threading.Lock()
         self._played_frames = 0
         self._output_level = 0.0
+        self._speech_detector = speech_detector
+        self._speech_run_frames = 0
         self._in_stream = None
         self._out_stream = None
 
@@ -110,6 +135,8 @@ class DuplexAudio:
         """Open both streams. Raises :class:`TalkAudioError` when it cannot."""
 
         sd = import_sounddevice()
+        if self._speech_detector is None:
+            self._speech_detector = import_webrtcvad().Vad(3)
         try:
             self._in_stream = sd.RawInputStream(
                 samplerate=SAMPLE_RATE,
@@ -147,6 +174,21 @@ class DuplexAudio:
                 pass
             setattr(self, attr, None)
 
+    def _contains_speech(self, pcm: bytes) -> bool:
+        detector = self._speech_detector
+        if detector is None:
+            return True
+        downsampled = _downsample_24k_to_8k(pcm)
+        for offset in range(0, len(downsampled) - VAD_FRAME_BYTES + 1, VAD_FRAME_BYTES):
+            frame = downsampled[offset : offset + VAD_FRAME_BYTES]
+            if detector.is_speech(frame, VAD_SAMPLE_RATE):
+                self._speech_run_frames += 1
+                if self._speech_run_frames >= VAD_SPEECH_FRAMES:
+                    return True
+            else:
+                self._speech_run_frames = 0
+        return False
+
     # -- PortAudio callbacks (audio thread) -----------------------------------
 
     def _input_callback(self, indata, _frames, _time, _status) -> None:
@@ -157,6 +199,8 @@ class DuplexAudio:
         output_active = output_level > OUTPUT_ACTIVE_LEVEL
         echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
         if output_active and input_level < echo_threshold:
+            return
+        if output_active and not self._contains_speech(pcm):
             return
         # Drop the block rather than stall the device: a blocked PortAudio
         # callback is a glitch the operator hears.

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -25,6 +25,8 @@ import shutil
 import subprocess
 import sys
 import threading
+import uuid
+from typing import ClassVar
 
 try:
     from . import talk_config
@@ -82,10 +84,11 @@ def import_webrtcvad():
 
 
 def audio_available() -> bool:
-    """True when a duplex session could actually open devices."""
+    """True when all dependencies needed by a duplex session are importable."""
 
     try:
         import_sounddevice()
+        import_webrtcvad()
     except TalkAudioError:
         return False
     return True
@@ -121,11 +124,18 @@ def _downsample_24k_to_8k(pcm: bytes) -> bytes:
 class _PulseWebRtcAudio:
     """Process-local PulseAudio WebRTC AEC/NS route for default Linux devices."""
 
+    _environment_lock = threading.Lock()
+    _active_routes: ClassVar[list[_PulseWebRtcAudio]] = []
+    _baseline_source: object | str = object()
+    _baseline_sink: object | str = object()
+    _missing = object()
+
     def __init__(self) -> None:
         self._pactl: str | None = None
         self._module_id: str | None = None
-        self._previous_source: str | None = None
-        self._previous_sink: str | None = None
+        self._source_name: str | None = None
+        self._sink_name: str | None = None
+        self._changed_environment = False
 
     @property
     def active(self) -> bool:
@@ -144,7 +154,7 @@ class _PulseWebRtcAudio:
         if pactl is None:
             return input_device, output_device
 
-        suffix = str(os.getpid())
+        suffix = f"{os.getpid()}_{uuid.uuid4().hex}"
         source_name = f"hermes_talk_aec_{suffix}"
         sink_name = f"hermes_talk_aec_sink_{suffix}"
         try:
@@ -171,21 +181,49 @@ class _PulseWebRtcAudio:
 
         self._pactl = pactl
         self._module_id = module_id
-        self._previous_source = os.environ.get("PULSE_SOURCE")
-        self._previous_sink = os.environ.get("PULSE_SINK")
-        os.environ["PULSE_SOURCE"] = source_name
-        os.environ["PULSE_SINK"] = sink_name
+        self._source_name = source_name
+        self._sink_name = sink_name
+        with self._environment_lock:
+            if not self._active_routes:
+                type(self)._baseline_source = os.environ.get("PULSE_SOURCE", self._missing)
+                type(self)._baseline_sink = os.environ.get("PULSE_SINK", self._missing)
+            self._active_routes.append(self)
+            os.environ["PULSE_SOURCE"] = source_name
+            os.environ["PULSE_SINK"] = sink_name
+            self._changed_environment = True
         return "pulse", "pulse"
 
+    @classmethod
+    def _restore(cls, name: str, baseline: object | str) -> None:
+        if baseline is cls._missing:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = baseline
+
     def stop(self) -> None:
-        if self._previous_source is None:
-            os.environ.pop("PULSE_SOURCE", None)
-        else:
-            os.environ["PULSE_SOURCE"] = self._previous_source
-        if self._previous_sink is None:
-            os.environ.pop("PULSE_SINK", None)
-        else:
-            os.environ["PULSE_SINK"] = self._previous_sink
+        with self._environment_lock:
+            if self._changed_environment:
+                self._changed_environment = False
+                with contextlib.suppress(ValueError):
+                    self._active_routes.remove(self)
+                managed_values = {
+                    route._source_name
+                    for route in self._active_routes
+                } | {self._source_name}
+                if os.environ.get("PULSE_SOURCE") in managed_values:
+                    if self._active_routes:
+                        os.environ["PULSE_SOURCE"] = self._active_routes[-1]._source_name
+                    else:
+                        self._restore("PULSE_SOURCE", self._baseline_source)
+                managed_values = {
+                    route._sink_name
+                    for route in self._active_routes
+                } | {self._sink_name}
+                if os.environ.get("PULSE_SINK") in managed_values:
+                    if self._active_routes:
+                        os.environ["PULSE_SINK"] = self._active_routes[-1]._sink_name
+                    else:
+                        self._restore("PULSE_SINK", self._baseline_sink)
 
         if self._pactl is not None and self._module_id is not None:
             with contextlib.suppress(OSError, subprocess.SubprocessError):
@@ -198,6 +236,8 @@ class _PulseWebRtcAudio:
                 )
         self._pactl = None
         self._module_id = None
+        self._source_name = None
+        self._sink_name = None
 
 
 class DuplexAudio:
@@ -224,35 +264,45 @@ class DuplexAudio:
         sd = import_sounddevice()
         if self._speech_detector is None:
             self._speech_detector = import_webrtcvad().Vad(3)
-        input_device = _device(talk_config.audio_input_device())
-        output_device = _device(talk_config.audio_output_device())
-        input_device, output_device = self._pulse_webrtc.start(input_device, output_device)
+        original_input = _device(talk_config.audio_input_device())
+        original_output = _device(talk_config.audio_output_device())
+        input_device, output_device = self._pulse_webrtc.start(
+            original_input, original_output
+        )
         try:
-            self._in_stream = sd.RawInputStream(
-                samplerate=SAMPLE_RATE,
-                blocksize=BLOCKSIZE,
-                device=input_device,
-                channels=CHANNELS,
-                dtype="int16",
-                callback=self._input_callback,
-            )
-            self._out_stream = sd.RawOutputStream(
-                samplerate=SAMPLE_RATE,
-                blocksize=BLOCKSIZE,
-                device=output_device,
-                channels=CHANNELS,
-                dtype="int16",
-                callback=self._output_callback,
-            )
-            self._in_stream.start()
-            self._out_stream.start()
-        except Exception as exc:  # PortAudio raises its own exception types
-            self.stop()
-            raise TalkAudioError(f"could not open audio devices: {exc}") from exc
+            self._open_streams(sd, input_device, output_device)
+        except Exception as routed_exc:  # PortAudio raises its own exception types
+            self._close_streams()
+            if not self._pulse_webrtc.active:
+                raise TalkAudioError(f"could not open audio devices: {routed_exc}") from routed_exc
+            self._pulse_webrtc.stop()
+            try:
+                self._open_streams(sd, original_input, original_output)
+            except Exception as exc:
+                self._close_streams()
+                raise TalkAudioError(f"could not open audio devices: {exc}") from exc
 
-    def stop(self) -> None:
-        """Close both streams. Safe to call twice, and on a failed start."""
+    def _open_streams(self, sd, input_device, output_device) -> None:
+        self._in_stream = sd.RawInputStream(
+            samplerate=SAMPLE_RATE,
+            blocksize=BLOCKSIZE,
+            device=input_device,
+            channels=CHANNELS,
+            dtype="int16",
+            callback=self._input_callback,
+        )
+        self._out_stream = sd.RawOutputStream(
+            samplerate=SAMPLE_RATE,
+            blocksize=BLOCKSIZE,
+            device=output_device,
+            channels=CHANNELS,
+            dtype="int16",
+            callback=self._output_callback,
+        )
+        self._in_stream.start()
+        self._out_stream.start()
 
+    def _close_streams(self) -> None:
         for attr in ("_in_stream", "_out_stream"):
             stream = getattr(self, attr, None)
             if stream is None:
@@ -263,6 +313,11 @@ class DuplexAudio:
             except Exception:  # noqa: BLE001 — teardown is best-effort
                 pass
             setattr(self, attr, None)
+
+    def stop(self) -> None:
+        """Close both streams. Safe to call twice, and on a failed start."""
+
+        self._close_streams()
         self._pulse_webrtc.stop()
 
     def _contains_speech(self, pcm: bytes) -> bool:
@@ -289,10 +344,12 @@ class DuplexAudio:
             output_level = self._output_level
         if not self._pulse_webrtc.active:
             output_active = output_level > OUTPUT_ACTIVE_LEVEL
-            echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
-            if output_active and input_level < echo_threshold:
-                return
-            if output_active and not self._contains_speech(pcm):
+            if output_active and self._contains_speech(pcm):
+                pass
+            elif output_active:
+                echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
+                if input_level < echo_threshold:
+                    return
                 return
         # Drop the block rather than stall the device: a blocked PortAudio
         # callback is a glitch the operator hears.

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -49,10 +49,6 @@ MAX_PLAYBACK_BLOCKS = 200
 OUTPUT_ACTIVE_LEVEL = 0.015
 MIN_BARGE_IN_LEVEL = 0.04
 OUTPUT_ECHO_RATIO = 0.65
-VAD_SAMPLE_RATE = 8_000
-VAD_FRAME_SAMPLES = 240  # 30 ms
-VAD_FRAME_BYTES = VAD_FRAME_SAMPLES * SAMPLE_WIDTH
-VAD_SPEECH_FRAMES = 2  # 60 ms filters transient room noise, stays under OMP's 150 ms target
 
 _INSTALL_HINT = (
     'audio support is not installed — run: pip install "hermes-talk[audio]" '
@@ -73,14 +69,6 @@ def import_sounddevice():
         raise TalkAudioError(f"{_INSTALL_HINT} ({exc})") from exc
     return sd
 
-def import_webrtcvad():
-    """Lazy-import the speech classifier shipped by the audio extra."""
-
-    try:
-        import webrtcvad
-    except (ImportError, OSError) as exc:
-        raise TalkAudioError(f"{_INSTALL_HINT} ({exc})") from exc
-    return webrtcvad
 
 
 def audio_available() -> bool:
@@ -88,7 +76,6 @@ def audio_available() -> bool:
 
     try:
         import_sounddevice()
-        import_webrtcvad()
     except TalkAudioError:
         return False
     return True
@@ -110,15 +97,6 @@ def _pcm16_rms(pcm: bytes) -> float:
     sum_squares = sum(sample * sample for sample in samples)
     return min(1.0, math.sqrt(sum_squares / len(samples)) / 32_768)
 
-def _downsample_24k_to_8k(pcm: bytes) -> bytes:
-    """Decimate PCM16 by three for WebRTC VAD's supported 8 kHz input."""
-
-    source = memoryview(pcm).cast("h")
-    target = bytearray((len(source) // 3) * SAMPLE_WIDTH)
-    samples = memoryview(target).cast("h")
-    for index in range(len(samples)):
-        samples[index] = source[index * 3]
-    return bytes(target)
 
 
 class _PulseWebRtcAudio:
@@ -243,15 +221,18 @@ class _PulseWebRtcAudio:
 class DuplexAudio:
     """Full-duplex pcm16 capture and playback over PortAudio."""
 
-    def __init__(self, speech_detector=None) -> None:
+    _startup_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    def __init__(self) -> None:
         self._input: queue.Queue[bytes] = queue.Queue(maxsize=MAX_INPUT_BLOCKS)
-        self._playback: queue.Queue[bytes] = queue.Queue(maxsize=MAX_PLAYBACK_BLOCKS)
-        self._residual = b""
+        self._playback: queue.Queue[tuple[str | None, bytes]] = queue.Queue(
+            maxsize=MAX_PLAYBACK_BLOCKS
+        )
+        self._residual: tuple[str | None, bytes] | None = None
         self._lock = threading.Lock()
+        self._played_item_id: str | None = None
         self._played_frames = 0
         self._output_level = 0.0
-        self._speech_detector = speech_detector
-        self._speech_run_frames = 0
         self._in_stream = None
         self._out_stream = None
         self._pulse_webrtc = _PulseWebRtcAudio()
@@ -262,25 +243,26 @@ class DuplexAudio:
         """Open both streams. Raises :class:`TalkAudioError` when it cannot."""
 
         sd = import_sounddevice()
-        if self._speech_detector is None:
-            self._speech_detector = import_webrtcvad().Vad(3)
         original_input = _device(talk_config.audio_input_device())
         original_output = _device(talk_config.audio_output_device())
-        input_device, output_device = self._pulse_webrtc.start(
-            original_input, original_output
-        )
-        try:
-            self._open_streams(sd, input_device, output_device)
-        except Exception as routed_exc:  # PortAudio raises its own exception types
-            self._close_streams()
-            if not self._pulse_webrtc.active:
-                raise TalkAudioError(f"could not open audio devices: {routed_exc}") from routed_exc
-            self._pulse_webrtc.stop()
+        with self._startup_lock:
+            input_device, output_device = self._pulse_webrtc.start(
+                original_input, original_output
+            )
             try:
-                self._open_streams(sd, original_input, original_output)
-            except Exception as exc:
+                self._open_streams(sd, input_device, output_device)
+            except Exception as routed_exc:  # PortAudio raises its own exception types
                 self._close_streams()
-                raise TalkAudioError(f"could not open audio devices: {exc}") from exc
+                if not self._pulse_webrtc.active:
+                    raise TalkAudioError(
+                        f"could not open audio devices: {routed_exc}"
+                    ) from routed_exc
+                self._pulse_webrtc.stop()
+                try:
+                    self._open_streams(sd, original_input, original_output)
+                except Exception as exc:
+                    self._close_streams()
+                    raise TalkAudioError(f"could not open audio devices: {exc}") from exc
 
     def _open_streams(self, sd, input_device, output_device) -> None:
         self._in_stream = sd.RawInputStream(
@@ -320,20 +302,6 @@ class DuplexAudio:
         self._close_streams()
         self._pulse_webrtc.stop()
 
-    def _contains_speech(self, pcm: bytes) -> bool:
-        detector = self._speech_detector
-        if detector is None:
-            return True
-        downsampled = _downsample_24k_to_8k(pcm)
-        for offset in range(0, len(downsampled) - VAD_FRAME_BYTES + 1, VAD_FRAME_BYTES):
-            frame = downsampled[offset : offset + VAD_FRAME_BYTES]
-            if detector.is_speech(frame, VAD_SAMPLE_RATE):
-                self._speech_run_frames += 1
-                if self._speech_run_frames >= VAD_SPEECH_FRAMES:
-                    return True
-            else:
-                self._speech_run_frames = 0
-        return False
 
     # -- PortAudio callbacks (audio thread) -----------------------------------
 
@@ -344,12 +312,11 @@ class DuplexAudio:
             output_level = self._output_level
         if not self._pulse_webrtc.active:
             output_active = output_level > OUTPUT_ACTIVE_LEVEL
-            if output_active and self._contains_speech(pcm):
-                pass
-            elif output_active:
-                echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
-                if input_level < echo_threshold:
-                    return
+            echo_threshold = max(
+                MIN_BARGE_IN_LEVEL,
+                output_level * OUTPUT_ECHO_RATIO,
+            )
+            if output_active and input_level < echo_threshold:
                 return
         # Drop the block rather than stall the device: a blocked PortAudio
         # callback is a glitch the operator hears.
@@ -358,23 +325,42 @@ class DuplexAudio:
 
     def _output_callback(self, outdata, frames, _time, _status) -> None:
         wanted = frames * FRAME_BYTES
-        chunk = self._take_playback(wanted)
-        outdata[: len(chunk)] = chunk
-        if len(chunk) < wanted:
-            outdata[len(chunk) :] = b"\x00" * (wanted - len(chunk))
         with self._lock:
+            chunk, segments = self._take_playback(wanted)
+            outdata[: len(chunk)] = chunk
+            if len(chunk) < wanted:
+                outdata[len(chunk) :] = b"\x00" * (wanted - len(chunk))
             self._output_level = _pcm16_rms(chunk)
-            self._played_frames += len(chunk) // FRAME_BYTES
+            for item_id, played_frames in segments:
+                if item_id != self._played_item_id:
+                    self._played_item_id = item_id
+                    self._played_frames = 0
+                self._played_frames += played_frames
 
-    def _take_playback(self, wanted: int) -> bytes:
-        buf = self._residual
-        while len(buf) < wanted:
-            try:
-                buf += self._playback.get_nowait()
-            except queue.Empty:
-                break
-        self._residual = buf[wanted:]
-        return buf[:wanted]
+    def _take_playback(
+        self, wanted: int
+    ) -> tuple[bytes, list[tuple[str | None, int]]]:
+        parts: list[bytes] = []
+        segments: list[tuple[str | None, int]] = []
+        remaining = wanted
+        packet = self._residual
+        self._residual = None
+        while remaining > 0:
+            if packet is None:
+                try:
+                    packet = self._playback.get_nowait()
+                except queue.Empty:
+                    break
+            item_id, data = packet
+            taken = data[:remaining]
+            parts.append(taken)
+            frames = len(taken) // FRAME_BYTES
+            if frames:
+                segments.append((item_id, frames))
+            remaining -= len(taken)
+            packet = (item_id, data[len(taken) :]) if len(taken) < len(data) else None
+        self._residual = packet
+        return b"".join(parts), segments
 
     # -- session interface ----------------------------------------------------
 
@@ -386,23 +372,31 @@ class DuplexAudio:
         except queue.Empty:
             return None
 
-    def queue_playback(self, pcm: bytes) -> None:
+    def queue_playback(self, pcm: bytes, item_id: str | None = None) -> None:
         """Queue model audio for the speaker. Drops on overflow, never blocks."""
 
         if not pcm:
             return
-        with contextlib.suppress(queue.Full):
-            self._playback.put_nowait(pcm)
+        with self._lock, contextlib.suppress(queue.Full):
+            self._playback.put_nowait((item_id, pcm))
 
-    def drain_playback(self) -> None:
-        """Barge-in: stop speaking now. Everything not yet played is discarded."""
+    def drain_playback(self) -> tuple[str | None, int]:
+        """Discard unheard audio and atomically return the heard boundary."""
 
-        while True:
-            try:
-                self._playback.get_nowait()
-            except queue.Empty:
-                break
-        self._residual = b""
+        with self._lock:
+            while True:
+                try:
+                    self._playback.get_nowait()
+                except queue.Empty:
+                    break
+            self._residual = None
+            boundary = (
+                self._played_item_id,
+                int(self._played_frames * 1000 / SAMPLE_RATE),
+            )
+            self._played_item_id = None
+            self._played_frames = 0
+            return boundary
 
     @property
     def played_ms(self) -> int:
@@ -412,9 +406,10 @@ class DuplexAudio:
             return int(self._played_frames * 1000 / SAMPLE_RATE)
 
     def reset_played_ms(self) -> None:
-        """Zero the counter — called when a new response starts speaking."""
+        """Reset legacy callers that do not attach item identity to audio."""
 
         with self._lock:
+            self._played_item_id = None
             self._played_frames = 0
 
 

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -233,6 +233,8 @@ class DuplexAudio:
         self._queued_playback_bytes = 0
         self._lock = threading.Lock()
         self._played_item_id: str | None = None
+        self._dropped_input_blocks = 0
+        self._dropped_playback_bytes = 0
         self._played_frames = 0
         self._output_level = 0.0
         self._in_stream = None
@@ -320,10 +322,18 @@ class DuplexAudio:
             )
             if output_active and input_level < echo_threshold:
                 return
-        # Drop the block rather than stall the device: a blocked PortAudio
-        # callback is a glitch the operator hears.
-        with contextlib.suppress(queue.Full):
+        try:
             self._input.put_nowait(pcm)
+        except queue.Full:
+            # Capture is realtime: preserving a five-second-old block while
+            # discarding the operator's current speech corrupts the turn.
+            # Evict one oldest block and retain the newest available audio.
+            with contextlib.suppress(queue.Empty):
+                self._input.get_nowait()
+            with contextlib.suppress(queue.Full):
+                self._input.put_nowait(pcm)
+            with self._lock:
+                self._dropped_input_blocks += 1
 
     def _output_callback(self, outdata, frames, _time, _status) -> None:
         wanted = frames * FRAME_BYTES
@@ -379,10 +389,12 @@ class DuplexAudio:
             return
         with self._lock:
             if self._queued_playback_bytes + len(pcm) > MAX_PLAYBACK_BYTES:
+                self._dropped_playback_bytes += len(pcm)
                 return
             try:
                 self._playback.put_nowait((item_id, pcm))
             except queue.Full:
+                self._dropped_playback_bytes += len(pcm)
                 return
             self._queued_playback_bytes += len(pcm)
 
@@ -418,6 +430,20 @@ class DuplexAudio:
         with self._lock:
             self._played_item_id = None
             self._played_frames = 0
+
+    @property
+    def dropped_input_blocks(self) -> int:
+        """Count capture overflows handled with a newest-audio preference."""
+
+        with self._lock:
+            return self._dropped_input_blocks
+
+    @property
+    def dropped_playback_bytes(self) -> int:
+        """Count provider audio bytes rejected by playback capacity limits."""
+
+        with self._lock:
+            return self._dropped_playback_bytes
 
 
 __all__ = [

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -19,7 +19,11 @@ from __future__ import annotations
 
 import contextlib
 import math
+import os
 import queue
+import shutil
+import subprocess
+import sys
 import threading
 
 try:
@@ -114,6 +118,88 @@ def _downsample_24k_to_8k(pcm: bytes) -> bytes:
     return bytes(target)
 
 
+class _PulseWebRtcAudio:
+    """Process-local PulseAudio WebRTC AEC/NS route for default Linux devices."""
+
+    def __init__(self) -> None:
+        self._pactl: str | None = None
+        self._module_id: str | None = None
+        self._previous_source: str | None = None
+        self._previous_sink: str | None = None
+
+    @property
+    def active(self) -> bool:
+        """Whether capture already comes from PulseAudio's echo canceller."""
+
+        return self._module_id is not None
+
+    def start(
+        self,
+        input_device: str | int | None,
+        output_device: str | int | None,
+    ) -> tuple[str | int | None, str | int | None]:
+        if input_device is not None or output_device is not None or sys.platform != "linux":
+            return input_device, output_device
+        pactl = shutil.which("pactl")
+        if pactl is None:
+            return input_device, output_device
+
+        suffix = str(os.getpid())
+        source_name = f"hermes_talk_aec_{suffix}"
+        sink_name = f"hermes_talk_aec_sink_{suffix}"
+        try:
+            result = subprocess.run(
+                [
+                    pactl,
+                    "load-module",
+                    "module-echo-cancel",
+                    "aec_method=webrtc",
+                    f"source_name={source_name}",
+                    f"sink_name={sink_name}",
+                    "aec_args=analog_gain_control=0 digital_gain_control=1 noise_suppression=1",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            module_id = result.stdout.strip()
+            if not module_id.isdigit():
+                raise ValueError("pactl returned no module id")
+        except (OSError, subprocess.SubprocessError, ValueError):
+            return input_device, output_device
+
+        self._pactl = pactl
+        self._module_id = module_id
+        self._previous_source = os.environ.get("PULSE_SOURCE")
+        self._previous_sink = os.environ.get("PULSE_SINK")
+        os.environ["PULSE_SOURCE"] = source_name
+        os.environ["PULSE_SINK"] = sink_name
+        return "pulse", "pulse"
+
+    def stop(self) -> None:
+        if self._previous_source is None:
+            os.environ.pop("PULSE_SOURCE", None)
+        else:
+            os.environ["PULSE_SOURCE"] = self._previous_source
+        if self._previous_sink is None:
+            os.environ.pop("PULSE_SINK", None)
+        else:
+            os.environ["PULSE_SINK"] = self._previous_sink
+
+        if self._pactl is not None and self._module_id is not None:
+            with contextlib.suppress(OSError, subprocess.SubprocessError):
+                subprocess.run(
+                    [self._pactl, "unload-module", self._module_id],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+        self._pactl = None
+        self._module_id = None
+
+
 class DuplexAudio:
     """Full-duplex pcm16 capture and playback over PortAudio."""
 
@@ -128,6 +214,7 @@ class DuplexAudio:
         self._speech_run_frames = 0
         self._in_stream = None
         self._out_stream = None
+        self._pulse_webrtc = _PulseWebRtcAudio()
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -137,11 +224,14 @@ class DuplexAudio:
         sd = import_sounddevice()
         if self._speech_detector is None:
             self._speech_detector = import_webrtcvad().Vad(3)
+        input_device = _device(talk_config.audio_input_device())
+        output_device = _device(talk_config.audio_output_device())
+        input_device, output_device = self._pulse_webrtc.start(input_device, output_device)
         try:
             self._in_stream = sd.RawInputStream(
                 samplerate=SAMPLE_RATE,
                 blocksize=BLOCKSIZE,
-                device=_device(talk_config.audio_input_device()),
+                device=input_device,
                 channels=CHANNELS,
                 dtype="int16",
                 callback=self._input_callback,
@@ -149,7 +239,7 @@ class DuplexAudio:
             self._out_stream = sd.RawOutputStream(
                 samplerate=SAMPLE_RATE,
                 blocksize=BLOCKSIZE,
-                device=_device(talk_config.audio_output_device()),
+                device=output_device,
                 channels=CHANNELS,
                 dtype="int16",
                 callback=self._output_callback,
@@ -173,6 +263,7 @@ class DuplexAudio:
             except Exception:  # noqa: BLE001 — teardown is best-effort
                 pass
             setattr(self, attr, None)
+        self._pulse_webrtc.stop()
 
     def _contains_speech(self, pcm: bytes) -> bool:
         detector = self._speech_detector
@@ -196,12 +287,13 @@ class DuplexAudio:
         input_level = _pcm16_rms(pcm)
         with self._lock:
             output_level = self._output_level
-        output_active = output_level > OUTPUT_ACTIVE_LEVEL
-        echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
-        if output_active and input_level < echo_threshold:
-            return
-        if output_active and not self._contains_speech(pcm):
-            return
+        if not self._pulse_webrtc.active:
+            output_active = output_level > OUTPUT_ACTIVE_LEVEL
+            echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
+            if output_active and input_level < echo_threshold:
+                return
+            if output_active and not self._contains_speech(pcm):
+                return
         # Drop the block rather than stall the device: a blocked PortAudio
         # callback is a glitch the operator hears.
         with contextlib.suppress(queue.Full):

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -43,6 +43,7 @@ FRAME_BYTES = SAMPLE_WIDTH * CHANNELS
 #: the tighter of the two: stale microphone audio is worse than dropped audio.
 MAX_INPUT_BLOCKS = 50
 MAX_PLAYBACK_BLOCKS = 200
+MAX_PLAYBACK_BYTES = SAMPLE_RATE * FRAME_BYTES * 20
 
 # Match OMP's live controller: while model audio is playing, microphone blocks
 # below the acoustic echo floor are local playback leakage, not barge-in.
@@ -229,6 +230,7 @@ class DuplexAudio:
             maxsize=MAX_PLAYBACK_BLOCKS
         )
         self._residual: tuple[str | None, bytes] | None = None
+        self._queued_playback_bytes = 0
         self._lock = threading.Lock()
         self._played_item_id: str | None = None
         self._played_frames = 0
@@ -326,22 +328,16 @@ class DuplexAudio:
     def _output_callback(self, outdata, frames, _time, _status) -> None:
         wanted = frames * FRAME_BYTES
         with self._lock:
-            chunk, segments = self._take_playback(wanted)
-            outdata[: len(chunk)] = chunk
-            if len(chunk) < wanted:
-                outdata[len(chunk) :] = b"\x00" * (wanted - len(chunk))
-            self._output_level = _pcm16_rms(chunk)
-            for item_id, played_frames in segments:
-                if item_id != self._played_item_id:
-                    self._played_item_id = item_id
-                    self._played_frames = 0
-                self._played_frames += played_frames
+            chunk = self._take_playback(wanted)
+        output_level = _pcm16_rms(chunk)
+        with self._lock:
+            self._output_level = output_level
+        outdata[: len(chunk)] = chunk
+        if len(chunk) < wanted:
+            outdata[len(chunk) :] = b"\x00" * (wanted - len(chunk))
 
-    def _take_playback(
-        self, wanted: int
-    ) -> tuple[bytes, list[tuple[str | None, int]]]:
+    def _take_playback(self, wanted: int) -> bytes:
         parts: list[bytes] = []
-        segments: list[tuple[str | None, int]] = []
         remaining = wanted
         packet = self._residual
         self._residual = None
@@ -354,13 +350,17 @@ class DuplexAudio:
             item_id, data = packet
             taken = data[:remaining]
             parts.append(taken)
-            frames = len(taken) // FRAME_BYTES
-            if frames:
-                segments.append((item_id, frames))
+            self._queued_playback_bytes -= len(taken)
+            played_frames = len(taken) // FRAME_BYTES
+            if played_frames:
+                if item_id != self._played_item_id:
+                    self._played_item_id = item_id
+                    self._played_frames = 0
+                self._played_frames += played_frames
             remaining -= len(taken)
             packet = (item_id, data[len(taken) :]) if len(taken) < len(data) else None
         self._residual = packet
-        return b"".join(parts), segments
+        return b"".join(parts)
 
     # -- session interface ----------------------------------------------------
 
@@ -377,8 +377,14 @@ class DuplexAudio:
 
         if not pcm:
             return
-        with self._lock, contextlib.suppress(queue.Full):
-            self._playback.put_nowait((item_id, pcm))
+        with self._lock:
+            if self._queued_playback_bytes + len(pcm) > MAX_PLAYBACK_BYTES:
+                return
+            try:
+                self._playback.put_nowait((item_id, pcm))
+            except queue.Full:
+                return
+            self._queued_playback_bytes += len(pcm)
 
     def drain_playback(self) -> tuple[str | None, int]:
         """Discard unheard audio and atomically return the heard boundary."""
@@ -390,6 +396,7 @@ class DuplexAudio:
                 except queue.Empty:
                     break
             self._residual = None
+            self._queued_playback_bytes = 0
             boundary = (
                 self._played_item_id,
                 int(self._played_frames * 1000 / SAMPLE_RATE),

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -18,6 +18,7 @@ already generated far more than the operator heard.
 from __future__ import annotations
 
 import contextlib
+import math
 import queue
 import threading
 
@@ -36,6 +37,12 @@ FRAME_BYTES = SAMPLE_WIDTH * CHANNELS
 #: the tighter of the two: stale microphone audio is worse than dropped audio.
 MAX_INPUT_BLOCKS = 50
 MAX_PLAYBACK_BLOCKS = 200
+
+# Match OMP's live controller: while model audio is playing, microphone blocks
+# below the acoustic echo floor are local playback leakage, not barge-in.
+OUTPUT_ACTIVE_LEVEL = 0.015
+MIN_BARGE_IN_LEVEL = 0.04
+OUTPUT_ECHO_RATIO = 0.65
 
 _INSTALL_HINT = (
     'audio support is not installed — run: pip install "hermes-talk[audio]" '
@@ -74,6 +81,15 @@ def _device(raw: str | None) -> str | int | None:
         return None
     return int(raw) if raw.lstrip("-").isdigit() else raw
 
+def _pcm16_rms(pcm: bytes) -> float:
+    """Normalized RMS for little-endian mono PCM16 without copying samples."""
+
+    if not pcm:
+        return 0.0
+    samples = memoryview(pcm).cast("h")
+    sum_squares = sum(sample * sample for sample in samples)
+    return min(1.0, math.sqrt(sum_squares / len(samples)) / 32_768)
+
 
 class DuplexAudio:
     """Full-duplex pcm16 capture and playback over PortAudio."""
@@ -84,6 +100,7 @@ class DuplexAudio:
         self._residual = b""
         self._lock = threading.Lock()
         self._played_frames = 0
+        self._output_level = 0.0
         self._in_stream = None
         self._out_stream = None
 
@@ -133,10 +150,18 @@ class DuplexAudio:
     # -- PortAudio callbacks (audio thread) -----------------------------------
 
     def _input_callback(self, indata, _frames, _time, _status) -> None:
+        pcm = bytes(indata)
+        input_level = _pcm16_rms(pcm)
+        with self._lock:
+            output_level = self._output_level
+        output_active = output_level > OUTPUT_ACTIVE_LEVEL
+        echo_threshold = max(MIN_BARGE_IN_LEVEL, output_level * OUTPUT_ECHO_RATIO)
+        if output_active and input_level < echo_threshold:
+            return
         # Drop the block rather than stall the device: a blocked PortAudio
         # callback is a glitch the operator hears.
         with contextlib.suppress(queue.Full):
-            self._input.put_nowait(bytes(indata))
+            self._input.put_nowait(pcm)
 
     def _output_callback(self, outdata, frames, _time, _status) -> None:
         wanted = frames * FRAME_BYTES
@@ -145,6 +170,7 @@ class DuplexAudio:
         if len(chunk) < wanted:
             outdata[len(chunk) :] = b"\x00" * (wanted - len(chunk))
         with self._lock:
+            self._output_level = _pcm16_rms(chunk)
             self._played_frames += len(chunk) // FRAME_BYTES
 
     def _take_playback(self, wanted: int) -> bytes:

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -44,6 +44,7 @@ try:
         talk_cascade_voice,
         talk_config,
         talk_doctor,
+        talk_gemini_auth,
         talk_gemini_realtime,
         talk_grok_auth,
         talk_grok_realtime,
@@ -71,6 +72,7 @@ except ImportError:  # pragma: no cover - flat-module fallback (Hermes file-path
     import talk_cascade_voice
     import talk_config
     import talk_doctor
+    import talk_gemini_auth
     import talk_gemini_realtime
     import talk_grok_auth
     import talk_grok_realtime
@@ -1029,27 +1031,6 @@ def _grok_auth() -> talk_auth.TalkAuth:
     return talk_grok_auth.resolve_grok_auth()
 
 
-def _gemini_auth() -> talk_auth.TalkAuth:
-    """The Gemini credential for the Gemini Live lane, in the factory's shape.
-
-    Gemini has no OAuth lane and no ephemeral mint — the resolved key rides
-    the socket URL query. Source names reuse the OpenAI receipt vocabulary so
-    receipts name lanes, never keys.
-    """
-
-    scoped = (os.environ.get("TALK_GEMINI_API_KEY") or "").strip()
-    token = talk_config.resolve_gemini_key()
-    if scoped:
-        return talk_auth.TalkAuth(
-            token=token,
-            source=talk_auth.SOURCE_CONFIGURED,
-            detail="TALK_GEMINI_API_KEY (Talk-scoped key)",
-        )
-    return talk_auth.TalkAuth(
-        token=token,
-        source=talk_auth.SOURCE_ENV,
-        detail="GEMINI_API_KEY environment variable",
-    )
 
 
 def _realtime_session(auth: talk_auth.TalkAuth) -> talk_realtime.RealtimeSession:
@@ -1176,7 +1157,7 @@ async def run_talk_session(
             model = talk_config.talk_grok_model()
             voice = talk_config.talk_grok_voice()
         elif provider == "gemini":
-            auth = _gemini_auth()
+            auth = talk_gemini_auth.resolve_gemini_auth()
             model = talk_config.talk_gemini_model()
             voice = talk_config.talk_gemini_voice()
         else:

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -1888,6 +1888,31 @@ def cli_entry(args: argparse.Namespace | None = None) -> int:
         return 0
 
     try:
+        try:
+            from . import talk_core_cli, talk_core_realtime
+        except ImportError:
+            import talk_core_cli
+            import talk_core_realtime
+        core_runner = (
+            talk_core_cli.run_core_talk_session
+            if talk_core_realtime.coordinator_contract_available()
+            and talk_core_realtime.configured_core_provider_supported()
+            else None
+        )
+    except ImportError:
+        core_runner = None
+
+    if core_runner is not None:
+        try:
+            code = asyncio.run(core_runner())
+        except KeyboardInterrupt:
+            print("\ntalk: hung up.")
+            return 0
+        if code:
+            raise SystemExit(code)
+        return 0
+
+    try:
         code = asyncio.run(run_talk_session())
     except KeyboardInterrupt:
         print("\ntalk: hung up.")

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -1267,16 +1267,20 @@ async def run_talk_session(
 
     def on_barge_in() -> None:
         played = audio.played_ms
-        audio.drain_playback()
+        boundary = audio.drain_playback()
+        played_item = None
+        if boundary is not None:
+            played_item, played = boundary
         if relay.response_active:
             # An approval question interrupted mid-ask is a question not fully
             # heard: the bridge denies it. Speech after the prompt's response
             # finished (response_active False) is an answer, never a barge-in.
             talk_approvals.note_barge_in()
-        if relay.last_audio_item_id and played > 0:
+        item_id = played_item or relay.last_audio_item_id
+        if item_id and played > 0:
             pending.append(
                 talk_realtime.TruncateOutput(
-                    item_id=relay.last_audio_item_id, audio_end_ms=played
+                    item_id=item_id, audio_end_ms=played
                 )
             )
 

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -1895,7 +1895,8 @@ def cli_entry(args: argparse.Namespace | None = None) -> int:
             import talk_core_realtime
         core_runner = (
             talk_core_cli.run_core_talk_session
-            if talk_core_realtime.coordinator_contract_available()
+            if os.environ.get(talk_core_cli.EVENT_STREAM_ENV) == "jsonl"
+            and talk_core_realtime.coordinator_contract_available()
             and talk_core_realtime.configured_core_provider_supported()
             else None
         )

--- a/talk_core_cli.py
+++ b/talk_core_cli.py
@@ -1,0 +1,290 @@
+"""Terminal audio surface for the Hermes #95147 coordinator seam."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sys
+import uuid
+
+from agent.realtime_voice import RealtimeEvent, RealtimeEventType
+from agent.realtime_voice_coordinator import RealtimeVoiceCoordinator
+from agent.realtime_voice_registry import get_provider
+from model_tools import get_tool_definitions
+
+try:
+    from . import talk_audio, talk_config, talk_host, talk_identity, talk_transcript
+    from .talk_core_realtime_contract import configured_provider_name
+except ImportError:  # pragma: no cover - flat-module fallback
+    import talk_audio
+    import talk_config
+    import talk_host
+    import talk_identity
+    import talk_transcript
+    from talk_core_realtime_contract import configured_provider_name
+
+logger = logging.getLogger(__name__)
+
+IDLE_POLL_S = 0.01
+EVENT_STREAM_ENV = "HERMES_TALK_EVENT_STREAM"
+MAX_PROVIDER_ITEM_ID_LENGTH = 32
+EVENT_PREFIX = "talk: event "
+DELEGATE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "client_delegate",
+        "description": (
+            "Delegate tool use, coding, research, commands, or other substantive "
+            "work to the Hermes text agent."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "request": {
+                    "type": "string",
+                    "description": "Complete plain-language request with relevant context.",
+                }
+            },
+            "required": ["request"],
+            "additionalProperties": False,
+        },
+    },
+}
+DELEGATE_INSTRUCTIONS = """
+
+You are Hermes Live, the realtime voice surface of one unified assistant.
+Respond directly, briefly, and conversationally. Never read long answers,
+implementation detail, markdown, code, or tool output aloud.
+
+You MUST call client_delegate promptly for research, tool use, commands,
+coding, repository work, or any substantive factual task. The delegated text
+agent owns execution and displays its detailed response to the user while it
+works. You may give one short acknowledgement, then wait. Treat the returned
+result as your own internal context and speak only a concise useful summary.
+Never mention delegation, a backend, a tool protocol, or another assistant.
+Answer greetings and ordinary conversation directly without delegation.
+""".strip()
+
+
+def _emit_event(payload: dict) -> None:
+    print(f"{EVENT_PREFIX}{json.dumps(payload, separators=(',', ':'))}", flush=True)
+
+
+def _progress_item_id(request_id: str, index: int) -> str:
+    """Build a unique progress item id within provider wire limits."""
+
+    return f"p{index:x}-{request_id}"[:MAX_PROVIDER_ITEM_ID_LENGTH]
+
+
+async def run_core_talk_session(audio=None) -> int:
+    """Run duplex media through the registered provider and Hermes coordinator."""
+
+    event_stream = os.environ.get(EVENT_STREAM_ENV) == "jsonl"
+    provider = get_provider(configured_provider_name())
+    if provider is None:
+        print("talk: no registered realtime voice provider", file=sys.stderr)
+        return 1
+    ctx = talk_host.get_ctx()
+    if not event_stream and (
+        ctx is None or not callable(getattr(ctx, "dispatch_tool", None))
+    ):
+        print("talk: Hermes tool authority is unavailable", file=sys.stderr)
+        return 1
+
+    tools = [DELEGATE_TOOL] if event_stream else (get_tool_definitions(quiet_mode=True) or [])
+    instructions = talk_identity.build_instructions(
+        talk_host.host().identity_sections(),
+        tools=tools,
+        host_execution=True,
+        lane="cli",
+    )
+    if event_stream:
+        instructions = f"{instructions}\n\n{DELEGATE_INSTRUCTIONS}"
+    if audio is None:
+        audio = talk_audio.DuplexAudio()
+    try:
+        audio.start()
+    except talk_audio.TalkAudioError as exc:
+        print(f"talk: {exc}", file=sys.stderr)
+        return 1
+
+    async def dispatch_tool(name: str, arguments: dict) -> str:
+        if not event_stream:
+            return await asyncio.to_thread(ctx.dispatch_tool, name, arguments)
+        if name != "client_delegate":
+            return f"Error: unsupported live voice tool {name!r}"
+        request = str(arguments.get("request") or "").strip()
+        if not request:
+            return "Error: client_delegate requires a non-empty request"
+        request_id = uuid.uuid4().hex
+        progress_index = 0
+        _emit_event({"type": "delegate", "id": request_id, "request": request})
+        while True:
+            line = await asyncio.to_thread(sys.stdin.readline)
+            if not line:
+                raise RuntimeError("Hermes TUI closed the live delegation channel")
+            try:
+                command = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(command, dict) or command.get("id") != request_id:
+                continue
+            if command.get("type") == "delegate.progress":
+                progress = str(command.get("text") or "").strip()
+                if progress:
+                    progress_index += 1
+                    try:
+                        await coordinator.add_context(
+                            _progress_item_id(request_id, progress_index),
+                            f"Silent Hermes text-agent progress:\n\n{progress}",
+                        )
+                    except Exception as exc:  # noqa: BLE001 - progress is optional
+                        logger.warning(
+                            "Realtime voice progress context was rejected; "
+                            "continuing to await the final text-agent result: %s",
+                            exc,
+                        )
+                continue
+            if command.get("type") == "delegate.result":
+                output = str(command.get("output") or "").strip()
+                return f'"Agent Final Message":\n\n{output}'
+
+    coordinator = RealtimeVoiceCoordinator(
+        provider,
+        dispatch_tool=dispatch_tool,
+        max_in_flight_tool_calls=1 if event_stream else 16,
+    )
+    capture = talk_transcript.TranscriptCapture(talk_config.get_hermes_home())
+    configured = talk_config.talk_provider()
+    model = (
+        talk_config.talk_grok_model()
+        if configured == "grok"
+        else talk_config.talk_model()
+    )
+    voice = (
+        talk_config.talk_grok_voice()
+        if configured == "grok"
+        else talk_config.talk_voice()
+    )
+    try:
+        await coordinator.open(
+            instructions=instructions,
+            tools=tools,
+            voice=voice,
+        )
+    except Exception as exc:  # noqa: BLE001 - provider startup is a voice boundary
+        audio.stop()
+        capture.finish()
+        print(f"talk: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"talk: connected ({model}, voice {voice}). "
+        "Ctrl+C to hang up.\n",
+        flush=True,
+    )
+    last_audio_event: RealtimeEvent | None = None
+    print("talk: state listening", flush=True)
+    active_item_id: str | None = None
+
+    async def send_microphone() -> None:
+        while True:
+            chunk = audio.read_input_chunk()
+            if chunk is None:
+                await asyncio.sleep(IDLE_POLL_S)
+                continue
+            await coordinator.send_audio(chunk)
+
+    async def receive_events() -> None:
+        nonlocal active_item_id, last_audio_event
+        async for event in coordinator.events():
+            if event.type is RealtimeEventType.AUDIO:
+                if not event.audio_bytes:
+                    continue
+                if event.item_id != active_item_id:
+                    active_item_id = event.item_id
+                    last_audio_event = None
+                    audio.reset_played_ms()
+                print("talk: state composing", flush=True)
+                audio.queue_playback(event.audio_bytes)
+                last_audio_event = event
+                continue
+            if event.type is RealtimeEventType.TRANSCRIPT:
+                if event.text:
+                    if event_stream and event.role in {"user", "assistant"}:
+                        _emit_event(
+                            {
+                                "type": "transcript",
+                                "role": event.role,
+                                "text": event.text,
+                                "final": event.final,
+                            }
+                        )
+                    elif not event_stream:
+                        print(event.text, end="\n" if event.final else "", flush=True)
+                    if event.final and event.role in {"user", "assistant"}:
+                        capture.append_turn(event.role, event.text)
+                continue
+            if event.type is RealtimeEventType.TURN_ENDED:
+                if event.role == "user":
+                    print("talk: state solving", flush=True)
+                elif event.role == "assistant":
+                    print("talk: state listening", flush=True)
+                    last_audio_event = None
+                    active_item_id = None
+                continue
+            if event.type is RealtimeEventType.TURN_STARTED:
+                if event.role == "assistant":
+                    print("talk: state composing", flush=True)
+                elif event.role == "user" and last_audio_event is not None:
+                    coordinator.report_audio_heard(
+                        last_audio_event,
+                        audio_end_ms=audio.played_ms,
+                    )
+                    audio.drain_playback()
+                    await coordinator.cancel_response()
+                    last_audio_event = None
+                    active_item_id = None
+                    print("talk: state listening", flush=True)
+                continue
+            if event.type is RealtimeEventType.ERROR:
+                raise RuntimeError(event.text or "realtime voice provider failed")
+
+    microphone = asyncio.create_task(send_microphone())
+    receiver = asyncio.create_task(receive_events())
+    try:
+        done, pending = await asyncio.wait(
+            (microphone, receiver),
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        for task in done:
+            try:
+                task.result()
+            except Exception as exc:
+                if event_stream:
+                    _emit_event(
+                        {
+                            "type": "error",
+                            "message": f"{type(exc).__name__}: {exc}",
+                        }
+                    )
+                raise
+        return 0
+    finally:
+        microphone.cancel()
+        receiver.cancel()
+        await asyncio.gather(microphone, receiver, return_exceptions=True)
+        with contextlib.suppress(Exception):
+            await coordinator.close()
+        audio.stop()
+        capture.finish()
+        talk_transcript.sweep_transcripts(talk_config.get_hermes_home())
+
+
+__all__ = ["IDLE_POLL_S", "run_core_talk_session"]

--- a/talk_core_cli.py
+++ b/talk_core_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import io
 import json
 import logging
 import os
@@ -78,6 +79,26 @@ def _progress_item_id(request_id: str, index: int) -> str:
 
     return f"p{index:x}-{request_id}"[:MAX_PROVIDER_ITEM_ID_LENGTH]
 
+async def _read_stdin_line() -> str:
+    """Read one TUI command without leaving a blocking executor task on POSIX."""
+
+    loop = asyncio.get_running_loop()
+    try:
+        descriptor = sys.stdin.fileno()
+        result: asyncio.Future[str] = loop.create_future()
+
+        def ready() -> None:
+            if not result.done():
+                result.set_result(sys.stdin.readline())
+
+        loop.add_reader(descriptor, ready)
+    except (AttributeError, io.UnsupportedOperation, NotImplementedError):
+        return await asyncio.to_thread(sys.stdin.readline)
+    try:
+        return await result
+    finally:
+        loop.remove_reader(descriptor)
+
 
 async def run_core_talk_session(audio=None) -> int:
     """Run duplex media through the registered provider and Hermes coordinator."""
@@ -123,7 +144,7 @@ async def run_core_talk_session(audio=None) -> int:
         progress_index = 0
         _emit_event({"type": "delegate", "id": request_id, "request": request})
         while True:
-            line = await asyncio.to_thread(sys.stdin.readline)
+            line = await _read_stdin_line()
             if not line:
                 raise RuntimeError("Hermes TUI closed the live delegation channel")
             try:
@@ -233,8 +254,6 @@ async def run_core_talk_session(audio=None) -> int:
                     print("talk: state solving", flush=True)
                 elif event.role == "assistant":
                     print("talk: state listening", flush=True)
-                    last_audio_event = None
-                    active_item_id = None
                 continue
             if event.type is RealtimeEventType.TURN_STARTED:
                 if event.role == "assistant":
@@ -266,20 +285,21 @@ async def run_core_talk_session(audio=None) -> int:
         for task in done:
             try:
                 task.result()
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 - runtime boundary
+                message = f"{type(exc).__name__}: {exc}"
                 if event_stream:
-                    _emit_event(
-                        {
-                            "type": "error",
-                            "message": f"{type(exc).__name__}: {exc}",
-                        }
-                    )
-                raise
+                    _emit_event({"type": "error", "message": message})
+                else:
+                    print(f"talk: {message}", file=sys.stderr)
+                return 1
         return 0
     finally:
         microphone.cancel()
         receiver.cancel()
         await asyncio.gather(microphone, receiver, return_exceptions=True)
+        if event_stream:
+            with contextlib.suppress(Exception):
+                sys.stdin.close()
         with contextlib.suppress(Exception):
             await coordinator.close()
         audio.stop()

--- a/talk_core_cli.py
+++ b/talk_core_cli.py
@@ -10,6 +10,7 @@ import logging
 import os
 import sys
 import threading
+import time
 import uuid
 
 from agent.realtime_voice import RealtimeEvent, RealtimeEventType
@@ -34,6 +35,7 @@ EVENT_STREAM_ENV = "HERMES_TALK_EVENT_STREAM"
 MAX_PROVIDER_ITEM_ID_LENGTH = 32
 MAX_CONTROL_FRAME_CHARS = 65_536
 MAX_PENDING_CONTROL_FRAMES = 64
+PROTOCOL_VERSION = 1
 EVENT_PREFIX = "talk: event "
 DELEGATE_TOOL = {
     "type": "function",
@@ -72,7 +74,7 @@ Answer greetings and ordinary conversation directly without delegation.
 """.strip()
 
 
-def _emit_event(payload: dict) -> None:
+def _write_event(payload: dict) -> None:
     print(f"{EVENT_PREFIX}{json.dumps(payload, separators=(',', ':'))}", flush=True)
 
 
@@ -224,16 +226,15 @@ async def run_core_talk_session(audio=None) -> int:
         instructions = f"{instructions}\n\n{DELEGATE_INSTRUCTIONS}"
         capture = talk_transcript.TranscriptCapture(talk_config.get_hermes_home())
         configured = talk_config.talk_provider()
-        model = (
-            talk_config.talk_grok_model()
-            if configured == "grok"
-            else talk_config.talk_model()
-        )
-        voice = (
-            talk_config.talk_grok_voice()
-            if configured == "grok"
-            else talk_config.talk_voice()
-        )
+        if configured == "grok":
+            model = talk_config.talk_grok_model()
+            voice = talk_config.talk_grok_voice()
+        elif configured == "gemini":
+            model = talk_config.talk_gemini_model()
+            voice = talk_config.talk_gemini_voice()
+        else:
+            model = talk_config.talk_model()
+            voice = talk_config.talk_voice()
         audio = audio or talk_audio.DuplexAudio()
     except Exception as exc:  # noqa: BLE001 - startup configuration boundary
         print(f"talk: {exc}", file=sys.stderr)
@@ -245,6 +246,21 @@ async def run_core_talk_session(audio=None) -> int:
     audio_started = False
     delegation_idle = asyncio.Event()
     delegation_idle.set()
+
+    surface_session_id = uuid.uuid4().hex
+    event_sequence = 0
+
+    def emit_event(payload: dict) -> None:
+        nonlocal event_sequence
+        event_sequence += 1
+        _write_event(
+            {
+                **payload,
+                "protocol_version": PROTOCOL_VERSION,
+                "surface_session_id": surface_session_id,
+                "sequence": event_sequence,
+            }
+        )
 
     async def dispatch_tool(name: str, arguments: dict) -> str:
         if name != "client_delegate":
@@ -258,7 +274,7 @@ async def run_core_talk_session(audio=None) -> int:
         request_id = uuid.uuid4().hex
         progress_index = 0
         delegation_idle.clear()
-        _emit_event({"type": "delegate", "id": request_id, "request": request})
+        emit_event({"type": "delegate", "id": request_id, "request": request})
         try:
             while True:
                 line = await stdin_reader.readline()
@@ -299,6 +315,46 @@ async def run_core_talk_session(audio=None) -> int:
     )
     last_audio_event: RealtimeEvent | None = None
     last_state: str | None = None
+    provider_ready = False
+    reported_input_drops = 0
+    reported_playback_drops = 0
+    user_endpoint_at: float | None = None
+    session_open_started = 0.0
+
+    def emit_metric(name: str, started_at: float) -> None:
+        emit_event(
+            {
+                "type": "metric",
+                "name": name,
+                "value_ms": round((time.monotonic() - started_at) * 1000, 3),
+            }
+        )
+
+    def report_audio_pressure() -> None:
+        nonlocal reported_input_drops, reported_playback_drops
+        input_drops = int(getattr(audio, "dropped_input_blocks", 0))
+        if input_drops > reported_input_drops and (
+            reported_input_drops == 0 or input_drops - reported_input_drops >= 100
+        ):
+            reported_input_drops = input_drops
+            emit_event(
+                {
+                    "type": "warning",
+                    "message": f"microphone queue dropped {input_drops} stale block(s)",
+                }
+            )
+        playback_drops = int(getattr(audio, "dropped_playback_bytes", 0))
+        if playback_drops > reported_playback_drops and (
+            reported_playback_drops == 0
+            or playback_drops - reported_playback_drops >= 24_000
+        ):
+            reported_playback_drops = playback_drops
+            emit_event(
+                {
+                    "type": "warning",
+                    "message": f"playback queue dropped {playback_drops} byte(s)",
+                }
+            )
 
     def emit_state(state: str) -> None:
         nonlocal last_state
@@ -314,21 +370,46 @@ async def run_core_talk_session(audio=None) -> int:
                 await asyncio.sleep(IDLE_POLL_S)
                 continue
             await coordinator.send_audio(chunk)
+            report_audio_pressure()
 
     async def receive_events() -> None:
-        nonlocal active_item_id, last_audio_event
+        nonlocal last_audio_event, provider_ready, user_endpoint_at
         async for event in coordinator.events():
+            if event.type is RealtimeEventType.SESSION_READY:
+                if provider_ready:
+                    continue
+                provider_ready = True
+                print(
+                    f"talk: connected ({model}, voice {voice}). "
+                    "Ctrl+C to hang up.\n",
+                    flush=True,
+                )
+                emit_metric("session_ready_ms", session_open_started)
+                emit_state("listening")
+                continue
+            if event.type is RealtimeEventType.WARNING:
+                emit_event(
+                    {
+                        "type": "warning",
+                        "message": event.text or "realtime voice provider warning",
+                    }
+                )
+                continue
             if event.type is RealtimeEventType.AUDIO:
                 if not event.audio_bytes:
                     continue
                 emit_state("composing")
                 audio.queue_playback(event.audio_bytes, item_id=event.item_id)
+                report_audio_pressure()
+                if user_endpoint_at is not None:
+                    emit_metric("endpoint_to_first_audio_ms", user_endpoint_at)
+                    user_endpoint_at = None
                 last_audio_event = event
                 continue
             if event.type is RealtimeEventType.TRANSCRIPT:
                 if event.text:
                     if event.role in {"user", "assistant"}:
-                        _emit_event(
+                        emit_event(
                             {
                                 "type": "transcript",
                                 "role": event.role,
@@ -341,6 +422,7 @@ async def run_core_talk_session(audio=None) -> int:
                 continue
             if event.type is RealtimeEventType.TURN_ENDED:
                 if event.role == "user":
+                    user_endpoint_at = time.monotonic()
                     emit_state("solving")
                 elif event.role == "assistant":
                     emit_state("listening")
@@ -349,14 +431,21 @@ async def run_core_talk_session(audio=None) -> int:
                 if event.role == "assistant":
                     emit_state("composing")
                 elif event.role == "user" and last_audio_event is not None:
-                    coordinator.report_audio_heard(
-                        last_audio_event,
-                        audio_end_ms=audio.played_ms,
-                    )
-                    audio.drain_playback()
+                    interruption_started_at = time.monotonic()
+                    played_item, played_ms = audio.drain_playback()
+                    if (
+                        played_item is not None
+                        and played_item == last_audio_event.item_id
+                        and played_ms > 0
+                    ):
+                        coordinator.report_audio_heard(
+                            last_audio_event,
+                            audio_end_ms=played_ms,
+                        )
                     await coordinator.cancel_response()
                     last_audio_event = None
                     emit_state("listening")
+                    emit_metric("interruption_to_local_silence_ms", interruption_started_at)
                 continue
             if event.type is RealtimeEventType.ERROR:
                 raise RuntimeError(event.text or "realtime voice provider failed")
@@ -366,17 +455,12 @@ async def run_core_talk_session(audio=None) -> int:
         audio.start()
         audio_started = True
         stdin_reader = _StdinLineReader()
+        session_open_started = time.monotonic()
         await coordinator.open(
             instructions=instructions,
             tools=tools,
             voice=voice,
         )
-        print(
-            f"talk: connected ({model}, voice {voice}). "
-            "Ctrl+C to hang up.\n",
-            flush=True,
-        )
-        emit_state("listening")
 
         runtime_tasks = [
             asyncio.create_task(send_microphone()),
@@ -398,7 +482,7 @@ async def run_core_talk_session(audio=None) -> int:
     except asyncio.CancelledError:
         raise
     except Exception as exc:  # noqa: BLE001 - terminal runtime boundary
-        _emit_event(
+        emit_event(
             {
                 "type": "error",
                 "message": f"{type(exc).__name__}: {exc}",
@@ -420,4 +504,4 @@ async def run_core_talk_session(audio=None) -> int:
         talk_transcript.sweep_transcripts(talk_config.get_hermes_home())
 
 
-__all__ = ["IDLE_POLL_S", "run_core_talk_session"]
+__all__ = ["IDLE_POLL_S", "PROTOCOL_VERSION", "run_core_talk_session"]

--- a/talk_core_cli.py
+++ b/talk_core_cli.py
@@ -9,12 +9,12 @@ import json
 import logging
 import os
 import sys
+import threading
 import uuid
 
 from agent.realtime_voice import RealtimeEvent, RealtimeEventType
 from agent.realtime_voice_coordinator import RealtimeVoiceCoordinator
 from agent.realtime_voice_registry import get_provider
-from model_tools import get_tool_definitions
 
 try:
     from . import talk_audio, talk_config, talk_host, talk_identity, talk_transcript
@@ -79,136 +79,200 @@ def _progress_item_id(request_id: str, index: int) -> str:
 
     return f"p{index:x}-{request_id}"[:MAX_PROVIDER_ITEM_ID_LENGTH]
 
-async def _read_stdin_line() -> str:
-    """Read one TUI command without leaving a blocking executor task on POSIX."""
+class _StdinLineReader:
+    """One owner for stdin buffering; POSIX stays event-driven."""
 
-    loop = asyncio.get_running_loop()
-    try:
-        descriptor = sys.stdin.fileno()
-        result: asyncio.Future[str] = loop.create_future()
+    def __init__(self, stream=None) -> None:
+        self._stream = stream or sys.stdin
+        self._loop = asyncio.get_running_loop()
+        self._lines: asyncio.Queue[str | None] = asyncio.Queue()
+        self._buffered_lines = 0
+        self._eof = asyncio.Event()
+        self._drained = asyncio.Event()
+        self._drained.set()
+        self._descriptor: int | None = None
+        self._text_buffer = ""
+        self._thread: threading.Thread | None = None
+        try:
+            self._descriptor = self._stream.fileno()
+            self._loop.add_reader(self._descriptor, self._read_ready)
+        except (AttributeError, io.UnsupportedOperation, NotImplementedError):
+            self._descriptor = None
+            self._thread = threading.Thread(
+                target=self._read_lines,
+                name="hermes-talk-stdin",
+                daemon=True,
+            )
+            self._thread.start()
 
-        def ready() -> None:
-            if not result.done():
-                result.set_result(sys.stdin.readline())
+    def _read_ready(self) -> None:
+        assert self._descriptor is not None
+        try:
+            chunk = os.read(self._descriptor, 65_536)
+        except OSError:
+            chunk = b""
+        if not chunk:
+            self._mark_eof()
+            return
+        self._feed_text(chunk.decode("utf-8", errors="replace"))
 
-        loop.add_reader(descriptor, ready)
-    except (AttributeError, io.UnsupportedOperation, NotImplementedError):
-        return await asyncio.to_thread(sys.stdin.readline)
-    try:
-        return await result
-    finally:
-        loop.remove_reader(descriptor)
+    def _read_lines(self) -> None:
+        try:
+            for line in self._stream:
+                self._loop.call_soon_threadsafe(self._feed_text, line)
+        except (OSError, ValueError):
+            pass
+        finally:
+            with contextlib.suppress(RuntimeError):
+                self._loop.call_soon_threadsafe(self._mark_eof)
+
+    def _feed_text(self, text: str) -> None:
+        self._text_buffer += text
+        lines = self._text_buffer.split("\n")
+        self._text_buffer = lines.pop()
+        for line in lines:
+            self._buffered_lines += 1
+            self._drained.clear()
+            self._lines.put_nowait(line.removesuffix("\r"))
+
+    def _mark_eof(self) -> None:
+        if self._eof.is_set():
+            return
+        if self._descriptor is not None:
+            self._loop.remove_reader(self._descriptor)
+        if self._text_buffer:
+            self._buffered_lines += 1
+            self._drained.clear()
+            self._lines.put_nowait(self._text_buffer)
+            self._text_buffer = ""
+        self._eof.set()
+        self._lines.put_nowait(None)
+
+    async def readline(self) -> str:
+        line = await self._lines.get()
+        if line is None:
+            return ""
+        self._buffered_lines -= 1
+        if self._buffered_lines == 0:
+            self._drained.set()
+        return line
+
+    async def wait_for_parent_close(self, delegation_idle: asyncio.Event) -> None:
+        await self._eof.wait()
+        await self._drained.wait()
+        await delegation_idle.wait()
+        raise RuntimeError("Hermes TUI closed the live delegation channel")
+
+    def close(self) -> None:
+        if self._descriptor is not None:
+            with contextlib.suppress(Exception):
+                self._loop.remove_reader(self._descriptor)
+        if self._thread is not None:
+            with contextlib.suppress(Exception):
+                self._stream.close()
 
 
 async def run_core_talk_session(audio=None) -> int:
-    """Run duplex media through the registered provider and Hermes coordinator."""
+    """Run the TUI's client-delegated duplex session through Hermes core."""
 
-    event_stream = os.environ.get(EVENT_STREAM_ENV) == "jsonl"
-    provider = get_provider(configured_provider_name())
+    if os.environ.get(EVENT_STREAM_ENV) != "jsonl":
+        print("talk: core realtime mode is reserved for the Hermes TUI", file=sys.stderr)
+        return 1
+
+    try:
+        provider = get_provider(configured_provider_name())
+    except Exception as exc:  # noqa: BLE001 - configuration boundary
+        print(f"talk: {exc}", file=sys.stderr)
+        return 1
     if provider is None:
         print("talk: no registered realtime voice provider", file=sys.stderr)
         return 1
-    ctx = talk_host.get_ctx()
-    if not event_stream and (
-        ctx is None or not callable(getattr(ctx, "dispatch_tool", None))
-    ):
-        print("talk: Hermes tool authority is unavailable", file=sys.stderr)
-        return 1
 
-    tools = [DELEGATE_TOOL] if event_stream else (get_tool_definitions(quiet_mode=True) or [])
-    instructions = talk_identity.build_instructions(
-        talk_host.host().identity_sections(),
-        tools=tools,
-        host_execution=True,
-        lane="cli",
-    )
-    if event_stream:
-        instructions = f"{instructions}\n\n{DELEGATE_INSTRUCTIONS}"
-    if audio is None:
-        audio = talk_audio.DuplexAudio()
+    tools = [DELEGATE_TOOL]
     try:
-        audio.start()
-    except talk_audio.TalkAudioError as exc:
+        instructions = talk_identity.build_instructions(
+            talk_host.host().identity_sections(),
+            tools=tools,
+            host_execution=True,
+            lane="cli",
+        )
+        instructions = f"{instructions}\n\n{DELEGATE_INSTRUCTIONS}"
+        capture = talk_transcript.TranscriptCapture(talk_config.get_hermes_home())
+        configured = talk_config.talk_provider()
+        model = (
+            talk_config.talk_grok_model()
+            if configured == "grok"
+            else talk_config.talk_model()
+        )
+        voice = (
+            talk_config.talk_grok_voice()
+            if configured == "grok"
+            else talk_config.talk_voice()
+        )
+        audio = audio or talk_audio.DuplexAudio()
+    except Exception as exc:  # noqa: BLE001 - startup configuration boundary
         print(f"talk: {exc}", file=sys.stderr)
         return 1
 
+    coordinator: RealtimeVoiceCoordinator | None = None
+    stdin_reader: _StdinLineReader | None = None
+    runtime_tasks: list[asyncio.Task] = []
+    audio_started = False
+    delegation_idle = asyncio.Event()
+    delegation_idle.set()
+
     async def dispatch_tool(name: str, arguments: dict) -> str:
-        if not event_stream:
-            return await asyncio.to_thread(ctx.dispatch_tool, name, arguments)
         if name != "client_delegate":
             return f"Error: unsupported live voice tool {name!r}"
         request = str(arguments.get("request") or "").strip()
         if not request:
             return "Error: client_delegate requires a non-empty request"
+        if stdin_reader is None or coordinator is None:
+            raise RuntimeError("Hermes TUI delegation channel is unavailable")
+
         request_id = uuid.uuid4().hex
         progress_index = 0
+        delegation_idle.clear()
         _emit_event({"type": "delegate", "id": request_id, "request": request})
-        while True:
-            line = await _read_stdin_line()
-            if not line:
-                raise RuntimeError("Hermes TUI closed the live delegation channel")
-            try:
-                command = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(command, dict) or command.get("id") != request_id:
-                continue
-            if command.get("type") == "delegate.progress":
-                progress = str(command.get("text") or "").strip()
-                if progress:
-                    progress_index += 1
-                    try:
-                        await coordinator.add_context(
-                            _progress_item_id(request_id, progress_index),
-                            f"Silent Hermes text-agent progress:\n\n{progress}",
-                        )
-                    except Exception as exc:  # noqa: BLE001 - progress is optional
-                        logger.warning(
-                            "Realtime voice progress context was rejected; "
-                            "continuing to await the final text-agent result: %s",
-                            exc,
-                        )
-                continue
-            if command.get("type") == "delegate.result":
-                output = str(command.get("output") or "").strip()
-                return f'"Agent Final Message":\n\n{output}'
+        try:
+            while True:
+                line = await stdin_reader.readline()
+                if not line:
+                    raise RuntimeError("Hermes TUI closed the live delegation channel")
+                try:
+                    command = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(command, dict) or command.get("id") != request_id:
+                    continue
+                if command.get("type") == "delegate.progress":
+                    progress = str(command.get("text") or "").strip()
+                    if progress:
+                        progress_index += 1
+                        try:
+                            await coordinator.add_context(
+                                _progress_item_id(request_id, progress_index),
+                                f"Silent Hermes text-agent progress:\n\n{progress}",
+                            )
+                        except Exception as exc:  # noqa: BLE001 - progress is optional
+                            logger.warning(
+                                "Realtime voice progress context was rejected; "
+                                "continuing to await the final text-agent result: %s",
+                                exc,
+                            )
+                    continue
+                if command.get("type") == "delegate.result":
+                    output = str(command.get("output") or "").strip()
+                    return f'"Agent Final Message":\n\n{output}'
+        finally:
+            delegation_idle.set()
 
     coordinator = RealtimeVoiceCoordinator(
         provider,
         dispatch_tool=dispatch_tool,
-        max_in_flight_tool_calls=1 if event_stream else 16,
-    )
-    capture = talk_transcript.TranscriptCapture(talk_config.get_hermes_home())
-    configured = talk_config.talk_provider()
-    model = (
-        talk_config.talk_grok_model()
-        if configured == "grok"
-        else talk_config.talk_model()
-    )
-    voice = (
-        talk_config.talk_grok_voice()
-        if configured == "grok"
-        else talk_config.talk_voice()
-    )
-    try:
-        await coordinator.open(
-            instructions=instructions,
-            tools=tools,
-            voice=voice,
-        )
-    except Exception as exc:  # noqa: BLE001 - provider startup is a voice boundary
-        audio.stop()
-        capture.finish()
-        print(f"talk: {exc}", file=sys.stderr)
-        return 1
-
-    print(
-        f"talk: connected ({model}, voice {voice}). "
-        "Ctrl+C to hang up.\n",
-        flush=True,
+        max_in_flight_tool_calls=1,
     )
     last_audio_event: RealtimeEvent | None = None
-    print("talk: state listening", flush=True)
     active_item_id: str | None = None
 
     async def send_microphone() -> None:
@@ -235,7 +299,7 @@ async def run_core_talk_session(audio=None) -> int:
                 continue
             if event.type is RealtimeEventType.TRANSCRIPT:
                 if event.text:
-                    if event_stream and event.role in {"user", "assistant"}:
+                    if event.role in {"user", "assistant"}:
                         _emit_event(
                             {
                                 "type": "transcript",
@@ -244,8 +308,6 @@ async def run_core_talk_session(audio=None) -> int:
                                 "final": event.final,
                             }
                         )
-                    elif not event_stream:
-                        print(event.text, end="\n" if event.final else "", flush=True)
                     if event.final and event.role in {"user", "assistant"}:
                         capture.append_turn(event.role, event.text)
                 continue
@@ -271,38 +333,62 @@ async def run_core_talk_session(audio=None) -> int:
                 continue
             if event.type is RealtimeEventType.ERROR:
                 raise RuntimeError(event.text or "realtime voice provider failed")
+        raise RuntimeError("realtime voice provider closed unexpectedly")
 
-    microphone = asyncio.create_task(send_microphone())
-    receiver = asyncio.create_task(receive_events())
     try:
+        audio.start()
+        audio_started = True
+        stdin_reader = _StdinLineReader()
+        await coordinator.open(
+            instructions=instructions,
+            tools=tools,
+            voice=voice,
+        )
+        print(
+            f"talk: connected ({model}, voice {voice}). "
+            "Ctrl+C to hang up.\n",
+            flush=True,
+        )
+        print("talk: state listening", flush=True)
+
+        runtime_tasks = [
+            asyncio.create_task(send_microphone()),
+            asyncio.create_task(receive_events()),
+            asyncio.create_task(
+                stdin_reader.wait_for_parent_close(delegation_idle)
+            ),
+        ]
         done, pending = await asyncio.wait(
-            (microphone, receiver),
+            runtime_tasks,
             return_when=asyncio.FIRST_COMPLETED,
         )
         for task in pending:
             task.cancel()
         await asyncio.gather(*pending, return_exceptions=True)
         for task in done:
-            try:
-                task.result()
-            except Exception as exc:  # noqa: BLE001 - runtime boundary
-                message = f"{type(exc).__name__}: {exc}"
-                if event_stream:
-                    _emit_event({"type": "error", "message": message})
-                else:
-                    print(f"talk: {message}", file=sys.stderr)
-                return 1
+            task.result()
         return 0
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - terminal runtime boundary
+        _emit_event(
+            {
+                "type": "error",
+                "message": f"{type(exc).__name__}: {exc}",
+            }
+        )
+        return 1
     finally:
-        microphone.cancel()
-        receiver.cancel()
-        await asyncio.gather(microphone, receiver, return_exceptions=True)
-        if event_stream:
-            with contextlib.suppress(Exception):
-                sys.stdin.close()
+        for task in runtime_tasks:
+            task.cancel()
+        if runtime_tasks:
+            await asyncio.gather(*runtime_tasks, return_exceptions=True)
+        if stdin_reader is not None:
+            stdin_reader.close()
         with contextlib.suppress(Exception):
             await coordinator.close()
-        audio.stop()
+        if audio_started:
+            audio.stop()
         capture.finish()
         talk_transcript.sweep_transcripts(talk_config.get_hermes_home())
 

--- a/talk_core_cli.py
+++ b/talk_core_cli.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 IDLE_POLL_S = 0.01
 EVENT_STREAM_ENV = "HERMES_TALK_EVENT_STREAM"
 MAX_PROVIDER_ITEM_ID_LENGTH = 32
+MAX_CONTROL_FRAME_CHARS = 65_536
+MAX_PENDING_CONTROL_FRAMES = 64
 EVENT_PREFIX = "talk: event "
 DELEGATE_TOOL = {
     "type": "function",
@@ -85,11 +87,11 @@ class _StdinLineReader:
     def __init__(self, stream=None) -> None:
         self._stream = stream or sys.stdin
         self._loop = asyncio.get_running_loop()
-        self._lines: asyncio.Queue[str | None] = asyncio.Queue()
-        self._buffered_lines = 0
+        self._lines: asyncio.Queue[str | None] = asyncio.Queue(
+            maxsize=MAX_PENDING_CONTROL_FRAMES + 1
+        )
         self._eof = asyncio.Event()
-        self._drained = asyncio.Event()
-        self._drained.set()
+        self._failure: RuntimeError | None = None
         self._descriptor: int | None = None
         self._text_buffer = ""
         self._thread: threading.Thread | None = None
@@ -127,12 +129,21 @@ class _StdinLineReader:
                 self._loop.call_soon_threadsafe(self._mark_eof)
 
     def _feed_text(self, text: str) -> None:
+        if self._eof.is_set():
+            return
         self._text_buffer += text
         lines = self._text_buffer.split("\n")
         self._text_buffer = lines.pop()
+        if self._text_buffer and len(self._text_buffer) > MAX_CONTROL_FRAME_CHARS:
+            self._fail("Hermes TUI sent an oversized live delegation frame")
+            return
         for line in lines:
-            self._buffered_lines += 1
-            self._drained.clear()
+            if len(line) > MAX_CONTROL_FRAME_CHARS:
+                self._fail("Hermes TUI sent an oversized live delegation frame")
+                return
+            if self._lines.qsize() >= MAX_PENDING_CONTROL_FRAMES:
+                self._fail("Hermes TUI flooded the live delegation channel")
+                return
             self._lines.put_nowait(line.removesuffix("\r"))
 
     def _mark_eof(self) -> None:
@@ -141,26 +152,40 @@ class _StdinLineReader:
         if self._descriptor is not None:
             self._loop.remove_reader(self._descriptor)
         if self._text_buffer:
-            self._buffered_lines += 1
-            self._drained.clear()
-            self._lines.put_nowait(self._text_buffer)
+            if len(self._text_buffer) > MAX_CONTROL_FRAME_CHARS:
+                self._failure = RuntimeError(
+                    "Hermes TUI sent an oversized live delegation frame"
+                )
+            elif self._lines.qsize() >= MAX_PENDING_CONTROL_FRAMES:
+                self._failure = RuntimeError(
+                    "Hermes TUI flooded the live delegation channel"
+                )
+            else:
+                self._lines.put_nowait(self._text_buffer)
             self._text_buffer = ""
         self._eof.set()
         self._lines.put_nowait(None)
 
+    def _fail(self, message: str) -> None:
+        self._failure = RuntimeError(message)
+        self._text_buffer = ""
+        while not self._lines.empty():
+            self._lines.get_nowait()
+        self._mark_eof()
+
     async def readline(self) -> str:
         line = await self._lines.get()
         if line is None:
+            if self._failure is not None:
+                raise self._failure
             return ""
-        self._buffered_lines -= 1
-        if self._buffered_lines == 0:
-            self._drained.set()
         return line
 
     async def wait_for_parent_close(self, delegation_idle: asyncio.Event) -> None:
         await self._eof.wait()
-        await self._drained.wait()
         await delegation_idle.wait()
+        if self._failure is not None:
+            raise self._failure
         raise RuntimeError("Hermes TUI closed the live delegation channel")
 
     def close(self) -> None:
@@ -273,7 +298,14 @@ async def run_core_talk_session(audio=None) -> int:
         max_in_flight_tool_calls=1,
     )
     last_audio_event: RealtimeEvent | None = None
-    active_item_id: str | None = None
+    last_state: str | None = None
+
+    def emit_state(state: str) -> None:
+        nonlocal last_state
+        if state == last_state:
+            return
+        last_state = state
+        print(f"talk: state {state}", flush=True)
 
     async def send_microphone() -> None:
         while True:
@@ -289,12 +321,8 @@ async def run_core_talk_session(audio=None) -> int:
             if event.type is RealtimeEventType.AUDIO:
                 if not event.audio_bytes:
                     continue
-                if event.item_id != active_item_id:
-                    active_item_id = event.item_id
-                    last_audio_event = None
-                    audio.reset_played_ms()
-                print("talk: state composing", flush=True)
-                audio.queue_playback(event.audio_bytes)
+                emit_state("composing")
+                audio.queue_playback(event.audio_bytes, item_id=event.item_id)
                 last_audio_event = event
                 continue
             if event.type is RealtimeEventType.TRANSCRIPT:
@@ -313,13 +341,13 @@ async def run_core_talk_session(audio=None) -> int:
                 continue
             if event.type is RealtimeEventType.TURN_ENDED:
                 if event.role == "user":
-                    print("talk: state solving", flush=True)
+                    emit_state("solving")
                 elif event.role == "assistant":
-                    print("talk: state listening", flush=True)
+                    emit_state("listening")
                 continue
             if event.type is RealtimeEventType.TURN_STARTED:
                 if event.role == "assistant":
-                    print("talk: state composing", flush=True)
+                    emit_state("composing")
                 elif event.role == "user" and last_audio_event is not None:
                     coordinator.report_audio_heard(
                         last_audio_event,
@@ -328,8 +356,7 @@ async def run_core_talk_session(audio=None) -> int:
                     audio.drain_playback()
                     await coordinator.cancel_response()
                     last_audio_event = None
-                    active_item_id = None
-                    print("talk: state listening", flush=True)
+                    emit_state("listening")
                 continue
             if event.type is RealtimeEventType.ERROR:
                 raise RuntimeError(event.text or "realtime voice provider failed")
@@ -349,7 +376,7 @@ async def run_core_talk_session(audio=None) -> int:
             "Ctrl+C to hang up.\n",
             flush=True,
         )
-        print("talk: state listening", flush=True)
+        emit_state("listening")
 
         runtime_tasks = [
             asyncio.create_task(send_microphone()),

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -129,26 +129,26 @@ try:
 except Exception as exc:  # noqa: BLE001 - optional core must never poison legacy imports
     _CORE_IMPORT_ERROR = exc
 
-_V1_PROVIDER = None
-_V1_CONFIGURED_PROVIDER = None
+_COORDINATOR_PROVIDER = None
+_CONFIGURED_COORDINATOR_PROVIDER = None
 try:
     try:
         from .talk_core_realtime_contract import (
-            TalkOpenAIRealtimeProvider as _V1_PROVIDER,
+            TalkOpenAIRealtimeProvider as _COORDINATOR_PROVIDER,
         )
         from .talk_core_realtime_contract import (
-            configured_provider as _V1_CONFIGURED_PROVIDER,
+            configured_provider as _CONFIGURED_COORDINATOR_PROVIDER,
         )
     except ImportError:
         from talk_core_realtime_contract import (
-            TalkOpenAIRealtimeProvider as _V1_PROVIDER,
+            TalkOpenAIRealtimeProvider as _COORDINATOR_PROVIDER,
         )
         from talk_core_realtime_contract import (
-            configured_provider as _V1_CONFIGURED_PROVIDER,
+            configured_provider as _CONFIGURED_COORDINATOR_PROVIDER,
         )
 except Exception:  # noqa: BLE001 - #95147 is optional on older Hermes hosts
-    _V1_PROVIDER = None
-    _V1_CONFIGURED_PROVIDER = None
+    _COORDINATOR_PROVIDER = None
+    _CONFIGURED_COORDINATOR_PROVIDER = None
 
 # Compatibility diagnostics intentionally distinguish the detected data surface
 # from the complete production capability (which also requires enum claims and
@@ -182,20 +182,20 @@ _PROVIDER_EOF_MESSAGE = "provider connection closed unexpectedly"
 def core_provider_available() -> bool:
     """Return whether either supported Hermes realtime contract is importable."""
 
-    return _CORE_IMPORT_ERROR is None or _V1_PROVIDER is not None
+    return _CORE_IMPORT_ERROR is None or _COORDINATOR_PROVIDER is not None
 
 
 def coordinator_contract_available() -> bool:
     """Return whether Hermes #95147 is the active optional core contract."""
 
-    return _CORE_IMPORT_ERROR is not None and _V1_PROVIDER is not None
+    return _CORE_IMPORT_ERROR is not None and _COORDINATOR_PROVIDER is not None
 
 
 def configured_core_provider():
     """Build the configured provider for the active Hermes core contract."""
 
     if coordinator_contract_available():
-        return _V1_CONFIGURED_PROVIDER()
+        return _CONFIGURED_COORDINATOR_PROVIDER()
     if TalkOpenAIRealtimeProvider is None:
         raise RuntimeError("Hermes realtime voice provider contract is unavailable")
     return TalkOpenAIRealtimeProvider()
@@ -206,7 +206,7 @@ def configured_core_provider_supported() -> bool:
 
     try:
         if coordinator_contract_available():
-            _V1_CONFIGURED_PROVIDER()
+            _CONFIGURED_COORDINATOR_PROVIDER()
             return True
         return talk_config.talk_provider() == "openai"
     except Exception:  # noqa: BLE001 - selection probes never break plugin loading
@@ -1399,7 +1399,7 @@ else:
     SUPPORTED_INPUT_AUDIO_FORMAT = None
     SUPPORTED_OUTPUT_AUDIO_FORMAT = None
     CORE_CAPABILITIES = frozenset()
-    TalkOpenAIRealtimeProvider = _V1_PROVIDER
+    TalkOpenAIRealtimeProvider = _COORDINATOR_PROVIDER
 
 
 __all__ = [

--- a/talk_core_realtime.py
+++ b/talk_core_realtime.py
@@ -129,6 +129,27 @@ try:
 except Exception as exc:  # noqa: BLE001 - optional core must never poison legacy imports
     _CORE_IMPORT_ERROR = exc
 
+_V1_PROVIDER = None
+_V1_CONFIGURED_PROVIDER = None
+try:
+    try:
+        from .talk_core_realtime_contract import (
+            TalkOpenAIRealtimeProvider as _V1_PROVIDER,
+        )
+        from .talk_core_realtime_contract import (
+            configured_provider as _V1_CONFIGURED_PROVIDER,
+        )
+    except ImportError:
+        from talk_core_realtime_contract import (
+            TalkOpenAIRealtimeProvider as _V1_PROVIDER,
+        )
+        from talk_core_realtime_contract import (
+            configured_provider as _V1_CONFIGURED_PROVIDER,
+        )
+except Exception:  # noqa: BLE001 - #95147 is optional on older Hermes hosts
+    _V1_PROVIDER = None
+    _V1_CONFIGURED_PROVIDER = None
+
 # Compatibility diagnostics intentionally distinguish the detected data surface
 # from the complete production capability (which also requires enum claims and
 # the concrete mapper/hook implemented below).
@@ -159,9 +180,37 @@ _PROVIDER_EOF_MESSAGE = "provider connection closed unexpectedly"
 
 
 def core_provider_available() -> bool:
-    """Return only whether the exact optional Hermes core API-v2 is importable."""
+    """Return whether either supported Hermes realtime contract is importable."""
 
-    return _CORE_IMPORT_ERROR is None
+    return _CORE_IMPORT_ERROR is None or _V1_PROVIDER is not None
+
+
+def coordinator_contract_available() -> bool:
+    """Return whether Hermes #95147 is the active optional core contract."""
+
+    return _CORE_IMPORT_ERROR is not None and _V1_PROVIDER is not None
+
+
+def configured_core_provider():
+    """Build the configured provider for the active Hermes core contract."""
+
+    if coordinator_contract_available():
+        return _V1_CONFIGURED_PROVIDER()
+    if TalkOpenAIRealtimeProvider is None:
+        raise RuntimeError("Hermes realtime voice provider contract is unavailable")
+    return TalkOpenAIRealtimeProvider()
+
+
+def configured_core_provider_supported() -> bool:
+    """Return whether the active core seam supports TALK_PROVIDER."""
+
+    try:
+        if coordinator_contract_available():
+            _V1_CONFIGURED_PROVIDER()
+            return True
+        return talk_config.talk_provider() == "openai"
+    except Exception:  # noqa: BLE001 - selection probes never break plugin loading
+        return False
 
 
 def explicit_output_available() -> bool:
@@ -172,12 +221,12 @@ def explicit_output_available() -> bool:
 
 def core_provider_diagnostic() -> dict[str, bool]:
     """Return passive contract/provider readiness without exposing credentials."""
-
     contract_available = core_provider_available()
     provider_available = False
-    if contract_available and TalkOpenAIRealtimeProvider is not None:
+
+    if contract_available:
         try:
-            provider_available = bool(TalkOpenAIRealtimeProvider().is_available())
+            provider_available = bool(configured_core_provider().is_available())
         except Exception:  # noqa: BLE001 - diagnostics must stay passive and bounded
             provider_available = False
     return {
@@ -1350,7 +1399,7 @@ else:
     SUPPORTED_INPUT_AUDIO_FORMAT = None
     SUPPORTED_OUTPUT_AUDIO_FORMAT = None
     CORE_CAPABILITIES = frozenset()
-    TalkOpenAIRealtimeProvider = None
+    TalkOpenAIRealtimeProvider = _V1_PROVIDER
 
 
 __all__ = [
@@ -1363,6 +1412,9 @@ __all__ = [
     "OpenAIWireEOF",
     "OpenAIWireError",
     "TalkOpenAIRealtimeProvider",
+    "configured_core_provider",
+    "configured_core_provider_supported",
+    "coordinator_contract_available",
     "core_provider_available",
     "core_provider_diagnostic",
     "explicit_output_available",

--- a/talk_core_realtime_contract.py
+++ b/talk_core_realtime_contract.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections import OrderedDict
 from collections.abc import AsyncIterator, Callable, Mapping
 from typing import Any
 
@@ -35,6 +36,7 @@ except ImportError:  # pragma: no cover - flat-module fallback
 OPENAI_PROVIDER_NAME = "talk_openai_realtime"
 GROK_PROVIDER_NAME = "talk_grok_realtime"
 PROVIDER_NAME = OPENAI_PROVIDER_NAME
+MAX_SETTLED_IDENTIFIERS = 256
 
 
 def _tool_definition(value: Mapping[str, Any]) -> rt.ToolDefinition:
@@ -64,9 +66,14 @@ class TalkRealtimeSession(RealtimeSession):
         self._closed = False
         self._tool_lock = asyncio.Lock()
         self._pending_tool_calls: list[str] = []
+        self._tool_call_responses: dict[str, str | None] = {}
         self._tool_outputs: dict[str, str] = {}
+        self._completed_tool_calls: OrderedDict[str, None] = OrderedDict()
         self._response_finished = False
-        self._response_active = False
+        self._response_in_flight = False
+        self._active_response_id: str | None = None
+        self._unnamed_response_cancelled = False
+        self._settled_response_ids: OrderedDict[str, None] = OrderedDict()
 
     async def send_audio(self, pcm: bytes) -> None:
         await self._session.send((rt.AppendInputAudio(bytes(pcm)),))
@@ -82,16 +89,27 @@ class TalkRealtimeSession(RealtimeSession):
 
     def _map_event(self, event: rt.RealtimeEvent) -> RealtimeEvent | None:
         if isinstance(event, rt.OutputAudio):
+            if not self._belongs_to_active(event.response_id):
+                return None
             return RealtimeEvent.audio(event.data, item_id=event.item_id)
         if isinstance(event, rt.Transcript):
+            if (
+                event.role is rt.TranscriptRole.ASSISTANT
+                and not self._belongs_to_active(event.response_id)
+            ):
+                return None
             return RealtimeEvent.transcript(
                 event.text,
                 final=event.final,
                 role=event.role.value,
             )
         if isinstance(event, rt.FunctionCall):
-            if event.call_id not in self._pending_tool_calls:
-                self._pending_tool_calls.append(event.call_id)
+            if (
+                event.call_id in self._completed_tool_calls
+                or event.call_id in self._pending_tool_calls
+                or not self._belongs_to_active(event.response_id)
+            ):
+                return None
             try:
                 arguments = json.loads(event.arguments)
             except json.JSONDecodeError as exc:
@@ -104,27 +122,38 @@ class TalkRealtimeSession(RealtimeSession):
                     type=RealtimeEventType.ERROR,
                     text="invalid tool arguments: expected an object",
                 )
+            self._pending_tool_calls.append(event.call_id)
+            self._tool_call_responses[event.call_id] = event.response_id
             return RealtimeEvent.tool_call(event.call_id, event.name, arguments)
         if isinstance(event, rt.SpeechStarted):
             return RealtimeEvent(type=RealtimeEventType.TURN_STARTED, role="user")
         if isinstance(event, rt.SpeechStopped):
             return RealtimeEvent(type=RealtimeEventType.TURN_ENDED, role="user")
         if isinstance(event, rt.ResponseStarted):
-            self._response_active = True
-            self._response_finished = False
+            if not self._start_response(event.response_id):
+                return None
             return RealtimeEvent(type=RealtimeEventType.TURN_STARTED, role="assistant")
         if isinstance(event, rt.ResponseFinished):
-            self._response_active = False
+            if not self._finish_response(event.response_id):
+                return None
             self._response_finished = True
             return RealtimeEvent(type=RealtimeEventType.TURN_ENDED, role="assistant")
         if isinstance(event, rt.ProviderFailure) and event.terminal:
             return RealtimeEvent(type=RealtimeEventType.ERROR, text=event.detail)
-        if isinstance(event, rt.SessionTerminated) and event.state is rt.SessionState.FAILED:
-            return RealtimeEvent(type=RealtimeEventType.ERROR, text=event.detail)
+        if isinstance(event, rt.SessionTerminated):
+            if event.state is rt.SessionState.FAILED:
+                return RealtimeEvent(type=RealtimeEventType.ERROR, text=event.detail)
+            if event.state is rt.SessionState.CLOSED and not self._closed:
+                return RealtimeEvent(
+                    type=RealtimeEventType.ERROR,
+                    text=event.detail or "realtime voice provider closed unexpectedly",
+                )
         return None
 
     async def submit_tool_result(self, call_id: str, output: str) -> None:
         async with self._tool_lock:
+            if call_id in self._completed_tool_calls:
+                return
             if call_id not in self._pending_tool_calls:
                 raise ValueError(f"unknown realtime tool call {call_id!r}")
             self._tool_outputs[call_id] = output
@@ -148,7 +177,10 @@ class TalkRealtimeSession(RealtimeSession):
             rt.StartResponse(),
         )
         await self._session.send(commands)
+        for call_id in self._pending_tool_calls:
+            self._mark_tool_call_completed(call_id)
         self._pending_tool_calls.clear()
+        self._tool_call_responses.clear()
         self._tool_outputs.clear()
         self._response_finished = False
 
@@ -174,8 +206,85 @@ class TalkRealtimeSession(RealtimeSession):
         )
 
     async def cancel_response(self) -> None:
-        if self._response_active:
+        if self._cancel_active_response():
             await self._session.send((rt.CancelResponse(),))
+
+    def _belongs_to_active(self, response_id: str | None) -> bool:
+        if response_id is None:
+            return not self._unnamed_response_cancelled
+        if response_id in self._settled_response_ids:
+            return False
+        return self._active_response_id is None or response_id == self._active_response_id
+
+    def _settle_response(self, response_id: str) -> None:
+        if response_id in self._settled_response_ids:
+            return
+        self._settled_response_ids[response_id] = None
+        if len(self._settled_response_ids) > MAX_SETTLED_IDENTIFIERS:
+            self._settled_response_ids.popitem(last=False)
+
+    def _start_response(self, response_id: str | None) -> bool:
+        if response_id is not None and response_id in self._settled_response_ids:
+            return False
+        if (
+            response_id is None
+            and self._response_in_flight
+            and self._active_response_id is not None
+        ):
+            return False
+        self._unnamed_response_cancelled = False
+        self._response_in_flight = True
+        self._active_response_id = response_id
+        self._response_finished = False
+        return True
+
+    def _cancel_active_response(self) -> bool:
+        if not self._response_in_flight:
+            return False
+        if self._active_response_id is not None:
+            if self._active_response_id in self._settled_response_ids:
+                return False
+            self._settle_response(self._active_response_id)
+        elif self._unnamed_response_cancelled:
+            return False
+        else:
+            self._unnamed_response_cancelled = True
+        self._abandon_tool_calls(self._active_response_id)
+        self._response_finished = False
+        return True
+
+    def _finish_response(self, response_id: str | None) -> bool:
+        eligible = self._belongs_to_active(response_id)
+        if response_id is not None:
+            self._settle_response(response_id)
+        if (
+            response_id is not None
+            and self._active_response_id is not None
+            and response_id != self._active_response_id
+        ):
+            return False
+        self._response_in_flight = False
+        self._active_response_id = None
+        self._unnamed_response_cancelled = False
+        return eligible
+
+    def _abandon_tool_calls(self, response_id: str | None) -> None:
+        abandoned = [
+            call_id
+            for call_id in self._pending_tool_calls
+            if self._tool_call_responses.get(call_id) == response_id
+        ]
+        for call_id in abandoned:
+            self._pending_tool_calls.remove(call_id)
+            self._tool_call_responses.pop(call_id, None)
+            self._tool_outputs.pop(call_id, None)
+            self._mark_tool_call_completed(call_id)
+
+    def _mark_tool_call_completed(self, call_id: str) -> None:
+        self._completed_tool_calls[call_id] = None
+        self._completed_tool_calls.move_to_end(call_id)
+        if len(self._completed_tool_calls) > MAX_SETTLED_IDENTIFIERS:
+            self._completed_tool_calls.popitem(last=False)
 
     async def close(self) -> None:
         if self._closed:

--- a/talk_core_realtime_contract.py
+++ b/talk_core_realtime_contract.py
@@ -21,15 +21,18 @@ from agent.realtime_voice import (
 )
 
 try:
-    from . import talk_auth, talk_config, talk_grok_auth
+    from . import talk_auth, talk_config, talk_gemini_auth, talk_grok_auth
     from . import talk_realtime as rt
+    from .talk_gemini_realtime import GeminiRealtimeSession
     from .talk_grok_realtime import GrokRealtimeSession
     from .talk_openai_realtime import OpenAIRealtimeSession
 except ImportError:  # pragma: no cover - flat-module fallback
     import talk_auth
     import talk_config
+    import talk_gemini_auth
     import talk_grok_auth
     import talk_realtime as rt
+    from talk_gemini_realtime import GeminiRealtimeSession
     from talk_grok_realtime import GrokRealtimeSession
     from talk_openai_realtime import OpenAIRealtimeSession
 
@@ -37,6 +40,7 @@ OPENAI_PROVIDER_NAME = "talk_openai_realtime"
 GROK_PROVIDER_NAME = "talk_grok_realtime"
 PROVIDER_NAME = OPENAI_PROVIDER_NAME
 MAX_SETTLED_IDENTIFIERS = 256
+GEMINI_PROVIDER_NAME = "talk_gemini_realtime"
 
 
 def _tool_definition(value: Mapping[str, Any]) -> rt.ToolDefinition:
@@ -88,6 +92,11 @@ class TalkRealtimeSession(RealtimeSession):
                 yield mapped
 
     def _map_event(self, event: rt.RealtimeEvent) -> RealtimeEvent | None:
+        if isinstance(event, rt.SessionReady):
+            return RealtimeEvent(
+                type=RealtimeEventType.SESSION_READY,
+                session_id=event.session_id,
+            )
         if isinstance(event, rt.OutputAudio):
             if not self._belongs_to_active(event.response_id):
                 return None
@@ -138,8 +147,15 @@ class TalkRealtimeSession(RealtimeSession):
                 return None
             self._response_finished = True
             return RealtimeEvent(type=RealtimeEventType.TURN_ENDED, role="assistant")
-        if isinstance(event, rt.ProviderFailure) and event.terminal:
-            return RealtimeEvent(type=RealtimeEventType.ERROR, text=event.detail)
+        if isinstance(event, rt.ProviderFailure):
+            return RealtimeEvent(
+                type=(
+                    RealtimeEventType.ERROR
+                    if event.terminal
+                    else RealtimeEventType.WARNING
+                ),
+                text=event.detail,
+            )
         if isinstance(event, rt.SessionTerminated):
             if event.state is rt.SessionState.FAILED:
                 return RealtimeEvent(type=RealtimeEventType.ERROR, text=event.detail)
@@ -399,6 +415,25 @@ class TalkGrokRealtimeProvider(_TalkRealtimeProvider):
         )
 
 
+class TalkGeminiRealtimeProvider(_TalkRealtimeProvider):
+    """Plugin-owned Gemini Live transport for the Hermes #95147 seam."""
+
+    def __init__(
+        self,
+        *,
+        auth_resolver: Callable[[], Any] = talk_gemini_auth.resolve_gemini_auth,
+        session_factory: Callable[..., Any] = GeminiRealtimeSession,
+    ) -> None:
+        super().__init__(
+            name=GEMINI_PROVIDER_NAME,
+            display_name="Hermes Talk Gemini Live",
+            auth_resolver=auth_resolver,
+            session_factory=session_factory,
+            model_resolver=talk_config.talk_gemini_model,
+            voice_resolver=talk_config.talk_gemini_voice,
+        )
+
+
 def configured_provider() -> RealtimeVoiceProvider:
     """Build the provider selected by TALK_PROVIDER for this invocation."""
 
@@ -407,6 +442,8 @@ def configured_provider() -> RealtimeVoiceProvider:
         return TalkOpenAIRealtimeProvider()
     if provider == "grok":
         return TalkGrokRealtimeProvider()
+    if provider == "gemini":
+        return TalkGeminiRealtimeProvider()
     raise talk_config.TalkConfigError(
         f"Hermes #95147 terminal voice does not support provider {provider!r}"
     )
@@ -420,15 +457,19 @@ def configured_provider_name() -> str:
         return OPENAI_PROVIDER_NAME
     if provider == "grok":
         return GROK_PROVIDER_NAME
+    if provider == "gemini":
+        return GEMINI_PROVIDER_NAME
     raise talk_config.TalkConfigError(
         f"Hermes #95147 terminal voice does not support provider {provider!r}"
     )
 
 
 __all__ = [
+    "GEMINI_PROVIDER_NAME",
     "GROK_PROVIDER_NAME",
     "OPENAI_PROVIDER_NAME",
     "PROVIDER_NAME",
+    "TalkGeminiRealtimeProvider",
     "TalkGrokRealtimeProvider",
     "TalkOpenAIRealtimeProvider",
     "TalkRealtimeSession",

--- a/talk_core_realtime_contract.py
+++ b/talk_core_realtime_contract.py
@@ -1,0 +1,300 @@
+"""Hermes #95147 realtime voice provider adapter.
+
+The transport remains plugin-owned. This adapter only maps Talk's existing
+provider-neutral session onto Hermes's host-owned coordinator contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import AsyncIterator, Callable, Mapping
+from typing import Any
+
+from agent.realtime_voice import (
+    HeardAudioBoundary,
+    RealtimeEvent,
+    RealtimeEventType,
+    RealtimeSession,
+    RealtimeVoiceProvider,
+)
+
+try:
+    from . import talk_auth, talk_config
+    from . import talk_realtime as rt
+    from .talk_grok_realtime import GrokRealtimeSession
+    from .talk_openai_realtime import OpenAIRealtimeSession
+except ImportError:  # pragma: no cover - flat-module fallback
+    import talk_auth
+    import talk_config
+    import talk_realtime as rt
+    from talk_grok_realtime import GrokRealtimeSession
+    from talk_openai_realtime import OpenAIRealtimeSession
+
+OPENAI_PROVIDER_NAME = "talk_openai_realtime"
+GROK_PROVIDER_NAME = "talk_grok_realtime"
+PROVIDER_NAME = OPENAI_PROVIDER_NAME
+
+
+def _tool_definition(value: Mapping[str, Any]) -> rt.ToolDefinition:
+    function = value.get("function")
+    source = function if isinstance(function, Mapping) else value
+    name = source.get("name")
+    description = source.get("description", "")
+    parameters = source.get("parameters", {"type": "object", "properties": {}})
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("realtime tool definitions require a non-empty name")
+    if not isinstance(description, str):
+        raise TypeError("realtime tool descriptions must be strings")
+    if not isinstance(parameters, Mapping):
+        raise TypeError("realtime tool parameters must be an object")
+    return rt.ToolDefinition(
+        name=name,
+        description=description,
+        parameters=dict(parameters),
+    )
+
+
+class TalkRealtimeSession(RealtimeSession):
+    """Translate one Talk session into the ordered Hermes event contract."""
+
+    def __init__(self, session) -> None:
+        self._session = session
+        self._closed = False
+
+    async def send_audio(self, pcm: bytes) -> None:
+        await self._session.send((rt.AppendInputAudio(bytes(pcm)),))
+
+    async def events(self) -> AsyncIterator[RealtimeEvent]:
+        async for event in self._session:
+            mapped = self._map_event(event)
+            if mapped is not None:
+                yield mapped
+
+    def _map_event(self, event: rt.RealtimeEvent) -> RealtimeEvent | None:
+        if isinstance(event, rt.OutputAudio):
+            return RealtimeEvent.audio(event.data, item_id=event.item_id)
+        if isinstance(event, rt.Transcript):
+            return RealtimeEvent.transcript(
+                event.text,
+                final=event.final,
+                role=event.role.value,
+            )
+        if isinstance(event, rt.FunctionCall):
+            try:
+                arguments = json.loads(event.arguments)
+            except json.JSONDecodeError as exc:
+                return RealtimeEvent(
+                    type=RealtimeEventType.ERROR,
+                    text=f"invalid tool arguments: {exc.msg}",
+                )
+            if not isinstance(arguments, dict):
+                return RealtimeEvent(
+                    type=RealtimeEventType.ERROR,
+                    text="invalid tool arguments: expected an object",
+                )
+            return RealtimeEvent.tool_call(event.call_id, event.name, arguments)
+        if isinstance(event, rt.SpeechStarted):
+            return RealtimeEvent(type=RealtimeEventType.TURN_STARTED, role="user")
+        if isinstance(event, rt.SpeechStopped):
+            return RealtimeEvent(type=RealtimeEventType.TURN_ENDED, role="user")
+        if isinstance(event, rt.ResponseStarted):
+            return RealtimeEvent(type=RealtimeEventType.TURN_STARTED, role="assistant")
+        if isinstance(event, rt.ResponseFinished):
+            return RealtimeEvent(type=RealtimeEventType.TURN_ENDED, role="assistant")
+        if isinstance(event, rt.ProviderFailure):
+            return RealtimeEvent(type=RealtimeEventType.ERROR, text=event.detail)
+        if isinstance(event, rt.SessionTerminated) and event.state is rt.SessionState.FAILED:
+            return RealtimeEvent(type=RealtimeEventType.ERROR, text=event.detail)
+        return None
+
+    async def submit_tool_result(self, call_id: str, output: str) -> None:
+        await self._session.send(
+            (
+                rt.SubmitToolResult(call_id=call_id, output=output),
+                rt.StartResponse(),
+            )
+        )
+
+    async def add_context(self, item_id: str, text: str) -> None:
+        await self._session.send(
+            (
+                rt.AddContext(
+                    item_id=item_id,
+                    text=text,
+                    role=rt.ContextRole.SYSTEM,
+                ),
+            )
+        )
+
+    async def truncate_response(self, boundary: HeardAudioBoundary) -> None:
+        await self._session.send(
+            (
+                rt.TruncateOutput(
+                    item_id=boundary.item_id,
+                    audio_end_ms=boundary.audio_end_ms,
+                ),
+            )
+        )
+
+    async def cancel_response(self) -> None:
+        await self._session.send((rt.CancelResponse(),))
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._session.close()
+
+
+class _TalkRealtimeProvider(RealtimeVoiceProvider):
+    """Shared #95147 mapping around one plugin-owned provider transport."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        display_name: str,
+        auth_resolver: Callable[[], Any],
+        session_factory: Callable[..., Any],
+        model_resolver: Callable[[], str],
+        voice_resolver: Callable[[], str],
+    ) -> None:
+        self._name = name
+        self._display_name = display_name
+        self._auth_resolver = auth_resolver
+        self._session_factory = session_factory
+        self._model_resolver = model_resolver
+        self._voice_resolver = voice_resolver
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def display_name(self) -> str:
+        return self._display_name
+
+    def is_available(self) -> bool:
+        try:
+            import aiohttp  # noqa: F401 - passive dependency probe
+
+            return bool(self._model_resolver() and self._auth_resolver().token)
+        except Exception:  # noqa: BLE001 - passive readiness must not escape
+            return False
+
+    def get_setup_schema(self) -> dict[str, Any]:
+        return {
+            "name": self.display_name,
+            "badge": "duplex",
+            "tag": "plugin",
+            "env_vars": [],
+        }
+
+    async def open_session(
+        self,
+        *,
+        instructions: str,
+        tools: list[dict[str, Any]],
+        voice: str | None = None,
+    ) -> RealtimeSession:
+        auth = self._auth_resolver()
+        session = self._session_factory(auth_token=auth.token, auth_source=auth.source)
+        setup = rt.SessionSetup(
+            model=self._model_resolver(),
+            voice=voice or self._voice_resolver(),
+            instructions=instructions,
+            tools=tuple(_tool_definition(tool) for tool in tools),
+            automatic_response=True,
+        )
+        try:
+            await session.connect(setup)
+        except BaseException:
+            await session.close()
+            raise
+        return TalkRealtimeSession(session)
+
+
+class TalkOpenAIRealtimeProvider(_TalkRealtimeProvider):
+    """Plugin-owned OpenAI duplex transport for the Hermes #95147 seam."""
+
+    def __init__(
+        self,
+        *,
+        auth_resolver: Callable[[], Any] = talk_auth.resolve_auth,
+        session_factory: Callable[..., Any] = OpenAIRealtimeSession,
+    ) -> None:
+        super().__init__(
+            name=OPENAI_PROVIDER_NAME,
+            display_name="Hermes Talk OpenAI Realtime",
+            auth_resolver=auth_resolver,
+            session_factory=session_factory,
+            model_resolver=talk_config.talk_model,
+            voice_resolver=talk_config.talk_voice,
+        )
+
+
+def _grok_auth() -> talk_auth.TalkAuth:
+    scoped = bool((os.environ.get("TALK_XAI_API_KEY") or "").strip())
+    return talk_auth.TalkAuth(
+        token=talk_config.resolve_xai_key(),
+        source=talk_auth.SOURCE_CONFIGURED if scoped else talk_auth.SOURCE_ENV,
+        detail="TALK_XAI_API_KEY" if scoped else "XAI_API_KEY",
+    )
+
+
+class TalkGrokRealtimeProvider(_TalkRealtimeProvider):
+    """Plugin-owned xAI Grok duplex transport for the Hermes #95147 seam."""
+
+    def __init__(
+        self,
+        *,
+        auth_resolver: Callable[[], Any] = _grok_auth,
+        session_factory: Callable[..., Any] = GrokRealtimeSession,
+    ) -> None:
+        super().__init__(
+            name=GROK_PROVIDER_NAME,
+            display_name="Hermes Talk Grok Realtime",
+            auth_resolver=auth_resolver,
+            session_factory=session_factory,
+            model_resolver=talk_config.talk_grok_model,
+            voice_resolver=talk_config.talk_grok_voice,
+        )
+
+
+def configured_provider() -> RealtimeVoiceProvider:
+    """Build the provider selected by TALK_PROVIDER for this invocation."""
+
+    provider = talk_config.talk_provider()
+    if provider == "openai":
+        return TalkOpenAIRealtimeProvider()
+    if provider == "grok":
+        return TalkGrokRealtimeProvider()
+    raise talk_config.TalkConfigError(
+        f"Hermes #95147 terminal voice does not support provider {provider!r}"
+    )
+
+
+def configured_provider_name() -> str:
+    """Return the #95147 registry key for the configured provider."""
+
+    provider = talk_config.talk_provider()
+    if provider == "openai":
+        return OPENAI_PROVIDER_NAME
+    if provider == "grok":
+        return GROK_PROVIDER_NAME
+    raise talk_config.TalkConfigError(
+        f"Hermes #95147 terminal voice does not support provider {provider!r}"
+    )
+
+
+__all__ = [
+    "GROK_PROVIDER_NAME",
+    "OPENAI_PROVIDER_NAME",
+    "PROVIDER_NAME",
+    "TalkGrokRealtimeProvider",
+    "TalkOpenAIRealtimeProvider",
+    "TalkRealtimeSession",
+    "configured_provider",
+    "configured_provider_name",
+]

--- a/talk_core_realtime_contract.py
+++ b/talk_core_realtime_contract.py
@@ -6,8 +6,8 @@ provider-neutral session onto Hermes's host-owned coordinator contract.
 
 from __future__ import annotations
 
+import asyncio
 import json
-import os
 from collections.abc import AsyncIterator, Callable, Mapping
 from typing import Any
 
@@ -20,13 +20,14 @@ from agent.realtime_voice import (
 )
 
 try:
-    from . import talk_auth, talk_config
+    from . import talk_auth, talk_config, talk_grok_auth
     from . import talk_realtime as rt
     from .talk_grok_realtime import GrokRealtimeSession
     from .talk_openai_realtime import OpenAIRealtimeSession
 except ImportError:  # pragma: no cover - flat-module fallback
     import talk_auth
     import talk_config
+    import talk_grok_auth
     import talk_realtime as rt
     from talk_grok_realtime import GrokRealtimeSession
     from talk_openai_realtime import OpenAIRealtimeSession
@@ -61,6 +62,11 @@ class TalkRealtimeSession(RealtimeSession):
     def __init__(self, session) -> None:
         self._session = session
         self._closed = False
+        self._tool_lock = asyncio.Lock()
+        self._pending_tool_calls: list[str] = []
+        self._tool_outputs: dict[str, str] = {}
+        self._response_finished = False
+        self._response_active = False
 
     async def send_audio(self, pcm: bytes) -> None:
         await self._session.send((rt.AppendInputAudio(bytes(pcm)),))
@@ -68,6 +74,9 @@ class TalkRealtimeSession(RealtimeSession):
     async def events(self) -> AsyncIterator[RealtimeEvent]:
         async for event in self._session:
             mapped = self._map_event(event)
+            if isinstance(event, rt.ResponseFinished):
+                async with self._tool_lock:
+                    await self._flush_tool_results()
             if mapped is not None:
                 yield mapped
 
@@ -81,6 +90,8 @@ class TalkRealtimeSession(RealtimeSession):
                 role=event.role.value,
             )
         if isinstance(event, rt.FunctionCall):
+            if event.call_id not in self._pending_tool_calls:
+                self._pending_tool_calls.append(event.call_id)
             try:
                 arguments = json.loads(event.arguments)
             except json.JSONDecodeError as exc:
@@ -99,22 +110,47 @@ class TalkRealtimeSession(RealtimeSession):
         if isinstance(event, rt.SpeechStopped):
             return RealtimeEvent(type=RealtimeEventType.TURN_ENDED, role="user")
         if isinstance(event, rt.ResponseStarted):
+            self._response_active = True
+            self._response_finished = False
             return RealtimeEvent(type=RealtimeEventType.TURN_STARTED, role="assistant")
         if isinstance(event, rt.ResponseFinished):
+            self._response_active = False
+            self._response_finished = True
             return RealtimeEvent(type=RealtimeEventType.TURN_ENDED, role="assistant")
-        if isinstance(event, rt.ProviderFailure):
+        if isinstance(event, rt.ProviderFailure) and event.terminal:
             return RealtimeEvent(type=RealtimeEventType.ERROR, text=event.detail)
         if isinstance(event, rt.SessionTerminated) and event.state is rt.SessionState.FAILED:
             return RealtimeEvent(type=RealtimeEventType.ERROR, text=event.detail)
         return None
 
     async def submit_tool_result(self, call_id: str, output: str) -> None:
-        await self._session.send(
-            (
-                rt.SubmitToolResult(call_id=call_id, output=output),
-                rt.StartResponse(),
-            )
+        async with self._tool_lock:
+            if call_id not in self._pending_tool_calls:
+                raise ValueError(f"unknown realtime tool call {call_id!r}")
+            self._tool_outputs[call_id] = output
+            await self._flush_tool_results()
+
+    async def _flush_tool_results(self) -> None:
+        if (
+            not self._response_finished
+            or not self._pending_tool_calls
+            or any(call_id not in self._tool_outputs for call_id in self._pending_tool_calls)
+        ):
+            return
+        commands = (
+            *(
+                rt.SubmitToolResult(
+                    call_id=call_id,
+                    output=self._tool_outputs[call_id],
+                )
+                for call_id in self._pending_tool_calls
+            ),
+            rt.StartResponse(),
         )
+        await self._session.send(commands)
+        self._pending_tool_calls.clear()
+        self._tool_outputs.clear()
+        self._response_finished = False
 
     async def add_context(self, item_id: str, text: str) -> None:
         await self._session.send(
@@ -138,7 +174,8 @@ class TalkRealtimeSession(RealtimeSession):
         )
 
     async def cancel_response(self) -> None:
-        await self._session.send((rt.CancelResponse(),))
+        if self._response_active:
+            await self._session.send((rt.CancelResponse(),))
 
     async def close(self) -> None:
         if self._closed:
@@ -234,28 +271,19 @@ class TalkOpenAIRealtimeProvider(_TalkRealtimeProvider):
         )
 
 
-def _grok_auth() -> talk_auth.TalkAuth:
-    scoped = bool((os.environ.get("TALK_XAI_API_KEY") or "").strip())
-    return talk_auth.TalkAuth(
-        token=talk_config.resolve_xai_key(),
-        source=talk_auth.SOURCE_CONFIGURED if scoped else talk_auth.SOURCE_ENV,
-        detail="TALK_XAI_API_KEY" if scoped else "XAI_API_KEY",
-    )
-
-
 class TalkGrokRealtimeProvider(_TalkRealtimeProvider):
     """Plugin-owned xAI Grok duplex transport for the Hermes #95147 seam."""
 
     def __init__(
         self,
         *,
-        auth_resolver: Callable[[], Any] = _grok_auth,
+        auth_resolver: Callable[[], Any] | None = None,
         session_factory: Callable[..., Any] = GrokRealtimeSession,
     ) -> None:
         super().__init__(
             name=GROK_PROVIDER_NAME,
             display_name="Hermes Talk Grok Realtime",
-            auth_resolver=auth_resolver,
+            auth_resolver=auth_resolver or talk_grok_auth.resolve_grok_auth,
             session_factory=session_factory,
             model_resolver=talk_config.talk_grok_model,
             voice_resolver=talk_config.talk_grok_voice,

--- a/talk_gemini_auth.py
+++ b/talk_gemini_auth.py
@@ -1,0 +1,32 @@
+"""Resolve Gemini Live credentials into Talk's provider-neutral auth shape."""
+
+from __future__ import annotations
+
+import os
+
+try:
+    from . import talk_auth, talk_config
+except ImportError:  # pragma: no cover - flat-module fallback
+    import talk_auth
+    import talk_config
+
+
+def resolve_gemini_auth() -> talk_auth.TalkAuth:
+    """Return the configured Gemini key without exposing it in receipts."""
+
+    scoped = (os.environ.get("TALK_GEMINI_API_KEY") or "").strip()
+    token = talk_config.resolve_gemini_key()
+    if scoped:
+        return talk_auth.TalkAuth(
+            token=token,
+            source=talk_auth.SOURCE_CONFIGURED,
+            detail="TALK_GEMINI_API_KEY (Talk-scoped key)",
+        )
+    return talk_auth.TalkAuth(
+        token=token,
+        source=talk_auth.SOURCE_ENV,
+        detail="GEMINI_API_KEY environment variable",
+    )
+
+
+__all__ = ["resolve_gemini_auth"]

--- a/talk_transcript.py
+++ b/talk_transcript.py
@@ -456,8 +456,9 @@ def _sweep_transcripts(
             if lease is None:
                 continue
             transcript_fd = _open_verified_regular(source)
+            original_name = source.name.split(".claimed-", 1)[0]
             claimed = source.with_name(
-                f"{source.name}.claimed-{os.getpid()}-{uuid.uuid4().hex}"
+                f"{original_name}.claimed-{os.getpid()}-{uuid.uuid4().hex}"
             )
             # Only one lease holder may claim this identity. The post-rename
             # lstat comparison catches a path swap injected after validation.

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -51,6 +51,16 @@ def test_input_chunks_round_trip():
 def _pcm16(amplitude: int, frames: int = 32) -> bytes:
     return struct.pack(f"<{frames}h", *([amplitude] * frames))
 
+class _SpeechDetector:
+    def __init__(self, speech: bool):
+        self.speech = speech
+        self.calls = 0
+
+    def is_speech(self, _frame: bytes, sample_rate: int) -> bool:
+        assert sample_rate == 8_000
+        self.calls += 1
+        return self.speech
+
 
 def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
     audio = talk_audio.DuplexAudio()
@@ -64,15 +74,30 @@ def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
 
 
 def test_voice_above_omp_barge_in_threshold_interrupts_playback():
-    audio = talk_audio.DuplexAudio()
-    playback = _pcm16(20_000)
+    detector = _SpeechDetector(True)
+    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
-    audio._output_callback(_Buffer(len(playback)), 32, None, None)
-    barge_in = _pcm16(30_000)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+    barge_in = _pcm16(30_000, 2_400)
 
-    audio._input_callback(barge_in, 32, None, None)
+    audio._input_callback(barge_in, 2_400, None, None)
 
     assert audio.read_input_chunk() == barge_in
+    assert detector.calls > 0
+
+
+def test_loud_room_noise_does_not_interrupt_playback():
+    detector = _SpeechDetector(False)
+    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    playback = _pcm16(20_000, 2_400)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+
+    audio._input_callback(_pcm16(30_000, 2_400), 2_400, None, None)
+
+    assert detector.calls > 0
+    assert audio.read_input_chunk() is None
 
 
 def test_microphone_audio_passes_when_playback_is_silent():

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -374,6 +374,20 @@ def test_full_playback_queue_drops_instead_of_blocking():
     assert audio._playback.qsize() == talk_audio.MAX_PLAYBACK_BLOCKS
 
 
+def test_playback_queue_is_bounded_by_bytes_not_only_packet_count():
+    audio = talk_audio.DuplexAudio()
+
+    audio.queue_playback(b"\x00" * (talk_audio.MAX_PLAYBACK_BYTES + 2))
+
+    assert audio._playback.qsize() == 0
+    assert audio._queued_playback_bytes == 0
+    audio.queue_playback(b"\x01\x02\x03\x04")
+    audio._output_callback(_Buffer(2), 1, None, None)
+    assert audio._queued_playback_bytes == 2
+    audio.drain_playback()
+    assert audio._queued_playback_bytes == 0
+
+
 def test_stop_is_safe_before_start_and_twice():
     audio = talk_audio.DuplexAudio()
     audio.stop()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -32,6 +32,16 @@ def test_lazy_import_failure_names_the_extra(monkeypatch):
         talk_audio.import_sounddevice()
     assert talk_audio.audio_available() is False
 
+def test_audio_is_unavailable_without_webrtc_vad(monkeypatch):
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: object())
+    monkeypatch.setattr(
+        talk_audio,
+        "import_webrtcvad",
+        lambda: (_ for _ in ()).throw(talk_audio.TalkAudioError("missing VAD")),
+    )
+
+    assert talk_audio.audio_available() is False
+
 
 def test_device_override_parses_index_or_name():
     assert talk_audio._device(None) is None
@@ -104,6 +114,41 @@ def test_linux_default_audio_uses_pulse_webrtc_echo_cancellation(monkeypatch):
     audio.stop()
 
     assert commands[-1] == ["/usr/bin/pactl", "unload-module", "42"]
+
+def test_pulse_device_open_failure_retries_original_devices(monkeypatch):
+    class FailingPulseSoundDevice(_SoundDevice):
+        def RawInputStream(self, **kwargs):
+            if kwargs["device"] == "pulse":
+                raise RuntimeError("Pulse route is unavailable")
+            return super().RawInputStream(**kwargs)
+
+    sd = FailingPulseSoundDevice()
+    commands = []
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
+    monkeypatch.setattr(
+        talk_audio,
+        "import_webrtcvad",
+        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
+    )
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda _command: "/usr/bin/pactl")
+    monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
+    monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: None)
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        return _CompletedProcess("42\n")
+
+    monkeypatch.setattr(talk_audio.subprocess, "run", run)
+    audio = talk_audio.DuplexAudio()
+
+    audio.start()
+
+    assert sd.input_stream.kwargs["device"] is None
+    assert sd.output_stream.kwargs["device"] is None
+    assert commands[-1] == ["/usr/bin/pactl", "unload-module", "42"]
+    assert audio._pulse_webrtc.active is False
+    audio.stop()
 
 
 def test_pulse_echo_cancelled_input_is_never_amplitude_gated(monkeypatch):
@@ -184,14 +229,28 @@ class _SpeechDetector:
 
 
 def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
-    audio = talk_audio.DuplexAudio()
-    playback = _pcm16(20_000)
+    detector = _SpeechDetector(False)
+    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
-    audio._output_callback(_Buffer(len(playback)), 32, None, None)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
 
-    audio._input_callback(_pcm16(5_000), 32, None, None)
+    audio._input_callback(_pcm16(5_000, 2_400), 2_400, None, None)
 
     assert audio.read_input_chunk() is None
+
+def test_webrtc_speech_overrides_fallback_echo_amplitude_gate():
+    detector = _SpeechDetector(True)
+    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    playback = _pcm16(20_000, 2_400)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+    moderate_speech = _pcm16(5_000, 2_400)
+
+    audio._input_callback(moderate_speech, 2_400, None, None)
+
+    assert detector.calls > 0
+    assert audio.read_input_chunk() == moderate_speech
 
 
 def test_voice_above_omp_barge_in_threshold_interrupts_playback():
@@ -310,3 +369,57 @@ def test_stop_is_safe_before_start_and_twice():
     audio = talk_audio.DuplexAudio()
     audio.stop()
     audio.stop()
+
+
+def test_pulse_stop_preserves_environment_when_never_started_or_load_failed(monkeypatch):
+    monkeypatch.setenv("PULSE_SOURCE", "external-source")
+    monkeypatch.setenv("PULSE_SINK", "external-sink")
+    route = talk_audio._PulseWebRtcAudio()
+    route.stop()
+    route.stop()
+    assert talk_audio.os.environ["PULSE_SOURCE"] == "external-source"
+    assert talk_audio.os.environ["PULSE_SINK"] == "external-sink"
+
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda _command: "/usr/bin/pactl")
+    monkeypatch.setattr(
+        talk_audio.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("load failed")),
+    )
+    assert route.start(None, None) == (None, None)
+    route.stop()
+    assert talk_audio.os.environ["PULSE_SOURCE"] == "external-source"
+    assert talk_audio.os.environ["PULSE_SINK"] == "external-sink"
+
+
+@pytest.mark.parametrize("stop_order", [(0, 1), (1, 0)])
+def test_concurrent_pulse_routes_restore_environment_in_either_order(
+    monkeypatch, stop_order
+):
+    monkeypatch.setenv("PULSE_SOURCE", "original-source")
+    monkeypatch.setenv("PULSE_SINK", "original-sink")
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda _command: "/usr/bin/pactl")
+    module_ids = iter(("41\n", "42\n"))
+    monkeypatch.setattr(
+        talk_audio.subprocess,
+        "run",
+        lambda command, **_kwargs: _CompletedProcess(next(module_ids))
+        if command[1] == "load-module"
+        else _CompletedProcess(""),
+    )
+    routes = [talk_audio._PulseWebRtcAudio(), talk_audio._PulseWebRtcAudio()]
+    routes[0].start(None, None)
+    first_source = routes[0]._source_name
+    routes[1].start(None, None)
+    second_source = routes[1]._source_name
+    assert first_source != second_source
+
+    routes[stop_order[0]].stop()
+    survivor = routes[stop_order[1]]
+    assert talk_audio.os.environ["PULSE_SOURCE"] == survivor._source_name
+    routes[stop_order[1]].stop()
+
+    assert talk_audio.os.environ["PULSE_SOURCE"] == "original-source"
+    assert talk_audio.os.environ["PULSE_SINK"] == "original-sink"

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -295,12 +295,21 @@ def test_microphone_audio_passes_when_playback_is_silent():
     assert audio.read_input_chunk() == microphone
 
 
-def test_full_input_queue_drops_instead_of_blocking():
+def test_full_input_queue_keeps_newest_audio_without_blocking():
     audio = talk_audio.DuplexAudio()
-    for _ in range(talk_audio.MAX_INPUT_BLOCKS + 10):
+    oldest = b"\x01\x00"
+    newest = b"\x02\x00"
+    audio._input_callback(oldest, 1, None, None)
+    for _ in range(talk_audio.MAX_INPUT_BLOCKS - 1):
         audio._input_callback(b"\x00\x00", 1, None, None)
 
+    audio._input_callback(newest, 1, None, None)
+
     assert audio._input.qsize() == talk_audio.MAX_INPUT_BLOCKS
+    assert audio.read_input_chunk() != oldest
+    queued = [audio.read_input_chunk() for _ in range(talk_audio.MAX_INPUT_BLOCKS - 1)]
+    assert queued[-1] == newest
+    assert audio.dropped_input_blocks == 1
 
 
 def test_playback_spans_queue_chunk_boundaries():
@@ -386,6 +395,7 @@ def test_playback_queue_is_bounded_by_bytes_not_only_packet_count():
     assert audio._queued_playback_bytes == 2
     audio.drain_playback()
     assert audio._queued_playback_bytes == 0
+    assert audio.dropped_playback_bytes == talk_audio.MAX_PLAYBACK_BYTES + 2
 
 
 def test_stop_is_safe_before_start_and_twice():

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -39,6 +39,127 @@ def test_device_override_parses_index_or_name():
     assert talk_audio._device("Speakers (Realtek)") == "Speakers (Realtek)"
 
 
+class _Stream:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class _SoundDevice:
+    def __init__(self):
+        self.input_stream = None
+        self.output_stream = None
+
+    def RawInputStream(self, **kwargs):
+        self.input_stream = _Stream(**kwargs)
+        return self.input_stream
+
+    def RawOutputStream(self, **kwargs):
+        self.output_stream = _Stream(**kwargs)
+        return self.output_stream
+
+
+class _CompletedProcess:
+    def __init__(self, stdout: str):
+        self.stdout = stdout
+
+
+def test_linux_default_audio_uses_pulse_webrtc_echo_cancellation(monkeypatch):
+    sd = _SoundDevice()
+    commands = []
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
+    monkeypatch.setattr(
+        talk_audio,
+        "import_webrtcvad",
+        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
+    )
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda command: f"/usr/bin/{command}")
+    monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
+    monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: None)
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        return _CompletedProcess("42\n")
+
+    monkeypatch.setattr(talk_audio.subprocess, "run", run)
+    audio = talk_audio.DuplexAudio()
+
+    audio.start()
+
+    assert commands[0][1:3] == ["load-module", "module-echo-cancel"]
+    assert sd.input_stream.kwargs["device"] == "pulse"
+    assert sd.output_stream.kwargs["device"] == "pulse"
+    assert talk_audio.os.environ["PULSE_SOURCE"].startswith("hermes_talk_aec_")
+    assert talk_audio.os.environ["PULSE_SINK"].startswith("hermes_talk_aec_sink_")
+
+    audio.stop()
+
+    assert commands[-1] == ["/usr/bin/pactl", "unload-module", "42"]
+
+
+def test_pulse_echo_cancelled_input_is_never_amplitude_gated(monkeypatch):
+    sd = _SoundDevice()
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
+    monkeypatch.setattr(
+        talk_audio,
+        "import_webrtcvad",
+        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(False)}),
+    )
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda command: f"/usr/bin/{command}")
+    monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
+    monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: None)
+    monkeypatch.setattr(
+        talk_audio.subprocess,
+        "run",
+        lambda *_args, **_kwargs: _CompletedProcess("42\n"),
+    )
+    audio = talk_audio.DuplexAudio()
+    audio.start()
+    playback = _pcm16(20_000, 2_400)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+    quiet_speech = _pcm16(2_000, 2_400)
+
+    audio._input_callback(quiet_speech, 2_400, None, None)
+
+    assert audio.read_input_chunk() == quiet_speech
+    audio.stop()
+
+
+def test_explicit_devices_skip_pulse_echo_module(monkeypatch):
+    sd = _SoundDevice()
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
+    monkeypatch.setattr(
+        talk_audio,
+        "import_webrtcvad",
+        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
+    )
+    monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: "microphone")
+    monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: "speaker")
+    monkeypatch.setattr(
+        talk_audio.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("explicit devices must not load a PulseAudio module"),
+    )
+    audio = talk_audio.DuplexAudio()
+
+    audio.start()
+
+    assert sd.input_stream.kwargs["device"] == "microphone"
+    assert sd.output_stream.kwargs["device"] == "speaker"
+    audio.stop()
+
+
 def test_input_chunks_round_trip():
     audio = talk_audio.DuplexAudio()
     assert audio.read_input_chunk() is None

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import struct
 import sys
+import threading
+import time
 
 import pytest
 
@@ -32,15 +34,10 @@ def test_lazy_import_failure_names_the_extra(monkeypatch):
         talk_audio.import_sounddevice()
     assert talk_audio.audio_available() is False
 
-def test_audio_is_unavailable_without_webrtc_vad(monkeypatch):
+def test_audio_availability_only_requires_sounddevice(monkeypatch):
     monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: object())
-    monkeypatch.setattr(
-        talk_audio,
-        "import_webrtcvad",
-        lambda: (_ for _ in ()).throw(talk_audio.TalkAudioError("missing VAD")),
-    )
 
-    assert talk_audio.audio_available() is False
+    assert talk_audio.audio_available() is True
 
 
 def test_device_override_parses_index_or_name():
@@ -86,11 +83,6 @@ def test_linux_default_audio_uses_pulse_webrtc_echo_cancellation(monkeypatch):
     sd = _SoundDevice()
     commands = []
     monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
-    monkeypatch.setattr(
-        talk_audio,
-        "import_webrtcvad",
-        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
-    )
     monkeypatch.setattr(talk_audio.sys, "platform", "linux")
     monkeypatch.setattr(talk_audio.shutil, "which", lambda command: f"/usr/bin/{command}")
     monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
@@ -125,11 +117,6 @@ def test_pulse_device_open_failure_retries_original_devices(monkeypatch):
     sd = FailingPulseSoundDevice()
     commands = []
     monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
-    monkeypatch.setattr(
-        talk_audio,
-        "import_webrtcvad",
-        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
-    )
     monkeypatch.setattr(talk_audio.sys, "platform", "linux")
     monkeypatch.setattr(talk_audio.shutil, "which", lambda _command: "/usr/bin/pactl")
     monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
@@ -154,11 +141,6 @@ def test_pulse_device_open_failure_retries_original_devices(monkeypatch):
 def test_pulse_echo_cancelled_input_is_never_amplitude_gated(monkeypatch):
     sd = _SoundDevice()
     monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
-    monkeypatch.setattr(
-        talk_audio,
-        "import_webrtcvad",
-        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(False)}),
-    )
     monkeypatch.setattr(talk_audio.sys, "platform", "linux")
     monkeypatch.setattr(talk_audio.shutil, "which", lambda command: f"/usr/bin/{command}")
     monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
@@ -184,11 +166,6 @@ def test_pulse_echo_cancelled_input_is_never_amplitude_gated(monkeypatch):
 def test_explicit_devices_skip_pulse_echo_module(monkeypatch):
     sd = _SoundDevice()
     monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: sd)
-    monkeypatch.setattr(
-        talk_audio,
-        "import_webrtcvad",
-        lambda: type("V", (), {"Vad": lambda *_: _SpeechDetector(True)}),
-    )
     monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: "microphone")
     monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: "speaker")
     monkeypatch.setattr(
@@ -205,6 +182,48 @@ def test_explicit_devices_skip_pulse_echo_module(monkeypatch):
     audio.stop()
 
 
+def test_audio_start_serializes_pulse_environment_through_stream_open(monkeypatch):
+    monkeypatch.setattr(talk_audio, "import_sounddevice", lambda: object())
+    monkeypatch.setattr(talk_audio.sys, "platform", "linux")
+    monkeypatch.setattr(talk_audio.shutil, "which", lambda _command: "/usr/bin/pactl")
+    monkeypatch.setattr(talk_audio.talk_config, "audio_input_device", lambda: None)
+    monkeypatch.setattr(talk_audio.talk_config, "audio_output_device", lambda: None)
+    module_ids = iter(("41", "42"))
+    monkeypatch.setattr(
+        talk_audio.subprocess,
+        "run",
+        lambda command, **_kwargs: _CompletedProcess(next(module_ids))
+        if command[1] == "load-module"
+        else _CompletedProcess(""),
+    )
+    active_opens = 0
+    maximum_active_opens = 0
+    lock = threading.Lock()
+
+    def open_streams(audio, _sd, _input_device, _output_device):
+        nonlocal active_opens, maximum_active_opens
+        with lock:
+            active_opens += 1
+            maximum_active_opens = max(maximum_active_opens, active_opens)
+            assert talk_audio.os.environ["PULSE_SOURCE"] == audio._pulse_webrtc._source_name
+        time.sleep(0.02)
+        with lock:
+            active_opens -= 1
+
+    monkeypatch.setattr(talk_audio.DuplexAudio, "_open_streams", open_streams)
+    sessions = [talk_audio.DuplexAudio(), talk_audio.DuplexAudio()]
+    workers = [threading.Thread(target=session.start) for session in sessions]
+
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    assert maximum_active_opens == 1
+    for session in sessions:
+        session.stop()
+
+
 def test_input_chunks_round_trip():
     audio = talk_audio.DuplexAudio()
     assert audio.read_input_chunk() is None
@@ -217,20 +236,10 @@ def test_input_chunks_round_trip():
 def _pcm16(amplitude: int, frames: int = 32) -> bytes:
     return struct.pack(f"<{frames}h", *([amplitude] * frames))
 
-class _SpeechDetector:
-    def __init__(self, speech: bool):
-        self.speech = speech
-        self.calls = 0
-
-    def is_speech(self, _frame: bytes, sample_rate: int) -> bool:
-        assert sample_rate == 8_000
-        self.calls += 1
-        return self.speech
 
 
 def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
-    detector = _SpeechDetector(False)
-    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    audio = talk_audio.DuplexAudio()
     playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
     audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
@@ -239,9 +248,8 @@ def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
 
     assert audio.read_input_chunk() is None
 
-def test_webrtc_speech_overrides_fallback_echo_amplitude_gate():
-    detector = _SpeechDetector(True)
-    audio = talk_audio.DuplexAudio(speech_detector=detector)
+def test_fallback_gate_does_not_allow_vad_to_override_omp_threshold():
+    audio = talk_audio.DuplexAudio()
     playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
     audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
@@ -249,13 +257,11 @@ def test_webrtc_speech_overrides_fallback_echo_amplitude_gate():
 
     audio._input_callback(moderate_speech, 2_400, None, None)
 
-    assert detector.calls > 0
-    assert audio.read_input_chunk() == moderate_speech
+    assert audio.read_input_chunk() is None
 
 
 def test_voice_above_omp_barge_in_threshold_interrupts_playback():
-    detector = _SpeechDetector(True)
-    audio = talk_audio.DuplexAudio(speech_detector=detector)
+    audio = talk_audio.DuplexAudio()
     playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
     audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
@@ -264,20 +270,18 @@ def test_voice_above_omp_barge_in_threshold_interrupts_playback():
     audio._input_callback(barge_in, 2_400, None, None)
 
     assert audio.read_input_chunk() == barge_in
-    assert detector.calls > 0
 
 
-def test_loud_room_noise_does_not_interrupt_playback():
-    detector = _SpeechDetector(False)
-    audio = talk_audio.DuplexAudio(speech_detector=detector)
+def test_loud_input_above_omp_threshold_is_uploaded():
+    audio = talk_audio.DuplexAudio()
     playback = _pcm16(20_000, 2_400)
     audio.queue_playback(playback)
     audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+    loud_input = _pcm16(30_000, 2_400)
 
-    audio._input_callback(_pcm16(30_000, 2_400), 2_400, None, None)
+    audio._input_callback(loud_input, 2_400, None, None)
 
-    assert detector.calls > 0
-    assert audio.read_input_chunk() is None
+    assert audio.read_input_chunk() == loud_input
 
 
 def test_microphone_audio_passes_when_playback_is_silent():
@@ -336,19 +340,24 @@ def test_drain_playback_discards_queue_and_residual():
     assert bytes(out.data) == b"\x00\x00\x00\x00"
 
 
-def test_played_ms_survives_a_drain_until_reset():
+def test_drain_returns_and_resets_the_atomic_heard_boundary():
     audio = talk_audio.DuplexAudio()
-    audio.queue_playback(b"\x00\x00" * 2_400)
+    audio.queue_playback(b"\x00\x00" * 2_400, item_id="item-1")
     audio._output_callback(_Buffer(4_800), 2_400, None, None)
 
     assert audio.played_ms == 100
-    # The truncate has to be measured AFTER the drain, so the counter cannot
-    # be cleared by the drain itself.
-    audio.drain_playback()
-    assert audio.played_ms == 100
-
-    audio.reset_played_ms()
+    assert audio.drain_playback() == ("item-1", 100)
     assert audio.played_ms == 0
+
+
+def test_callback_crossing_items_attributes_boundary_to_new_item():
+    audio = talk_audio.DuplexAudio()
+    audio.queue_playback(b"\x01\x00" * 2_400, item_id="old")
+    audio.queue_playback(b"\x02\x00" * 1_200, item_id="new")
+
+    audio._output_callback(_Buffer(7_200), 3_600, None, None)
+
+    assert audio.drain_playback() == ("new", 50)
 
 
 def test_empty_playback_is_ignored():

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -7,6 +7,7 @@ real device is a canary step, not a CI step.
 
 from __future__ import annotations
 
+import struct
 import sys
 
 import pytest
@@ -46,6 +47,43 @@ def test_input_chunks_round_trip():
 
     assert audio.read_input_chunk() == b"\x01\x02"
     assert audio.read_input_chunk() is None
+
+def _pcm16(amplitude: int, frames: int = 32) -> bytes:
+    return struct.pack(f"<{frames}h", *([amplitude] * frames))
+
+
+def test_playback_echo_below_omp_barge_in_threshold_is_not_uploaded():
+    audio = talk_audio.DuplexAudio()
+    playback = _pcm16(20_000)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 32, None, None)
+
+    audio._input_callback(_pcm16(5_000), 32, None, None)
+
+    assert audio.read_input_chunk() is None
+
+
+def test_voice_above_omp_barge_in_threshold_interrupts_playback():
+    audio = talk_audio.DuplexAudio()
+    playback = _pcm16(20_000)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 32, None, None)
+    barge_in = _pcm16(30_000)
+
+    audio._input_callback(barge_in, 32, None, None)
+
+    assert audio.read_input_chunk() == barge_in
+
+
+def test_microphone_audio_passes_when_playback_is_silent():
+    audio = talk_audio.DuplexAudio()
+    silence = _Buffer(64)
+    audio._output_callback(silence, 32, None, None)
+    microphone = _pcm16(2_000)
+
+    audio._input_callback(microphone, 32, None, None)
+
+    assert audio.read_input_chunk() == microphone
 
 
 def test_full_input_queue_drops_instead_of_blocking():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ import pytest
 import talk_audio
 import talk_capabilities
 import talk_cli
+import talk_core_realtime
 import talk_host
 import talk_identity
 import talk_operator_auth
@@ -1542,6 +1543,32 @@ def test_keyboard_interrupt_hangs_up_cleanly(monkeypatch, capsys):
 
     assert talk_cli.cli_entry() == 0
     assert "hung up" in capsys.readouterr().out
+
+
+def test_standalone_cli_keeps_mature_talk_runner_when_core_is_available(
+    monkeypatch
+):
+    called = []
+
+    async def mature_runner():
+        called.append("mature")
+        return 0
+
+    monkeypatch.delenv("HERMES_TALK_EVENT_STREAM", raising=False)
+    monkeypatch.setattr(talk_cli, "run_talk_session", mature_runner)
+    monkeypatch.setattr(
+        talk_core_realtime,
+        "coordinator_contract_available",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        talk_core_realtime,
+        "configured_core_provider_supported",
+        lambda: True,
+    )
+
+    assert talk_cli.cli_entry() == 0
+    assert called == ["mature"]
 
 
 def test_setup_cli_adds_no_required_arguments():

--- a/tests/test_core_cli.py
+++ b/tests/test_core_cli.py
@@ -169,6 +169,10 @@ def test_tui_event_stream_delegates_to_text_agent_and_frames_transcripts(
                 type=RealtimeEventType.WARNING,
                 text="provider recovered from one malformed frame",
             )
+            yield RealtimeEvent(
+                type=RealtimeEventType.TURN_ENDED,
+                role="user",
+            )
             self.result = await self.dispatch_tool(
                 "client_delegate",
                 {"request": SUM_REQUEST},
@@ -259,6 +263,12 @@ def test_tui_event_stream_delegates_to_text_agent_and_frames_transcripts(
     }
     assert {frame["surface_session_id"] for frame in frames} == {"call-1"}
     assert [frame["sequence"] for frame in frames] == list(range(1, len(frames) + 1))
+    metrics = [frame for frame in frames if frame["type"] == "metric"]
+    assert [metric["name"] for metric in metrics] == [
+        "session_ready_ms",
+        "endpoint_to_first_audio_ms",
+    ]
+    assert all(metric["value_ms"] >= 0 for metric in metrics)
     assert "talk: connected (realtime-test, voice cedar)" in output
     assert output.count("talk: state composing") == 1
     assert talk_core_cli.sys.stdin.closed is True
@@ -373,3 +383,50 @@ def test_startup_cancellation_still_closes_every_owned_resource(monkeypatch):
     assert audio.stopped is True
     assert capture.finished is True
     assert FakeCoordinator.instance.closed is True
+
+
+def test_core_barge_in_uses_atomic_boundary_for_latest_played_item(
+    monkeypatch, capsys
+):
+    class BoundaryCoordinator(FakeCoordinator):
+        async def events(self):
+            yield RealtimeEvent.audio(b"old", item_id="old-item")
+            yield RealtimeEvent.audio(b"new", item_id="new-item")
+            yield RealtimeEvent(type=RealtimeEventType.TURN_STARTED, role="user")
+
+    class OpenParent:
+        async def wait_for_parent_close(self, _delegation_idle):
+            await asyncio.Event().wait()
+
+        def close(self):
+            pass
+
+    audio = FakeAudio()
+    audio.played_boundary = ("new-item", 75)
+    capture = FakeCapture(None)
+    configure_event_stream(monkeypatch, capture, BoundaryCoordinator)
+    monkeypatch.setattr(talk_core_cli, "_StdinLineReader", OpenParent)
+
+    assert asyncio.run(talk_core_cli.run_core_talk_session(audio)) == 1
+    output = capsys.readouterr().out
+    frames = [
+        json.loads(line.removeprefix(talk_core_cli.EVENT_PREFIX))
+        for line in output.splitlines()
+        if line.startswith(talk_core_cli.EVENT_PREFIX)
+    ]
+    interruption_metrics = [
+        frame
+        for frame in frames
+        if frame.get("name") == "interruption_to_local_silence_ms"
+    ]
+    assert len(interruption_metrics) == 1
+    assert interruption_metrics[0]["value_ms"] >= 0
+
+    coordinator = FakeCoordinator.instance
+    assert audio.queued == [
+        ("old-item", b"old"),
+        ("new-item", b"new"),
+    ]
+    assert len(coordinator.heard) == 1
+    assert coordinator.heard[0][0].item_id == "new-item"
+    assert coordinator.heard[0][1] == 75

--- a/tests/test_core_cli.py
+++ b/tests/test_core_cli.py
@@ -105,56 +105,46 @@ class FakeCoordinator:
         self.closed = True
 
 
-def test_terminal_runtime_composes_audio_provider_and_hermes_authority(monkeypatch):
-    audio = FakeAudio()
-    capture = FakeCapture(None)
-    ctx = FakeContext()
-    provider = object()
-    monkeypatch.setattr(talk_core_cli, "get_provider", lambda _name: provider)
-    monkeypatch.setattr(talk_core_cli, "RealtimeVoiceCoordinator", FakeCoordinator)
-    monkeypatch.setattr(talk_core_cli.talk_host, "get_ctx", lambda: ctx)
+def configure_event_stream(monkeypatch, capture, coordinator=FakeCoordinator):
+    monkeypatch.setenv(talk_core_cli.EVENT_STREAM_ENV, "jsonl")
+    monkeypatch.setattr(talk_core_cli, "get_provider", lambda _name: object())
+    monkeypatch.setattr(talk_core_cli, "RealtimeVoiceCoordinator", coordinator)
     monkeypatch.setattr(
-        talk_core_cli.talk_host.host(),
-        "identity_sections",
-        lambda: {},
-    )
-    monkeypatch.setattr(
-        talk_core_cli,
-        "get_tool_definitions",
-        lambda **_kwargs: [{"name": "weather"}],
+        talk_core_cli.talk_host.host(), "identity_sections", lambda: {}
     )
     monkeypatch.setattr(
         talk_core_cli.talk_identity,
         "build_instructions",
-        lambda *_args, **_kwargs: "rules",
+        lambda *_args, **_kwargs: "identity rules",
     )
-    monkeypatch.setattr(talk_core_cli.talk_config, "talk_model", lambda: "realtime-test")
+    monkeypatch.setattr(
+        talk_core_cli.talk_config, "talk_model", lambda: "realtime-test"
+    )
     monkeypatch.setattr(talk_core_cli.talk_config, "talk_voice", lambda: "cedar")
-    monkeypatch.setattr(talk_core_cli.talk_config, "get_hermes_home", lambda: "/tmp/hermes")
-    monkeypatch.setattr(talk_core_cli.talk_transcript, "TranscriptCapture", lambda _home: capture)
-    monkeypatch.setattr(talk_core_cli.talk_transcript, "sweep_transcripts", lambda _home: None)
+    monkeypatch.setattr(
+        talk_core_cli.talk_config, "get_hermes_home", lambda: "/tmp/hermes"
+    )
+    monkeypatch.setattr(
+        talk_core_cli.talk_transcript,
+        "TranscriptCapture",
+        lambda _home: capture,
+    )
+    monkeypatch.setattr(
+        talk_core_cli.talk_transcript, "sweep_transcripts", lambda _home: None
+    )
+
+def test_core_runner_rejects_standalone_mode_before_starting_audio(
+    monkeypatch, capsys
+):
+    audio = FakeAudio()
+    monkeypatch.delenv(talk_core_cli.EVENT_STREAM_ENV, raising=False)
 
     result = asyncio.run(talk_core_cli.run_core_talk_session(audio))
 
-    coordinator = FakeCoordinator.instance
-    assert result == 0
-    assert audio.started is True
-    assert audio.stopped is True
-    assert audio.queued == [b"speaker"]
-    assert audio.drained == 1
-    assert coordinator.provider is provider
-    assert coordinator.opened == {
-        "instructions": "rules",
-        "tools": [{"name": "weather"}],
-        "voice": "cedar",
-    }
-    assert coordinator.heard[0][1] == 360
-    assert coordinator.cancelled == 1
-    assert coordinator.max_in_flight_tool_calls == 16
-    assert coordinator.closed is True
-    assert ctx.calls == [("weather", {"city": "Paris"})]
-    assert capture.turns == [("user", "hello")]
-    assert capture.finished is True
+    assert result == 1
+    assert audio.started is False
+    assert audio.stopped is False
+    assert "reserved for the Hermes TUI" in capsys.readouterr().err
 
 
 def test_tui_event_stream_delegates_to_text_agent_and_frames_transcripts(
@@ -223,7 +213,7 @@ def test_tui_event_stream_delegates_to_text_agent_and_frames_transcripts(
 
     output = capsys.readouterr().out
     coordinator = FakeCoordinator.instance
-    assert result == 0
+    assert result == 1
     assert coordinator.max_in_flight_tool_calls == 1
     assert coordinator.contexts == [
         (
@@ -258,3 +248,58 @@ def test_progress_item_ids_stay_within_provider_wire_limit():
     assert first == f"p1-{request_id}"[:32]
     assert len(first) == talk_core_cli.MAX_PROVIDER_ITEM_ID_LENGTH
     assert first != second
+
+
+def test_stdin_reader_consumes_prefetched_lines_without_deadlock():
+    async def scenario():
+        reader = talk_core_cli._StdinLineReader(io.StringIO("progress\nresult\n"))
+        try:
+            return (
+                await asyncio.wait_for(reader.readline(), timeout=0.1),
+                await asyncio.wait_for(reader.readline(), timeout=0.1),
+            )
+        finally:
+            reader.close()
+
+    assert asyncio.run(scenario()) == ("progress", "result")
+
+
+def test_parent_stdin_eof_stops_an_idle_session(monkeypatch, capsys):
+    class IdleCoordinator(FakeCoordinator):
+        async def events(self):
+            await asyncio.Event().wait()
+            if False:  # pragma: no cover - make this an async iterator
+                yield None
+
+    audio = FakeAudio()
+    capture = FakeCapture(None)
+    configure_event_stream(monkeypatch, capture, IdleCoordinator)
+    monkeypatch.setattr(talk_core_cli.sys, "stdin", io.StringIO(""))
+
+    result = asyncio.run(talk_core_cli.run_core_talk_session(audio))
+
+    assert result == 1
+    assert "closed the live delegation channel" in capsys.readouterr().out
+    assert audio.stopped is True
+    assert capture.finished is True
+    assert FakeCoordinator.instance.closed is True
+
+
+def test_startup_cancellation_still_closes_every_owned_resource(monkeypatch):
+    class CancelledOpenCoordinator(FakeCoordinator):
+        async def open(self, **kwargs):
+            self.opened = kwargs
+            raise asyncio.CancelledError
+
+    audio = FakeAudio()
+    capture = FakeCapture(None)
+    configure_event_stream(monkeypatch, capture, CancelledOpenCoordinator)
+    monkeypatch.setattr(talk_core_cli.sys, "stdin", io.StringIO(""))
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(talk_core_cli.run_core_talk_session(audio))
+
+    assert audio.started is True
+    assert audio.stopped is True
+    assert capture.finished is True
+    assert FakeCoordinator.instance.closed is True

--- a/tests/test_core_cli.py
+++ b/tests/test_core_cli.py
@@ -1,0 +1,258 @@
+"""Terminal runtime composition through Hermes's realtime coordinator."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+
+import pytest
+
+pytest.importorskip("agent.realtime_voice", reason="Hermes #95147 contract is optional")
+from agent.realtime_voice import RealtimeEvent, RealtimeEventType
+
+import talk_core_cli
+
+SUM_REQUEST = "Write a Python script that sums all numbers from 1 to 100 and run it."
+
+
+class FakeAudio:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+        self.queued = []
+        self.drained = 0
+        self.resets = 0
+        self.played_ms = 360
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+    def read_input_chunk(self):
+        return None
+
+    def queue_playback(self, pcm):
+        self.queued.append(pcm)
+
+    def drain_playback(self):
+        self.drained += 1
+
+    def reset_played_ms(self):
+        self.resets += 1
+
+
+class FakeCapture:
+    def __init__(self, _home):
+        self.turns = []
+        self.finished = False
+
+    def append_turn(self, role, text):
+        self.turns.append((role, text))
+
+    def finish(self):
+        self.finished = True
+
+
+class FakeContext:
+    def __init__(self):
+        self.calls = []
+
+    def dispatch_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        return "tool result"
+
+
+class FakeCoordinator:
+    instance = None
+
+    def __init__(self, provider, *, dispatch_tool, max_in_flight_tool_calls=16):
+        self.provider = provider
+        self.dispatch_tool = dispatch_tool
+        self.max_in_flight_tool_calls = max_in_flight_tool_calls
+        self.opened = None
+        self.contexts = []
+        self.heard = []
+        self.cancelled = 0
+        self.closed = False
+        FakeCoordinator.instance = self
+
+    async def open(self, **kwargs):
+        self.opened = kwargs
+
+    async def send_audio(self, _pcm):
+        pass
+
+    async def add_context(self, item_id, text):
+        self.contexts.append((item_id, text))
+
+    def report_audio_heard(self, event, *, audio_end_ms):
+        self.heard.append((event, audio_end_ms))
+        return True
+
+    async def cancel_response(self):
+        self.cancelled += 1
+
+    async def events(self):
+        await self.dispatch_tool("weather", {"city": "Paris"})
+        yield RealtimeEvent.audio(b"speaker", item_id="item-1")
+        yield RealtimeEvent.transcript("hello", final=True, role="user")
+        yield RealtimeEvent(type=RealtimeEventType.TURN_STARTED, role="user")
+
+    async def close(self):
+        self.closed = True
+
+
+def test_terminal_runtime_composes_audio_provider_and_hermes_authority(monkeypatch):
+    audio = FakeAudio()
+    capture = FakeCapture(None)
+    ctx = FakeContext()
+    provider = object()
+    monkeypatch.setattr(talk_core_cli, "get_provider", lambda _name: provider)
+    monkeypatch.setattr(talk_core_cli, "RealtimeVoiceCoordinator", FakeCoordinator)
+    monkeypatch.setattr(talk_core_cli.talk_host, "get_ctx", lambda: ctx)
+    monkeypatch.setattr(
+        talk_core_cli.talk_host.host(),
+        "identity_sections",
+        lambda: {},
+    )
+    monkeypatch.setattr(
+        talk_core_cli,
+        "get_tool_definitions",
+        lambda **_kwargs: [{"name": "weather"}],
+    )
+    monkeypatch.setattr(
+        talk_core_cli.talk_identity,
+        "build_instructions",
+        lambda *_args, **_kwargs: "rules",
+    )
+    monkeypatch.setattr(talk_core_cli.talk_config, "talk_model", lambda: "realtime-test")
+    monkeypatch.setattr(talk_core_cli.talk_config, "talk_voice", lambda: "cedar")
+    monkeypatch.setattr(talk_core_cli.talk_config, "get_hermes_home", lambda: "/tmp/hermes")
+    monkeypatch.setattr(talk_core_cli.talk_transcript, "TranscriptCapture", lambda _home: capture)
+    monkeypatch.setattr(talk_core_cli.talk_transcript, "sweep_transcripts", lambda _home: None)
+
+    result = asyncio.run(talk_core_cli.run_core_talk_session(audio))
+
+    coordinator = FakeCoordinator.instance
+    assert result == 0
+    assert audio.started is True
+    assert audio.stopped is True
+    assert audio.queued == [b"speaker"]
+    assert audio.drained == 1
+    assert coordinator.provider is provider
+    assert coordinator.opened == {
+        "instructions": "rules",
+        "tools": [{"name": "weather"}],
+        "voice": "cedar",
+    }
+    assert coordinator.heard[0][1] == 360
+    assert coordinator.cancelled == 1
+    assert coordinator.max_in_flight_tool_calls == 16
+    assert coordinator.closed is True
+    assert ctx.calls == [("weather", {"city": "Paris"})]
+    assert capture.turns == [("user", "hello")]
+    assert capture.finished is True
+
+
+def test_tui_event_stream_delegates_to_text_agent_and_frames_transcripts(
+    monkeypatch, capsys
+):
+    class BridgeCoordinator(FakeCoordinator):
+        async def add_context(self, item_id, text):
+            self.contexts.append((item_id, text))
+            raise RuntimeError("provider rejected optional progress context")
+
+        async def events(self):
+            self.result = await self.dispatch_tool(
+                "client_delegate",
+                {"request": SUM_REQUEST},
+            )
+            yield RealtimeEvent.transcript(
+                SUM_REQUEST,
+                final=True,
+                role="user",
+            )
+            yield RealtimeEvent.transcript(
+                "I found the issue.", final=True, role="assistant"
+            )
+
+    audio = FakeAudio()
+    capture = FakeCapture(None)
+    provider = object()
+    monkeypatch.setenv(talk_core_cli.EVENT_STREAM_ENV, "jsonl")
+    monkeypatch.setattr(talk_core_cli, "get_provider", lambda _name: provider)
+    monkeypatch.setattr(talk_core_cli, "RealtimeVoiceCoordinator", BridgeCoordinator)
+    monkeypatch.setattr(talk_core_cli.talk_host, "get_ctx", lambda: None)
+    monkeypatch.setattr(
+        talk_core_cli.talk_host.host(), "identity_sections", lambda: {}
+    )
+    monkeypatch.setattr(
+        talk_core_cli.talk_identity,
+        "build_instructions",
+        lambda *_args, **_kwargs: "identity rules",
+    )
+    monkeypatch.setattr(talk_core_cli.talk_config, "talk_model", lambda: "realtime-test")
+    monkeypatch.setattr(talk_core_cli.talk_config, "talk_voice", lambda: "cedar")
+    monkeypatch.setattr(
+        talk_core_cli.talk_config, "get_hermes_home", lambda: "/tmp/hermes"
+    )
+    monkeypatch.setattr(
+        talk_core_cli.talk_transcript, "TranscriptCapture", lambda _home: capture
+    )
+    monkeypatch.setattr(
+        talk_core_cli.talk_transcript, "sweep_transcripts", lambda _home: None
+    )
+    monkeypatch.setattr(
+        talk_core_cli.uuid,
+        "uuid4",
+        lambda: type("Id", (), {"hex": "call-1"})(),
+    )
+    monkeypatch.setattr(
+        talk_core_cli.sys,
+        "stdin",
+        io.StringIO(
+            '{"type":"delegate.progress","id":"call-1","text":"Checked the tests."}\n'
+            '{"type":"delegate.result","id":"call-1","output":"The script returned 5050."}\n'
+        ),
+    )
+
+    result = asyncio.run(talk_core_cli.run_core_talk_session(audio))
+
+    output = capsys.readouterr().out
+    coordinator = FakeCoordinator.instance
+    assert result == 0
+    assert coordinator.max_in_flight_tool_calls == 1
+    assert coordinator.contexts == [
+        (
+            "p1-call-1",
+            "Silent Hermes text-agent progress:\n\nChecked the tests.",
+        )
+    ]
+    assert coordinator.opened["tools"] == [talk_core_cli.DELEGATE_TOOL]
+    assert talk_core_cli.DELEGATE_INSTRUCTIONS in coordinator.opened["instructions"]
+    assert coordinator.result == '"Agent Final Message":\n\nThe script returned 5050.'
+    assert (
+        'talk: event {"type":"delegate","id":"call-1",'
+        f'"request":"{SUM_REQUEST}"}}'
+    ) in output
+    assert (
+        'talk: event {"type":"transcript","role":"user",'
+        f'"text":"{SUM_REQUEST}","final":true}}'
+    ) in output
+    assert (
+        'talk: event {"type":"transcript","role":"assistant",'
+        '"text":"I found the issue.","final":true}'
+    ) in output
+
+
+def test_progress_item_ids_stay_within_provider_wire_limit():
+    request_id = "a" * 32
+
+    first = talk_core_cli._progress_item_id(request_id, 1)
+    second = talk_core_cli._progress_item_id(request_id, 2)
+
+    assert first == f"p1-{request_id}"[:32]
+    assert len(first) == talk_core_cli.MAX_PROVIDER_ITEM_ID_LENGTH
+    assert first != second

--- a/tests/test_core_cli.py
+++ b/tests/test_core_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import json
 
 import pytest
 
@@ -95,6 +96,10 @@ class FakeCoordinator:
         self.cancelled += 1
 
     async def events(self):
+        yield RealtimeEvent(
+            type=RealtimeEventType.SESSION_READY,
+            session_id="provider-session",
+        )
         await self.dispatch_tool("weather", {"city": "Paris"})
         yield RealtimeEvent.audio(b"speaker", item_id="item-1")
         yield RealtimeEvent(type=RealtimeEventType.TURN_ENDED, role="assistant")
@@ -156,6 +161,14 @@ def test_tui_event_stream_delegates_to_text_agent_and_frames_transcripts(
             raise RuntimeError("provider rejected optional progress context")
 
         async def events(self):
+            yield RealtimeEvent(
+                type=RealtimeEventType.SESSION_READY,
+                session_id="provider-session",
+            )
+            yield RealtimeEvent(
+                type=RealtimeEventType.WARNING,
+                text="provider recovered from one malformed frame",
+            )
             self.result = await self.dispatch_tool(
                 "client_delegate",
                 {"request": SUM_REQUEST},
@@ -227,18 +240,26 @@ def test_tui_event_stream_delegates_to_text_agent_and_frames_transcripts(
     assert coordinator.opened["tools"] == [talk_core_cli.DELEGATE_TOOL]
     assert talk_core_cli.DELEGATE_INSTRUCTIONS in coordinator.opened["instructions"]
     assert coordinator.result == '"Agent Final Message":\n\nThe script returned 5050.'
-    assert (
-        'talk: event {"type":"delegate","id":"call-1",'
-        f'"request":"{SUM_REQUEST}"}}'
-    ) in output
-    assert (
-        'talk: event {"type":"transcript","role":"user",'
-        f'"text":"{SUM_REQUEST}","final":true}}'
-    ) in output
-    assert (
-        'talk: event {"type":"transcript","role":"assistant",'
-        '"text":"I found the issue.","final":true}'
-    ) in output
+    frames = [
+        json.loads(line.removeprefix(talk_core_cli.EVENT_PREFIX))
+        for line in output.splitlines()
+        if line.startswith(talk_core_cli.EVENT_PREFIX)
+    ]
+    assert {
+        (frame["type"], frame.get("role"), frame.get("text"), frame.get("message"))
+        for frame in frames
+    } >= {
+        ("delegate", None, None, None),
+        ("transcript", "user", SUM_REQUEST, None),
+        ("transcript", "assistant", "I found the issue.", None),
+        ("warning", None, None, "provider recovered from one malformed frame"),
+    }
+    assert {frame["protocol_version"] for frame in frames} == {
+        talk_core_cli.PROTOCOL_VERSION
+    }
+    assert {frame["surface_session_id"] for frame in frames} == {"call-1"}
+    assert [frame["sequence"] for frame in frames] == list(range(1, len(frames) + 1))
+    assert "talk: connected (realtime-test, voice cedar)" in output
     assert output.count("talk: state composing") == 1
     assert talk_core_cli.sys.stdin.closed is True
 
@@ -304,6 +325,7 @@ def test_stdin_reader_discards_queued_frames_after_parent_flood():
         )
         reader = talk_core_cli._StdinLineReader(io.StringIO(f"{payload}\n"))
         try:
+            await asyncio.wait_for(reader._eof.wait(), timeout=0.1)
             with pytest.raises(RuntimeError, match="flooded"):
                 await asyncio.wait_for(reader.readline(), timeout=0.1)
         finally:

--- a/tests/test_core_cli.py
+++ b/tests/test_core_cli.py
@@ -22,8 +22,7 @@ class FakeAudio:
         self.stopped = False
         self.queued = []
         self.drained = 0
-        self.resets = 0
-        self.played_ms = 360
+        self.played_boundary = ("item-1", 360)
 
     def start(self):
         self.started = True
@@ -34,14 +33,12 @@ class FakeAudio:
     def read_input_chunk(self):
         return None
 
-    def queue_playback(self, pcm):
-        self.queued.append(pcm)
+    def queue_playback(self, pcm, item_id=None):
+        self.queued.append((item_id, pcm))
 
     def drain_playback(self):
         self.drained += 1
-
-    def reset_played_ms(self):
-        self.resets += 1
+        return self.played_boundary
 
 
 class FakeCapture:

--- a/tests/test_core_cli.py
+++ b/tests/test_core_cli.py
@@ -160,6 +160,9 @@ def test_tui_event_stream_delegates_to_text_agent_and_frames_transcripts(
                 "client_delegate",
                 {"request": SUM_REQUEST},
             )
+            yield RealtimeEvent.audio(b"speaker-1", item_id="item-1")
+            yield RealtimeEvent.audio(b"speaker-2", item_id="item-1")
+            yield RealtimeEvent.audio(b"speaker-3", item_id="item-1")
             yield RealtimeEvent.transcript(
                 SUM_REQUEST,
                 final=True,
@@ -236,6 +239,7 @@ def test_tui_event_stream_delegates_to_text_agent_and_frames_transcripts(
         'talk: event {"type":"transcript","role":"assistant",'
         '"text":"I found the issue.","final":true}'
     ) in output
+    assert output.count("talk: state composing") == 1
     assert talk_core_cli.sys.stdin.closed is True
 
 
@@ -262,6 +266,50 @@ def test_stdin_reader_consumes_prefetched_lines_without_deadlock():
             reader.close()
 
     assert asyncio.run(scenario()) == ("progress", "result")
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ("x" * (talk_core_cli.MAX_CONTROL_FRAME_CHARS + 1), "oversized"),
+        (
+            "\n".join(
+                "x" for _ in range(talk_core_cli.MAX_PENDING_CONTROL_FRAMES + 1)
+            ),
+            "flooded",
+        ),
+    ],
+)
+def test_stdin_reader_bounds_parent_protocol(payload, message):
+    async def scenario():
+        reader = talk_core_cli._StdinLineReader(io.StringIO(f"{payload}\n"))
+        idle = asyncio.Event()
+        idle.set()
+        try:
+            with pytest.raises(RuntimeError, match=message):
+                await asyncio.wait_for(
+                    reader.wait_for_parent_close(idle),
+                    timeout=0.1,
+                )
+        finally:
+            reader.close()
+
+    asyncio.run(scenario())
+
+
+def test_stdin_reader_discards_queued_frames_after_parent_flood():
+    async def scenario():
+        payload = "\n".join(
+            "x" for _ in range(talk_core_cli.MAX_PENDING_CONTROL_FRAMES + 1)
+        )
+        reader = talk_core_cli._StdinLineReader(io.StringIO(f"{payload}\n"))
+        try:
+            with pytest.raises(RuntimeError, match="flooded"):
+                await asyncio.wait_for(reader.readline(), timeout=0.1)
+        finally:
+            reader.close()
+
+    asyncio.run(scenario())
 
 
 def test_parent_stdin_eof_stops_an_idle_session(monkeypatch, capsys):

--- a/tests/test_core_cli.py
+++ b/tests/test_core_cli.py
@@ -97,6 +97,7 @@ class FakeCoordinator:
     async def events(self):
         await self.dispatch_tool("weather", {"city": "Paris"})
         yield RealtimeEvent.audio(b"speaker", item_id="item-1")
+        yield RealtimeEvent(type=RealtimeEventType.TURN_ENDED, role="assistant")
         yield RealtimeEvent.transcript("hello", final=True, role="user")
         yield RealtimeEvent(type=RealtimeEventType.TURN_STARTED, role="user")
 
@@ -245,6 +246,7 @@ def test_tui_event_stream_delegates_to_text_agent_and_frames_transcripts(
         'talk: event {"type":"transcript","role":"assistant",'
         '"text":"I found the issue.","final":true}'
     ) in output
+    assert talk_core_cli.sys.stdin.closed is True
 
 
 def test_progress_item_ids_stay_within_provider_wire_limit():

--- a/tests/test_core_realtime_contract_adapter.py
+++ b/tests/test_core_realtime_contract_adapter.py
@@ -1,0 +1,191 @@
+"""Hermes #95147 adapter tests; provider transport stays out of core."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("agent.realtime_voice", reason="Hermes #95147 contract is optional")
+from agent.realtime_voice import HeardAudioBoundary, RealtimeEventType
+
+import talk_core_realtime_contract as core_v1
+import talk_realtime as rt
+
+
+class FakeSession:
+    def __init__(self, events=(), **kwargs):
+        self.events = iter(events)
+        self.init = kwargs
+        self.setup = None
+        self.sent = []
+        self.closed = 0
+
+    async def connect(self, setup):
+        self.setup = setup
+
+    async def send(self, commands):
+        self.sent.extend(commands)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self.events)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+    async def close(self):
+        self.closed += 1
+
+
+class Harness:
+    def __init__(self, events=()):
+        self.session = FakeSession(events)
+
+    def auth(self):
+        return type("Auth", (), {"token": "secret", "source": "test"})()
+
+    def session_factory(self, **kwargs):
+        self.session.init = kwargs
+        return self.session
+
+    def provider(self):
+        return core_v1.TalkOpenAIRealtimeProvider(
+            auth_resolver=self.auth,
+            session_factory=self.session_factory,
+        )
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_provider_opens_plugin_transport_with_hermes_setup(monkeypatch):
+    harness = Harness()
+    monkeypatch.setattr(core_v1.talk_config, "talk_model", lambda: "gpt-realtime-test")
+    monkeypatch.setattr(core_v1.talk_config, "talk_voice", lambda: "cedar")
+
+    session = run(
+        harness.provider().open_session(
+            instructions="Hermes owns policy",
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "weather",
+                        "description": "Read weather",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        )
+    )
+
+    assert isinstance(session, core_v1.TalkRealtimeSession)
+    assert harness.session.init == {"auth_token": "secret", "auth_source": "test"}
+    assert harness.session.setup.model == "gpt-realtime-test"
+    assert harness.session.setup.voice == "cedar"
+    assert harness.session.setup.instructions == "Hermes owns policy"
+    assert harness.session.setup.tools[0].name == "weather"
+    assert harness.session.setup.automatic_response is True
+
+
+def test_grok_provider_uses_xai_model_voice_and_registry_name(monkeypatch):
+    harness = Harness()
+    monkeypatch.setattr(core_v1.talk_config, "talk_provider", lambda: "grok")
+    monkeypatch.setattr(core_v1.talk_config, "talk_grok_model", lambda: "grok-voice-test")
+    monkeypatch.setattr(core_v1.talk_config, "talk_grok_voice", lambda: "ara")
+    provider = core_v1.TalkGrokRealtimeProvider(
+        auth_resolver=harness.auth,
+        session_factory=harness.session_factory,
+    )
+
+    session = run(provider.open_session(instructions="Hermes owns policy", tools=[]))
+
+    assert isinstance(session, core_v1.TalkRealtimeSession)
+    assert provider.name == core_v1.GROK_PROVIDER_NAME
+    assert harness.session.setup.model == "grok-voice-test"
+    assert harness.session.setup.voice == "ara"
+    assert isinstance(core_v1.configured_provider(), core_v1.TalkGrokRealtimeProvider)
+    assert core_v1.configured_provider_name() == core_v1.GROK_PROVIDER_NAME
+
+
+def test_session_maps_audio_transcript_turns_and_tool_calls():
+    harness = Harness(
+        (
+            rt.SpeechStarted(input_id="input-1"),
+            rt.Transcript(
+                role=rt.TranscriptRole.USER,
+                text="hello",
+                final=True,
+                provenance=rt.TranscriptProvenance.INPUT_AUDIO,
+            ),
+            rt.OutputAudio(data=b"pcm", item_id="item-1", response_id="response-1"),
+            rt.FunctionCall(call_id="call-1", name="weather", arguments='{"city":"Paris"}'),
+            rt.ResponseFinished(response_id="response-1"),
+        )
+    )
+    session = core_v1.TalkRealtimeSession(harness.session)
+
+    async def collect():
+        return [event async for event in session.events()]
+
+    events = run(collect())
+
+    assert [event.role for event in events] == ["user", "user", None, None, "assistant"]
+    assert [event.type for event in events] == [
+        RealtimeEventType.TURN_STARTED,
+        RealtimeEventType.TRANSCRIPT,
+        RealtimeEventType.AUDIO,
+        RealtimeEventType.TOOL_CALL,
+        RealtimeEventType.TURN_ENDED,
+    ]
+    assert events[2].audio_bytes == b"pcm"
+    assert events[2].item_id == "item-1"
+    assert events[3].arguments == {"city": "Paris"}
+
+
+def test_session_commands_preserve_host_authority_and_barge_in_boundary():
+    harness = Harness()
+    session = core_v1.TalkRealtimeSession(harness.session)
+
+    async def scenario():
+        await session.send_audio(b"mic")
+        await session.submit_tool_result("call-1", "sunny")
+        await session.truncate_response(HeardAudioBoundary("item-1", 420))
+        await session.add_context("progress-1", "Checked the tests.")
+        await session.cancel_response()
+        await session.close()
+        await session.close()
+
+    run(scenario())
+
+    assert harness.session.sent == [
+        rt.AppendInputAudio(b"mic"),
+        rt.SubmitToolResult(call_id="call-1", output="sunny"),
+        rt.StartResponse(),
+        rt.TruncateOutput(item_id="item-1", audio_end_ms=420),
+        rt.AddContext(
+            item_id="progress-1",
+            text="Checked the tests.",
+            role=rt.ContextRole.SYSTEM,
+        ),
+        rt.CancelResponse(),
+    ]
+    assert harness.session.closed == 1
+
+
+def test_invalid_tool_arguments_surface_error_without_dispatch():
+    harness = Harness((rt.FunctionCall(call_id="call-1", name="weather", arguments="[]"),))
+    session = core_v1.TalkRealtimeSession(harness.session)
+
+    async def collect():
+        return [event async for event in session.events()]
+
+    events = run(collect())
+
+    assert len(events) == 1
+    assert events[0].type is RealtimeEventType.ERROR
+    assert events[0].text == "invalid tool arguments: expected an object"

--- a/tests/test_core_realtime_contract_adapter.py
+++ b/tests/test_core_realtime_contract_adapter.py
@@ -247,6 +247,87 @@ def test_cancel_is_sent_only_while_provider_response_is_active():
     assert harness.session.sent == [rt.CancelResponse()]
 
 
+def test_cancelled_response_tail_and_late_finish_cannot_clear_new_response():
+    harness = Harness(
+        (
+            rt.ResponseStarted(response_id="response-a"),
+            rt.OutputAudio(data=b"stale", item_id="item-a", response_id="response-a"),
+            rt.Transcript(
+                role=rt.TranscriptRole.ASSISTANT,
+                text="stale transcript",
+                final=True,
+                provenance=rt.TranscriptProvenance.OUTPUT_AUDIO,
+                response_id="response-a",
+            ),
+            rt.ResponseStarted(response_id="response-b"),
+            rt.ResponseFinished(response_id="response-a"),
+            rt.OutputAudio(data=b"current", item_id="item-b", response_id="response-b"),
+        )
+    )
+    session = core_v1.TalkRealtimeSession(harness.session)
+
+    async def scenario():
+        events = session.events()
+        assert (await anext(events)).type is RealtimeEventType.TURN_STARTED
+        await session.cancel_response()
+        started_b = await anext(events)
+        current_audio = await anext(events)
+        await session.cancel_response()
+        return started_b, current_audio
+
+    started_b, current_audio = run(scenario())
+
+    assert started_b.type is RealtimeEventType.TURN_STARTED
+    assert current_audio.audio_bytes == b"current"
+    assert harness.session.sent == [rt.CancelResponse(), rt.CancelResponse()]
+
+
+def test_completed_tool_call_replay_is_ignored_without_sticking_pending():
+    duplicate = rt.FunctionCall(
+        call_id="call-1",
+        name="weather",
+        arguments="{}",
+        response_id="response-1",
+    )
+    harness = Harness(
+        (
+            rt.ResponseStarted(response_id="response-1"),
+            duplicate,
+            rt.ResponseFinished(response_id="response-1"),
+            duplicate,
+        )
+    )
+    session = core_v1.TalkRealtimeSession(harness.session)
+
+    async def scenario():
+        events = session.events()
+        for _ in range(3):
+            await anext(events)
+        await session.submit_tool_result("call-1", "sunny")
+        return [event async for event in events]
+
+    assert run(scenario()) == []
+    assert session._pending_tool_calls == []
+    assert harness.session.sent == [
+        rt.SubmitToolResult(call_id="call-1", output="sunny"),
+        rt.StartResponse(),
+    ]
+
+
+def test_unexpected_clean_provider_close_surfaces_terminal_error():
+    harness = Harness((rt.SessionTerminated(state=rt.SessionState.CLOSED),))
+    session = core_v1.TalkRealtimeSession(harness.session)
+
+    async def collect():
+        return [event async for event in session.events()]
+
+    events = run(collect())
+
+    assert len(events) == 1
+    assert events[0].type is RealtimeEventType.ERROR
+    assert events[0].text == "realtime voice provider closed unexpectedly"
+
+
 def test_recoverable_provider_failure_does_not_end_the_session():
     harness = Harness(
         (

--- a/tests/test_core_realtime_contract_adapter.py
+++ b/tests/test_core_realtime_contract_adapter.py
@@ -7,7 +7,12 @@ import asyncio
 import pytest
 
 pytest.importorskip("agent.realtime_voice", reason="Hermes #95147 contract is optional")
-from agent.realtime_voice import HeardAudioBoundary, RealtimeEventType
+from agent.realtime_voice import (
+    HeardAudioBoundary,
+    RealtimeEventType,
+    RealtimeVoiceProvider,
+)
+from agent.realtime_voice_coordinator import RealtimeVoiceCoordinator
 
 import talk_core_realtime_contract as core_v1
 import talk_realtime as rt
@@ -247,6 +252,27 @@ def test_cancel_is_sent_only_while_provider_response_is_active():
     assert harness.session.sent == [rt.CancelResponse()]
 
 
+def test_cancel_is_not_sent_while_provider_is_idle_or_after_finish():
+    harness = Harness(
+        (
+            rt.ResponseStarted(response_id="response-1"),
+            rt.ResponseFinished(response_id="response-1"),
+        )
+    )
+    session = core_v1.TalkRealtimeSession(harness.session)
+
+    async def scenario():
+        await session.cancel_response()
+        events = session.events()
+        await anext(events)
+        await anext(events)
+        await session.cancel_response()
+
+    run(scenario())
+
+    assert harness.session.sent == []
+
+
 def test_cancelled_response_tail_and_late_finish_cannot_clear_new_response():
     harness = Harness(
         (
@@ -342,12 +368,78 @@ def test_recoverable_provider_failure_does_not_end_the_session():
     )
     session = core_v1.TalkRealtimeSession(harness.session)
 
+
     async def collect():
         return [event async for event in session.events()]
 
     events = run(collect())
 
     assert [event.text for event in events] == ["still here"]
+
+
+def test_real_coordinator_delegates_one_client_tool_through_adapter():
+    harness = Harness(
+        (
+            rt.ResponseStarted(response_id="response-1"),
+            rt.FunctionCall(
+                call_id="call-1",
+                name="client_delegate",
+                arguments='{"request":"search for current weather"}',
+                response_id="response-1",
+            ),
+            rt.ResponseFinished(response_id="response-1"),
+        )
+    )
+    adapter = core_v1.TalkRealtimeSession(harness.session)
+    dispatched = []
+
+    class Provider(RealtimeVoiceProvider):
+        @property
+        def name(self):
+            return "test"
+
+        @property
+        def display_name(self):
+            return "Test"
+
+        def is_available(self):
+            return True
+
+        def get_setup_schema(self):
+            return {}
+
+        async def open_session(self, **_kwargs):
+            return adapter
+
+    async def dispatch(name, arguments):
+        dispatched.append((name, arguments))
+        return "72°F and clear"
+
+    async def scenario():
+        coordinator = RealtimeVoiceCoordinator(Provider(), dispatch_tool=dispatch)
+        await coordinator.open(instructions="delegate", tools=[])
+        observed = [event async for event in coordinator.events()]
+        pending = tuple(coordinator._tool_tasks.values())
+        if pending:
+            await asyncio.gather(*pending)
+        await coordinator.close()
+        return observed
+
+    observed = run(scenario())
+
+    assert dispatched == [
+        ("client_delegate", {"request": "search for current weather"})
+    ]
+    assert [event.type for event in observed] == [
+        RealtimeEventType.TURN_STARTED,
+        RealtimeEventType.TOOL_CALL,
+        RealtimeEventType.TURN_ENDED,
+    ]
+    assert harness.session.sent == [
+        rt.SubmitToolResult(call_id="call-1", output="72°F and clear"),
+        rt.StartResponse(),
+    ]
+
 
 
 def test_invalid_tool_arguments_surface_error_without_dispatch():

--- a/tests/test_core_realtime_contract_adapter.py
+++ b/tests/test_core_realtime_contract_adapter.py
@@ -112,6 +112,26 @@ def test_grok_provider_uses_xai_model_voice_and_registry_name(monkeypatch):
     assert core_v1.configured_provider_name() == core_v1.GROK_PROVIDER_NAME
 
 
+def test_grok_provider_uses_supported_oauth_resolver_by_default(monkeypatch):
+    harness = Harness()
+    monkeypatch.setattr(
+        core_v1.talk_grok_auth,
+        "resolve_grok_auth",
+        lambda: type("Auth", (), {"token": "oauth-token", "source": "xai-oauth"})(),
+    )
+    monkeypatch.setattr(core_v1.talk_config, "talk_grok_model", lambda: "grok-voice-test")
+    monkeypatch.setattr(core_v1.talk_config, "talk_grok_voice", lambda: "ara")
+    provider = core_v1.TalkGrokRealtimeProvider(
+        session_factory=harness.session_factory,
+    )
+
+    run(provider.open_session(instructions="Hermes owns policy", tools=[]))
+
+    assert harness.session.init == {
+        "auth_token": "oauth-token",
+        "auth_source": "xai-oauth",
+    }
+
 def test_session_maps_audio_transcript_turns_and_tool_calls():
     harness = Harness(
         (
@@ -148,12 +168,23 @@ def test_session_maps_audio_transcript_turns_and_tool_calls():
 
 
 def test_session_commands_preserve_host_authority_and_barge_in_boundary():
-    harness = Harness()
+    harness = Harness(
+        (
+            rt.ResponseStarted(response_id="response-1"),
+            rt.FunctionCall(call_id="call-1", name="weather", arguments="{}"),
+            rt.ResponseFinished(response_id="response-1"),
+        )
+    )
     session = core_v1.TalkRealtimeSession(harness.session)
 
     async def scenario():
         await session.send_audio(b"mic")
+        events = session.events()
+        await anext(events)
+        await anext(events)
         await session.submit_tool_result("call-1", "sunny")
+        assert harness.session.sent == [rt.AppendInputAudio(b"mic")]
+        await anext(events)
         await session.truncate_response(HeardAudioBoundary("item-1", 420))
         await session.add_context("progress-1", "Checked the tests.")
         await session.cancel_response()
@@ -172,9 +203,70 @@ def test_session_commands_preserve_host_authority_and_barge_in_boundary():
             text="Checked the tests.",
             role=rt.ContextRole.SYSTEM,
         ),
-        rt.CancelResponse(),
     ]
     assert harness.session.closed == 1
+
+
+def test_tool_results_batch_in_call_order_after_response_finishes():
+    harness = Harness(
+        (
+            rt.ResponseStarted(response_id="response-1"),
+            rt.FunctionCall(call_id="call-1", name="first", arguments="{}"),
+            rt.FunctionCall(call_id="call-2", name="second", arguments="{}"),
+            rt.ResponseFinished(response_id="response-1"),
+        )
+    )
+    session = core_v1.TalkRealtimeSession(harness.session)
+
+    async def scenario():
+        events = session.events()
+        for _ in range(4):
+            await anext(events)
+        await session.submit_tool_result("call-2", "second result")
+        assert harness.session.sent == []
+        await session.submit_tool_result("call-1", "first result")
+
+    run(scenario())
+
+    assert harness.session.sent == [
+        rt.SubmitToolResult(call_id="call-1", output="first result"),
+        rt.SubmitToolResult(call_id="call-2", output="second result"),
+        rt.StartResponse(),
+    ]
+
+
+def test_cancel_is_sent_only_while_provider_response_is_active():
+    harness = Harness((rt.ResponseStarted(response_id="response-1"),))
+    session = core_v1.TalkRealtimeSession(harness.session)
+
+    async def scenario():
+        await anext(session.events())
+        await session.cancel_response()
+
+    run(scenario())
+    assert harness.session.sent == [rt.CancelResponse()]
+
+
+def test_recoverable_provider_failure_does_not_end_the_session():
+    harness = Harness(
+        (
+            rt.ProviderFailure(detail="bad audio chunk", terminal=False),
+            rt.Transcript(
+                role=rt.TranscriptRole.USER,
+                text="still here",
+                final=True,
+                provenance=rt.TranscriptProvenance.INPUT_AUDIO,
+            ),
+        )
+    )
+    session = core_v1.TalkRealtimeSession(harness.session)
+
+    async def collect():
+        return [event async for event in session.events()]
+
+    events = run(collect())
+
+    assert [event.text for event in events] == ["still here"]
 
 
 def test_invalid_tool_arguments_surface_error_without_dispatch():

--- a/tests/test_core_realtime_contract_adapter.py
+++ b/tests/test_core_realtime_contract_adapter.py
@@ -117,6 +117,30 @@ def test_grok_provider_uses_xai_model_voice_and_registry_name(monkeypatch):
     assert core_v1.configured_provider_name() == core_v1.GROK_PROVIDER_NAME
 
 
+def test_gemini_provider_uses_live_model_voice_and_registry_name(monkeypatch):
+    harness = Harness()
+    monkeypatch.setattr(core_v1.talk_config, "talk_provider", lambda: "gemini")
+    monkeypatch.setattr(
+        core_v1.talk_config,
+        "talk_gemini_model",
+        lambda: "gemini-live-test",
+    )
+    monkeypatch.setattr(core_v1.talk_config, "talk_gemini_voice", lambda: "Kore")
+    provider = core_v1.TalkGeminiRealtimeProvider(
+        auth_resolver=harness.auth,
+        session_factory=harness.session_factory,
+    )
+
+    session = run(provider.open_session(instructions="Hermes owns policy", tools=[]))
+
+    assert isinstance(session, core_v1.TalkRealtimeSession)
+    assert provider.name == core_v1.GEMINI_PROVIDER_NAME
+    assert harness.session.setup.model == "gemini-live-test"
+    assert harness.session.setup.voice == "Kore"
+    assert isinstance(core_v1.configured_provider(), core_v1.TalkGeminiRealtimeProvider)
+    assert core_v1.configured_provider_name() == core_v1.GEMINI_PROVIDER_NAME
+
+
 def test_grok_provider_uses_supported_oauth_resolver_by_default(monkeypatch):
     harness = Harness()
     monkeypatch.setattr(
@@ -354,9 +378,10 @@ def test_unexpected_clean_provider_close_surfaces_terminal_error():
     assert events[0].text == "realtime voice provider closed unexpectedly"
 
 
-def test_recoverable_provider_failure_does_not_end_the_session():
+def test_readiness_and_recoverable_failure_are_preserved_without_ending_session():
     harness = Harness(
         (
+            rt.SessionReady(session_id="provider-session"),
             rt.ProviderFailure(detail="bad audio chunk", terminal=False),
             rt.Transcript(
                 role=rt.TranscriptRole.USER,
@@ -368,13 +393,18 @@ def test_recoverable_provider_failure_does_not_end_the_session():
     )
     session = core_v1.TalkRealtimeSession(harness.session)
 
-
     async def collect():
         return [event async for event in session.events()]
 
     events = run(collect())
 
-    assert [event.text for event in events] == ["still here"]
+    assert [event.type for event in events] == [
+        RealtimeEventType.SESSION_READY,
+        RealtimeEventType.WARNING,
+        RealtimeEventType.TRANSCRIPT,
+    ]
+    assert events[0].session_id == "provider-session"
+    assert [event.text for event in events[1:]] == ["bad audio chunk", "still here"]
 
 
 def test_real_coordinator_delegates_one_client_tool_through_adapter():

--- a/tests/test_gemini_realtime.py
+++ b/tests/test_gemini_realtime.py
@@ -21,6 +21,7 @@ from fake_realtime import Recorder, build_relay, play_neutral
 import talk_auth
 import talk_cli
 import talk_config
+import talk_gemini_auth
 import talk_gemini_realtime as gemini_rt
 import talk_openai_realtime as openai_rt
 import talk_realtime as rt
@@ -1292,7 +1293,7 @@ def test_both_keys_set_uses_talk_provider_not_key_presence(clean_provider_env):
     auth = talk_auth.TalkAuth(token="openai-test", source="env", detail="test")
     assert isinstance(talk_cli._realtime_session(auth), openai_rt.OpenAIRealtimeSession)
     clean_provider_env.setenv("TALK_PROVIDER", "gemini")
-    gemini_auth = talk_cli._gemini_auth()
+    gemini_auth = talk_gemini_auth.resolve_gemini_auth()
     assert gemini_auth.token == "gemini-scoped"
     assert gemini_auth.source == talk_auth.SOURCE_CONFIGURED
     session = talk_cli._realtime_session(gemini_auth)
@@ -1302,6 +1303,6 @@ def test_both_keys_set_uses_talk_provider_not_key_presence(clean_provider_env):
 
 def test_gemini_auth_falls_back_to_the_shared_key(clean_provider_env):
     clean_provider_env.setenv("GEMINI_API_KEY", "gemini-shared")
-    auth = talk_cli._gemini_auth()
+    auth = talk_gemini_auth.resolve_gemini_auth()
     assert auth.token == "gemini-shared"
     assert auth.source == talk_auth.SOURCE_ENV

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -158,11 +158,12 @@ def test_realtime_registration_false_is_rejected_not_registered(plugin):
     assert len(ctx.realtime_providers) == 1
 
 
-def test_real_api_v2_context_accepts_the_talk_provider(plugin):
+def test_real_core_context_accepts_the_talk_provider(plugin):
     if not plugin.talk_core_realtime.core_provider_available():
-        pytest.skip("optional Hermes core API-v2 is absent")
+        pytest.skip("optional Hermes realtime voice contract is absent")
     try:
         from agent import realtime_voice_registry
+        from agent.realtime_voice import RealtimeVoiceProvider
         from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
     except ImportError:
         pytest.skip("optional Hermes plugin API is absent")
@@ -179,8 +180,7 @@ def test_real_api_v2_context_accepts_the_talk_provider(plugin):
         )
         registered = realtime_voice_registry.get_provider("talk_openai_realtime")
         assert plugin.REGISTRATION_RECEIPTS["realtime_voice_provider"] == "registered"
-        assert registered is not None
-        assert registered.api_version == 2
+        assert isinstance(registered, RealtimeVoiceProvider)
     finally:
         realtime_voice_registry._reset_for_tests()
 

--- a/tests/test_transcript.py
+++ b/tests/test_transcript.py
@@ -227,6 +227,23 @@ def test_next_start_recovers_a_claim_left_by_a_killed_sweeper(tmp_path):
     assert not orphaned_claim.exists()
 
 
+def test_recovered_claim_name_does_not_grow_past_filesystem_limit(tmp_path):
+    capture = talk_transcript.TranscriptCapture(tmp_path)
+    capture.append_turn("user", _long_turn("orphan user"))
+    capture.append_turn("assistant", _long_turn("orphan assistant"))
+    capture.finish()
+    orphaned_claim = capture.path.with_name(
+        f"{'x' * 195}.jsonl.claimed-deadgateway"
+    )
+    os.rename(capture.path, orphaned_claim)
+    prompts = []
+
+    talk_transcript.sweep_transcripts(tmp_path, run_agent=prompts.append)
+
+    assert len(prompts) == 1
+    assert not orphaned_claim.exists()
+
+
 def test_sweep_drops_a_symlink_that_escapes_the_transcript_directory(tmp_path):
     root = tmp_path / "state" / "talk-transcripts"
     root.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- adapt OpenAI and xAI realtime transports to the provider/session contract in NousResearch/hermes-agent#95147
- register the configured Talk provider through Hermes plugin context
- run terminal voice through Hermes' coordinator when the contract is available
- expose only `client_delegate` in TUI event-stream mode so the normal Hermes agent owns coding, tools, approvals, and detailed output
- return silent progress and concise final-result context to the voice session

## Stack
Depends on NousResearch/hermes-agent#95147 and the stacked Hermes TUI consumer PR.

Related to NousResearch/hermes-agent#77111.

## Verification
- focused adapter, registration, CLI bridge, and wheel-manifest suite — 41 passed
- `ruff check .` — passed
- exact regression covers: “Write a Python script that sums all numbers from 1 to 100 and run it”, progress framing, 32-character provider item IDs, and final result `5050`