### PR TITLE
fix(cli): say what refused a Discord talk join instead of "exited unsuccessfully"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ named rather than smoothed.
 ## [Unreleased]
 
 ### Fixed
+- A Discord `talk join` that refuses before going live now says WHAT
+  refused instead of "session exited unsuccessfully". The session already
+  knew — it printed the reason to the gateway's stderr and returned a bare
+  exit code — so the operator, the one person who could act on it, was the
+  only one who never saw it. Configuration and provider-connect refusals
+  also point at `/talk core join`, which resolves its provider through the
+  host and so routes around exactly those two. An audio refusal does not:
+  core voice opens the same channel and would fail the same way.
+- A tool-setup failure on the legacy Discord lane raised
+  `AttributeError` out of the session instead of refusing. That lane has no
+  host execution attachment, and the handler closed one unconditionally, so
+  the crash — not the tool problem — was what reached the operator.
 - Linux terminal calls now route default audio through PulseAudio's WebRTC
   echo canceller and noise suppressor. Echo-cancelled input bypasses the
   fallback amplitude/VAD gate so barge-in does not clip quiet words.

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -215,6 +215,23 @@ def _announcement_messages(headline: str, report: str) -> list[dict]:
 #: How the announcement pump waits for the wire to go idle. Session teardown
 #: cancels the pump; an active response is never overlapped just to meet a timer.
 ANNOUNCE_IDLE_POLL_S = 0.05
+#: Why a session refused BEFORE it went live. A lane that shows the operator a
+#: receipt (Discord) renders these; they are bounded codes, never exception
+#: text, because that receipt lands in a chat channel where a token, a path, or
+#: a provider payload must never appear. The terminal keeps the detail: every
+#: call site still prints its own stderr line first.
+STARTUP_REFUSAL_CONFIGURATION = "configuration"
+STARTUP_REFUSAL_TOOLS = "tools"
+STARTUP_REFUSAL_AUDIO = "audio"
+STARTUP_REFUSAL_PROVIDER = "provider"
+STARTUP_REFUSAL_REASONS = frozenset(
+    {
+        STARTUP_REFUSAL_CONFIGURATION,
+        STARTUP_REFUSAL_TOOLS,
+        STARTUP_REFUSAL_AUDIO,
+        STARTUP_REFUSAL_PROVIDER,
+    }
+)
 TOOL_SESSION_QUEUE_SIZE = 1
 TOOL_CLEANUP_WAIT_S = 6.0
 MAX_SPEAKER_DISPLAY_NAME_CHARS = 256
@@ -1149,6 +1166,7 @@ async def run_talk_session(
     session_factory=None,
     host_execution_attachment=None,
     lane: str = "cli",
+    on_refusal=None,
 ) -> int:
     """Run one voice session. Returns a process exit code.
 
@@ -1161,7 +1179,24 @@ async def run_talk_session(
     CLI lane composes a host summary: it is the lane whose session setup may
     spend an in-process read, and even there a cold or failed catalog yields
     no line rather than a stalled start.
+
+    ``on_refusal`` is an optional sink for the ONE bounded reason
+    (:data:`STARTUP_REFUSAL_REASONS`) a session refused before going live.
+    The exit code is unchanged either way; a lane that only exits a process
+    (the terminal) ignores it, and a lane that owes the operator a spoken
+    receipt (Discord) uses it to say what actually refused instead of
+    collapsing every startup failure into "exited unsuccessfully".
     """
+
+    def refuse(reason: str) -> int:
+        """Record a bounded refusal reason and return the session exit code."""
+
+        if on_refusal is not None:
+            # A caller's receipt hook must never turn a clean refusal into a
+            # crash the lane then reports as an unrelated session error.
+            with suppress(Exception):
+                on_refusal(reason)
+        return 1
 
     hermes_home = talk_config.get_hermes_home()
     talk_transcript.sweep_transcripts(hermes_home)
@@ -1196,7 +1231,7 @@ async def run_talk_session(
         print(f"talk: {exc}", file=sys.stderr)
         if host_execution_attachment is not None:
             host_execution_attachment.close()
-        return 1
+        return refuse(STARTUP_REFUSAL_CONFIGURATION)
 
     try:
         tools = (
@@ -1206,8 +1241,13 @@ async def run_talk_session(
         )
     except Exception as exc:  # noqa: BLE001 - host attachment startup boundary
         print(f"talk: host tool setup failed: {type(exc).__name__}", file=sys.stderr)
-        host_execution_attachment.close()
-        return 1
+        # The legacy lane reaches this handler with NO attachment (its tools
+        # come from talk_tools.default_talk_tools). Closing unconditionally
+        # raised AttributeError out of the session, so a tool-setup refusal
+        # surfaced to the operator as an unrelated crash instead of a reason.
+        if host_execution_attachment is not None:
+            host_execution_attachment.close()
+        return refuse(STARTUP_REFUSAL_TOOLS)
     # The live-catalog section rides every lane. A cold process used to lose
     # the race between the background warm above and this mint — the FIRST
     # session then permanently lacked the section — so the warm gets a
@@ -1250,7 +1290,7 @@ async def run_talk_session(
         print(f"talk: {exc}", file=sys.stderr)
         if host_execution_attachment is not None:
             host_execution_attachment.close()
-        return 1
+        return refuse(STARTUP_REFUSAL_AUDIO)
 
     setup = talk_realtime.SessionSetup(
         model=model,
@@ -1357,7 +1397,7 @@ async def run_talk_session(
         talk_transcript.sweep_transcripts(hermes_home)
         if host_execution_attachment is not None:
             host_execution_attachment.close()
-        return 1
+        return refuse(STARTUP_REFUSAL_PROVIDER)
 
     try:
         send_lock = asyncio.Lock()
@@ -1900,6 +1940,11 @@ def cli_entry(args: argparse.Namespace | None = None) -> int:
 __all__ = [
     "CONNECT_TIMEOUT_S",
     "IDLE_POLL_S",
+    "STARTUP_REFUSAL_AUDIO",
+    "STARTUP_REFUSAL_CONFIGURATION",
+    "STARTUP_REFUSAL_PROVIDER",
+    "STARTUP_REFUSAL_REASONS",
+    "STARTUP_REFUSAL_TOOLS",
     "WATCH_OUTPUT_TAIL_CHARS",
     "WATCH_POLL_S",
     "WORK_STARTED_RE",

--- a/talk_discord.py
+++ b/talk_discord.py
@@ -1211,6 +1211,43 @@ def _public_exception_failure(error: BaseException) -> str:
     return f"session error ({_safe_exception_name(error)})"
 
 
+#: One speakable sentence per bounded startup-refusal reason from
+#: :data:`talk_cli.STARTUP_REFUSAL_REASONS`. Fixed text, never exception text:
+#: this lands in a Discord channel, and the refusing exception can carry a
+#: token, a path, or a provider payload.
+#:
+#: `/talk core join` is offered ONLY where the canonical core lane is genuinely
+#: a different path. Core voice resolves its provider through the HOST, so a
+#: plugin-side configuration or connect refusal is exactly what it routes
+#: around. An audio refusal is the voice channel itself — core join opens the
+#: same channel and fails the same way — so pointing there would just waste the
+#: operator's next attempt.
+#: Keyed by literal so this module keeps its lazy ``talk_cli`` import (the
+#: import runs inside :func:`start_session` to avoid a cycle). The keys are
+#: pinned to ``talk_cli.STARTUP_REFUSAL_REASONS`` by a test, so a new reason
+#: cannot ship without a sentence and every sentence has a live reason.
+_STARTUP_REFUSAL_FAILURES = {
+    "configuration": (
+        "voice is not configured on this host — try `/talk core join`, or run "
+        "`hermes talk doctor` to see which setting is missing"
+    ),
+    "provider": (
+        "the voice provider refused the connection — try `/talk core join`, or "
+        "run `hermes talk doctor` to check the provider is reachable"
+    ),
+    "audio": "the voice channel would not open",
+    "tools": "the session's tools could not be prepared",
+}
+
+
+def _startup_refusal_failure(reason: str | None) -> str | None:
+    """Map a bounded refusal reason to its speakable line, or None."""
+
+    if reason is None:
+        return None
+    return _STARTUP_REFUSAL_FAILURES.get(reason)
+
+
 JOIN_USAGE = "Say `talk join` once I'm in a voice channel, or `talk leave` to hand it back."
 
 
@@ -1441,6 +1478,12 @@ def start_session(
 
     audio = DiscordAudio(bridge["guild_id"])
     generation = None
+    # Written by the session before it returns its exit code, read by _done
+    # after. Both run on this loop, so the write happens-before the read.
+    refusal: dict[str, str] = {}
+
+    def _note_refusal(reason: str) -> None:
+        refusal["reason"] = reason
 
     def _done(finished) -> None:
         global _LAST_FAILURE, _LAST_FAILURE_GENERATION
@@ -1465,10 +1508,18 @@ def start_session(
                             "the Discord voice connection liveness could not be verified",
                             "the Discord voice connection disconnected while I was listening",
                         }
+                        # A startup refusal knows exactly what refused; the
+                        # catch-all below is what an operator saw for every
+                        # one of them before (hermes-talk#58). A live bridge
+                        # failure still wins: it is the more specific cause
+                        # and it is the one that happens mid-session.
                         failure = (
                             bridge_failure
                             if bridge_failure in safe_bridge_failures
-                            else "session exited unsuccessfully"
+                            else (
+                                _startup_refusal_failure(refusal.get("reason"))
+                                or "session exited unsuccessfully"
+                            )
                         )
         except Exception as exc:  # noqa: BLE001 — a receipt must not raise
             failure = "session outcome unavailable"
@@ -1534,12 +1585,15 @@ def start_session(
         _SESSION_GENERATION += 1
         generation = _SESSION_GENERATION
         if host_execution_attachment is None:
-            session = talk_cli.run_talk_session(audio=audio, lane="discord")
+            session = talk_cli.run_talk_session(
+                audio=audio, lane="discord", on_refusal=_note_refusal
+            )
         else:
             session = talk_cli.run_talk_session(
                 audio=audio,
                 host_execution_attachment=host_execution_attachment,
                 lane="discord",
+                on_refusal=_note_refusal,
             )
         task = loop.create_task(session)
         task.add_done_callback(_done)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,6 +93,131 @@ def test_missing_audio_stack_exits_one_before_dialling(monkeypatch, capsys):
     assert "hermes-talk[audio]" in capsys.readouterr().err
 
 
+def _reasons(monkeypatch, **env):
+    """Run one session to refusal and return (exit_code, reasons_recorded)."""
+
+    seen: list[str] = []
+    for key, value in env.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+    code = asyncio.run(talk_cli.run_talk_session(on_refusal=seen.append))
+    assert set(seen) <= talk_cli.STARTUP_REFUSAL_REASONS, seen
+    return code, seen
+
+
+def test_a_configuration_refusal_names_itself(monkeypatch):
+    code, seen = _reasons(monkeypatch, OPENAI_API_KEY="sk-test", TALK_VOICE="not-a-voice")
+
+    assert code == 1
+    assert seen == [talk_cli.STARTUP_REFUSAL_CONFIGURATION]
+
+
+def test_an_audio_refusal_names_itself(monkeypatch):
+    def fail(_self):
+        raise talk_audio.TalkAudioError('run: pip install "hermes-talk[audio]"')
+
+    monkeypatch.setattr(talk_audio.DuplexAudio, "start", fail)
+
+    def never():  # pragma: no cover - must not be reached
+        raise AssertionError("dialled the provider without a working audio device")
+
+    monkeypatch.setattr(talk_cli, "_import_aiohttp", never)
+    code, seen = _reasons(monkeypatch, OPENAI_API_KEY="sk-test", TALK_VOICE=None)
+
+    assert code == 1
+    assert seen == [talk_cli.STARTUP_REFUSAL_AUDIO]
+
+
+def test_a_provider_refusal_names_itself(monkeypatch):
+    class _Audio:
+        played_ms = 0
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def read_input_chunk(self):  # pragma: no cover - connect never lands
+            raise AssertionError("read the microphone after a refused connect")
+
+        def queue_playback(self, _pcm):  # pragma: no cover - nothing plays
+            raise AssertionError("played audio after a refused connect")
+
+        def drain_playback(self):
+            pass
+
+        def reset_played_ms(self):
+            pass
+
+    class _RefusingSession:
+        async def connect(self, _setup):
+            raise ConnectionRefusedError("provider said no")
+
+        async def close(self):
+            pass
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("TALK_VOICE", raising=False)
+    seen: list[str] = []
+    code = asyncio.run(
+        talk_cli.run_talk_session(
+            audio=_Audio(),
+            session_factory=lambda _auth: _RefusingSession(),
+            on_refusal=seen.append,
+        )
+    )
+
+    assert code == 1
+    assert seen == [talk_cli.STARTUP_REFUSAL_PROVIDER]
+
+
+def test_a_legacy_tool_setup_failure_refuses_instead_of_crashing(monkeypatch, capsys):
+    """hermes-talk#58: the legacy lane has NO attachment to close.
+
+    The handler closed ``host_execution_attachment`` unconditionally, so on
+    the one lane that reaches it with ``None`` a tool-setup failure raised
+    ``AttributeError`` out of the session — and the operator's receipt named
+    that crash instead of the tool problem that actually refused.
+    """
+
+    def boom():
+        raise RuntimeError("tool catalog is unreadable")
+
+    monkeypatch.setattr(talk_cli.talk_tools, "default_talk_tools", boom)
+
+    def never(_self):  # pragma: no cover - must not be reached
+        raise AssertionError("opened audio after the tools refused")
+
+    monkeypatch.setattr(talk_audio.DuplexAudio, "start", never)
+    code, seen = _reasons(monkeypatch, OPENAI_API_KEY="sk-test", TALK_VOICE=None)
+
+    assert code == 1, "a legacy tool-setup failure must refuse, not raise"
+    assert seen == [talk_cli.STARTUP_REFUSAL_TOOLS]
+    assert "host tool setup failed" in capsys.readouterr().err
+
+
+def test_a_raising_refusal_hook_cannot_turn_a_refusal_into_a_crash(monkeypatch):
+    def explode(_reason):
+        raise RuntimeError("the receipt lane is broken")
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("TALK_VOICE", "not-a-voice")
+
+    assert asyncio.run(talk_cli.run_talk_session(on_refusal=explode)) == 1
+
+
+def test_a_session_with_no_refusal_hook_still_exits_one(monkeypatch):
+    """The exit-code contract is unchanged; the hook is purely additive."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("TALK_VOICE", "not-a-voice")
+
+    assert asyncio.run(talk_cli.run_talk_session()) == 1
+
+
 def test_slow_tool_does_not_block_inbound_barge_in(monkeypatch):
     """Receive and cancel keep moving while the serialized tool worker is busy."""
 

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -444,6 +444,145 @@ def test_legacy_join_receipt_and_status_label_the_limited_lane_and_core_parity(m
     asyncio.run(scenario())
 
 
+def _refusing_legacy_join(monkeypatch, reason):
+    """Drive one legacy join whose session refuses at startup for ``reason``.
+
+    Returns ``(receipt, status, delivered)`` — the join's own reply, the
+    ``talk status`` line afterwards, and every message pushed to the channel.
+    """
+
+    _connection, _receiver, _vc, adapter = _wired_host(monkeypatch)
+    delivered: list[str] = []
+
+    class _Channel:
+        async def send(self, content):
+            delivered.append(content)
+
+    adapter._voice_text_channels = {7: 123}
+    adapter._client = types.SimpleNamespace(get_channel=lambda channel_id: _Channel())
+
+    async def refuse(audio, *, on_refusal=None, **_kwargs):
+        if reason is not None:
+            on_refusal(reason)
+        return 1
+
+    monkeypatch.setattr(talk_cli, "run_talk_session", refuse)
+    return delivered
+
+
+def test_a_startup_refusal_is_spoken_with_its_reason_and_the_core_join_route(monkeypatch):
+    """hermes-talk#58: every startup failure read 'exited unsuccessfully'.
+
+    The session already knew which knob refused — it printed it to the
+    gateway's stderr and returned a bare 1 — so the one operator who needed
+    the reason was the one who never got it.
+    """
+
+    async def scenario():
+        delivered = _refusing_legacy_join(monkeypatch, talk_cli.STARTUP_REFUSAL_CONFIGURATION)
+
+        receipt = talk_discord.start_session(7)
+        assert "limited legacy provider-owned" in receipt.lower()
+        for _ in range(20):
+            if not talk_discord._SESSION:
+                break
+            await asyncio.sleep(0)
+        for _ in range(5):  # let the done callback's notification task run
+            await asyncio.sleep(0)
+
+        assert len(delivered) == 1
+        failure = delivered[0]
+        assert "voice is not configured" in failure
+        assert "/talk core join" in failure
+        assert "hermes talk doctor" in failure
+        assert "exited unsuccessfully" not in failure
+        # A refusal is a sentence, never a traceback.
+        assert "Traceback" not in failure and "Error" not in failure
+
+    asyncio.run(scenario())
+
+
+def test_an_audio_refusal_does_not_send_the_operator_to_core_join(monkeypatch):
+    """Core voice opens the SAME channel, so pointing there would waste a try."""
+
+    async def scenario():
+        delivered = _refusing_legacy_join(monkeypatch, talk_cli.STARTUP_REFUSAL_AUDIO)
+
+        talk_discord.start_session(7)
+        for _ in range(20):
+            if not talk_discord._SESSION:
+                break
+            await asyncio.sleep(0)
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert len(delivered) == 1
+        assert "the voice channel would not open" in delivered[0]
+        assert "core join" not in delivered[0].lower()
+
+    asyncio.run(scenario())
+
+
+def test_a_refusal_without_a_reason_keeps_the_generic_receipt(monkeypatch):
+    """An un-reported failure must degrade to the old line, never crash."""
+
+    async def scenario():
+        delivered = _refusing_legacy_join(monkeypatch, None)
+
+        talk_discord.start_session(7)
+        for _ in range(20):
+            if not talk_discord._SESSION:
+                break
+            await asyncio.sleep(0)
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert len(delivered) == 1
+        assert "session exited unsuccessfully" in delivered[0]
+
+    asyncio.run(scenario())
+
+
+def test_a_clean_legacy_session_never_delivers_a_failure_receipt(monkeypatch):
+    """The success path: exit 0 says nothing and leaves no failure on status."""
+
+    async def scenario():
+        delivered = _refusing_legacy_join(monkeypatch, None)
+
+        async def succeed(audio, *, on_refusal=None, **_kwargs):
+            assert on_refusal is not None, "the receipt lane lost its refusal sink"
+            return 0
+
+        monkeypatch.setattr(talk_cli, "run_talk_session", succeed)
+
+        receipt = talk_discord.start_session(7)
+        assert "limited legacy provider-owned" in receipt.lower()
+        for _ in range(20):
+            if not talk_discord._SESSION:
+                break
+            await asyncio.sleep(0)
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        assert delivered == []
+        assert "No live voice session" in talk_discord.session_status()
+
+    asyncio.run(scenario())
+
+
+def test_every_startup_refusal_reason_has_exactly_one_speakable_line():
+    """The mapping is keyed by literal (talk_cli imports lazily) — pin it."""
+
+    assert set(talk_discord._STARTUP_REFUSAL_FAILURES) == set(
+        talk_cli.STARTUP_REFUSAL_REASONS
+    )
+    for reason, line in talk_discord._STARTUP_REFUSAL_FAILURES.items():
+        assert talk_discord._startup_refusal_failure(reason) == line
+        assert line and len(line) < 200
+    assert talk_discord._startup_refusal_failure(None) is None
+    assert talk_discord._startup_refusal_failure("not-a-reason") is None
+
+
 def test_both_session_call_sites_pass_the_discord_lane(monkeypatch):
     """The lane line is only true if every path names its own room (#64)."""
 


### PR DESCRIPTION
Fixes #58

## What

A Discord `/talk join` that refuses **before going live** now names the reason. Two changes:

1. `run_talk_session` gains an optional `on_refusal` sink carrying one bounded code — `configuration` / `tools` / `audio` / `provider` (`talk_cli.STARTUP_REFUSAL_REASONS`). The `int` exit-code contract is unchanged; the hook is purely additive, and a hook that raises is suppressed rather than turning a clean refusal into an unrelated crash.
2. `talk_discord` maps each code to one fixed sentence in the fail-closed receipt (and therefore in `talk status` too).

Plus a latent crash fix on the same lane — see below.

## Why

The issue asks us to decide: make the legacy provider path work, or refuse it with a clear pointer at `/talk core join`.

**Read end to end, the legacy path is not dead code.** `__init__.py:186-194` routes `/talk join` to `talk_discord.start_session()` with no host attachment when the host does not expose `capture_realtime_execution_attachment`; that lands in the *same* `talk_cli.run_talk_session` the terminal lane runs, with its own limited toolset from `talk_tools.default_talk_tools()` (`talk_cli.py:1202-1206`). Refusing it outright would delete a working fallback for every host that does not expose that capability.

What was actually broken is that its failures were **unspeakable**. `run_talk_session` has four pre-live `return 1` sites — config/auth, tool setup, audio open, provider connect — and each one already knows exactly what refused. It prints that to the **gateway's stderr** and returns a bare `1`. The Discord `_done` callback then collapses all four into `"session exited unsuccessfully"`. The one person who could act on the reason was the only one who never saw it. That is the whole of the 08-20 report, and it is why the missing logs did not actually matter: the reason was never routed to the operator in the first place.

So: fix it *and* make the refusal actionable.

**Why `/talk core join` is offered for only two of the four.** Core voice resolves its provider through the **host** (`__init__.py:176-185` → `talk_core_realtime`), whereas the legacy lane resolves the plugin's own provider and auth (`talk_cli.py:1171-1179`). So a `configuration` or `provider` refusal is *exactly* what core join routes around — the pointer is real. An `audio` refusal is the Discord voice channel itself; core join opens the same channel and fails the same way, so pointing there would only waste the operator's next attempt. It gets `"the voice channel would not open"` instead.

A live bridge failure still wins the receipt: it is the more specific cause, and it is the one that happens mid-session rather than at startup.

## Also fixed: a latent crash on the legacy lane

```python
    except Exception as exc:  # noqa: BLE001 - host attachment startup boundary
        print(f"talk: host tool setup failed: {type(exc).__name__}", file=sys.stderr)
        host_execution_attachment.close()   # <- None on the legacy lane
        return 1
```

Every other refusal site in that function guards with `if host_execution_attachment is not None:`; this one did not. The legacy lane reaches it with `None`, so a tool-setup failure raised `AttributeError` **out of** the session — and the operator's receipt named that crash (`session error (AttributeError)`) instead of the tool problem that actually refused.

Proven fail-without-fix: with the guard removed, `test_a_legacy_tool_setup_failure_refuses_instead_of_crashing` fails with `AttributeError: 'NoneType' object has no attribute 'close'`.

## How to test

```bash
uv run pytest tests/test_cli.py tests/test_discord.py -q
uv run ruff check .
```

11 new tests:

**`tests/test_cli.py` (6)** — each of the four refusal reasons is reported and bounded (`set(seen) <= STARTUP_REFUSAL_REASONS`); the legacy tool-setup failure refuses instead of raising; a raising `on_refusal` hook cannot break the refusal; a session with no hook still exits 1 (contract unchanged).

**`tests/test_discord.py` (5)** — a configuration refusal is spoken with its reason **and** the core-join route, with no traceback in the receipt; an audio refusal deliberately does **not** point at core join; a refusal with no reason degrades to the old generic line; the **success path** delivers no failure receipt and leaves `talk status` clean; and the reason→sentence mapping is pinned to `talk_cli.STARTUP_REFUSAL_REASONS` (the map is keyed by literal because `talk_discord` imports `talk_cli` lazily to avoid a cycle, so a test holds the invariant instead of the import).

## Gates

- `uv run pytest -q` → **12 failed, 1586 passed, 2 skipped**. The 12 are the pre-existing env failures on this box (11 in `tests/test_capabilities.py`, 1 in `tests/test_cli.py::test_the_cli_lane_and_host_summary_ride_the_minted_prompt`) — they fail identically on untouched `main` (baseline before this branch: 12 failed, **1575** passed). Net +11, all green.
- `uv run ruff check .` → **All checks passed!**
- No line-ending flips: all touched files verified CRLF-only at byte level (0 bare LF). `talk_cli.py` shows one line of difference between `git diff --stat` and `--ignore-all-space --stat` — that is the deliberate re-indent of `host_execution_attachment.close()` under the new `if` guard, which `--ignore-all-space` collapses. Not a flip.

## What a live check would confirm

Not possible on this box (no Discord gateway, no voice channel). A live run would confirm the end-to-end wiring this PR's tests stub at the `run_talk_session` seam: that a real gateway `/talk join` against a deliberately broken `TALK_PROVIDER`/auth posts the configuration sentence *into the Discord channel* (not just to the returned string), that the message survives `_deliver_failure_receipt`'s channel-resolution path unmodified, and that `talk status` afterwards repeats the same actionable line. It would also confirm the receipt renders inside Discord's 2000-char limit with the backticked `/talk core join` intact — the tests bound each sentence under 200 chars but cannot see Discord's renderer.

— SmokeDev
