### PR TITLE
fix(audio): make the echo gate tunable and document it as cross-platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ named rather than smoothed.
 - Linux terminal calls now route default audio through PulseAudio's WebRTC
   echo canceller and noise suppressor. Echo-cancelled input bypasses the
   fallback amplitude/VAD gate so barge-in does not clip quiet words.
+
+### Changed
+- The software echo gate (mic blocks below the playback echo floor are
+  dropped while model audio plays) now runs on every platform whenever
+  PulseAudio AEC is not active — that is always on Windows and macOS. On
+  headphones there is no echo to suppress, so it is tunable:
+  `TALK_ECHO_GATE=off` disables it; `TALK_ECHO_GATE_OUTPUT_ACTIVE_LEVEL`,
+  `TALK_ECHO_GATE_MIN_BARGE_IN_LEVEL`, and `TALK_ECHO_GATE_RATIO` retune it.
+  Read when the audio stream is constructed.
 ## [0.16.0] — 2026-09-01
 
 Grok voice on a SuperGrok / X Premium+ subscription. `hermes auth add

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -47,9 +47,41 @@ MAX_PLAYBACK_BYTES = SAMPLE_RATE * FRAME_BYTES * 20
 
 # Match OMP's live controller: while model audio is playing, microphone blocks
 # below the acoustic echo floor are local playback leakage, not barge-in.
+# This software gate runs on every platform whenever PulseAudio WebRTC AEC is
+# not active (always on Windows/macOS). On headphones there is no echo to
+# suppress, so the operator can retune or disable it:
+#   TALK_ECHO_GATE=off                       disable the gate entirely
+#   TALK_ECHO_GATE_OUTPUT_ACTIVE_LEVEL=0.015 playback RMS that counts as "active"
+#   TALK_ECHO_GATE_MIN_BARGE_IN_LEVEL=0.04   floor a mic block must clear
+#   TALK_ECHO_GATE_RATIO=0.65                 fraction of playback RMS a block must clear
+# Read when DuplexAudio is constructed, not at import.
 OUTPUT_ACTIVE_LEVEL = 0.015
 MIN_BARGE_IN_LEVEL = 0.04
 OUTPUT_ECHO_RATIO = 0.65
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+def _echo_gate_settings() -> tuple[bool, float, float, float]:
+    """(enabled, output_active_level, min_barge_in_level, echo_ratio) from env."""
+
+    raw = (os.environ.get("TALK_ECHO_GATE") or "").strip().lower()
+    enabled = raw not in {"0", "off", "false", "no", "disabled"}
+    return (
+        enabled,
+        _env_float("TALK_ECHO_GATE_OUTPUT_ACTIVE_LEVEL", OUTPUT_ACTIVE_LEVEL),
+        _env_float("TALK_ECHO_GATE_MIN_BARGE_IN_LEVEL", MIN_BARGE_IN_LEVEL),
+        _env_float("TALK_ECHO_GATE_RATIO", OUTPUT_ECHO_RATIO),
+    )
 
 _INSTALL_HINT = (
     'audio support is not installed — run: pip install "hermes-talk[audio]" '
@@ -240,6 +272,12 @@ class DuplexAudio:
         self._in_stream = None
         self._out_stream = None
         self._pulse_webrtc = _PulseWebRtcAudio()
+        (
+            self._echo_gate_enabled,
+            self._output_active_level,
+            self._min_barge_in_level,
+            self._output_echo_ratio,
+        ) = _echo_gate_settings()
 
     # -- lifecycle ------------------------------------------------------------
 
@@ -314,11 +352,11 @@ class DuplexAudio:
         input_level = _pcm16_rms(pcm)
         with self._lock:
             output_level = self._output_level
-        if not self._pulse_webrtc.active:
-            output_active = output_level > OUTPUT_ACTIVE_LEVEL
+        if self._echo_gate_enabled and not self._pulse_webrtc.active:
+            output_active = output_level > self._output_active_level
             echo_threshold = max(
-                MIN_BARGE_IN_LEVEL,
-                output_level * OUTPUT_ECHO_RATIO,
+                self._min_barge_in_level,
+                output_level * self._output_echo_ratio,
             )
             if output_active and input_level < echo_threshold:
                 return

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -284,6 +284,42 @@ def test_loud_input_above_omp_threshold_is_uploaded():
     assert audio.read_input_chunk() == loud_input
 
 
+def test_echo_gate_off_passes_quiet_input_during_playback(monkeypatch):
+    monkeypatch.setenv("TALK_ECHO_GATE", "off")
+    audio = talk_audio.DuplexAudio()
+    playback = _pcm16(20_000, 2_400)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+    quiet_speech = _pcm16(5_000, 2_400)
+
+    audio._input_callback(quiet_speech, 2_400, None, None)
+
+    assert audio.read_input_chunk() == quiet_speech
+
+
+def test_echo_gate_thresholds_are_read_from_env_at_construction(monkeypatch):
+    monkeypatch.setenv("TALK_ECHO_GATE_MIN_BARGE_IN_LEVEL", "0.001")
+    monkeypatch.setenv("TALK_ECHO_GATE_RATIO", "0.01")
+    audio = talk_audio.DuplexAudio()
+    playback = _pcm16(20_000, 2_400)
+    audio.queue_playback(playback)
+    audio._output_callback(_Buffer(len(playback)), 2_400, None, None)
+    moderate_speech = _pcm16(5_000, 2_400)
+
+    audio._input_callback(moderate_speech, 2_400, None, None)
+
+    assert audio.read_input_chunk() == moderate_speech
+
+
+def test_echo_gate_ignores_invalid_env_values(monkeypatch):
+    monkeypatch.setenv("TALK_ECHO_GATE_MIN_BARGE_IN_LEVEL", "loud")
+    monkeypatch.setenv("TALK_ECHO_GATE_RATIO", "-1")
+    audio = talk_audio.DuplexAudio()
+
+    assert audio._min_barge_in_level == talk_audio.MIN_BARGE_IN_LEVEL
+    assert audio._output_echo_ratio == talk_audio.OUTPUT_ECHO_RATIO
+
+
 def test_microphone_audio_passes_when_playback_is_silent():
     audio = talk_audio.DuplexAudio()
     silence = _Buffer(64)


### PR DESCRIPTION
Follow-up to #81 (thanks @kvnloo). The new software echo gate runs on every platform whenever PulseAudio AEC is not active — always on Windows/macOS — so it is a cross-platform behavior change, and on headphones there is no echo to suppress.

- `TALK_ECHO_GATE=off` disables it; `TALK_ECHO_GATE_OUTPUT_ACTIVE_LEVEL`, `TALK_ECHO_GATE_MIN_BARGE_IN_LEVEL`, `TALK_ECHO_GATE_RATIO` retune it (read when the audio stream is constructed)
- CHANGELOG entry under **Changed**
- 3 tests; `tests/test_audio.py` 30 passed, ruff clean; full suite: only the 12 pre-existing host-capability failures (`test_capabilities`/`test_cli`), identical on untouched main

— SmokeDev