### PR TITLE
fix(audio): gate announcements on playback drain, not the server terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ named rather than smoothed.
   `AttributeError` out of the session instead of refusing. That lane has no
   host execution attachment, and the handler closed one unconditionally, so
   the crash — not the tool problem — was what reached the operator.
+- Proactive announcements now wait for the SPEAKER to drain, not just for the
+  server's `response.done`. The model streams far faster than realtime, so the
+  terminal event can arrive with a second of the previous answer still queued
+  locally — and the announcement started on top of it, overlapping two
+  responses at the only surface the operator actually has. `DuplexAudio` and
+  the Discord bridge gained a non-destructive `playback_pending`; the
+  announcement gate now consults it both in the pump's poll and in the
+  re-check inside the send lock, so the wire and the room are decided
+  together. A deferred announcement is delayed, never dropped.
+- An announcement deferred for longer than `ANNOUNCE_STARVATION_WARN_S`
+  (30s, 0 disables) now tells the operator once. Deferring is correct, but a
+  gate that never opens was previously a silent slow poll with nothing to see.
 - Linux terminal calls now route default audio through PulseAudio's WebRTC
   echo canceller and noise suppressor. Echo-cancelled input bypasses the
   fallback amplitude/VAD gate so barge-in does not clip quiet words.

--- a/talk_audio.py
+++ b/talk_audio.py
@@ -456,6 +456,26 @@ class DuplexAudio:
             return boundary
 
     @property
+    def playback_pending(self) -> bool:
+        """Whether model audio is still waiting to reach the speaker.
+
+        The non-destructive companion to :meth:`drain_playback`: it answers
+        "is the speaker still busy?" without discarding anything, which is
+        what an announcement needs. ``drain_playback`` is the barge-in verb —
+        asking it this question would throw away the audio being asked about.
+
+        The residual it CANNOT see is the device's own buffer: bytes already
+        handed to PortAudio in ``_output_callback`` are subtracted here but
+        have not physically been heard yet. That is one output block of
+        latency, not the seconds of queued response this exists to fence.
+        ``_residual`` (a partially consumed packet) is still counted, because
+        its bytes were never subtracted.
+        """
+
+        with self._lock:
+            return self._queued_playback_bytes > 0
+
+    @property
     def played_ms(self) -> int:
         """Milliseconds of the current response actually sent to the speaker."""
 

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -215,6 +215,11 @@ def _announcement_messages(headline: str, report: str) -> list[dict]:
 #: How the announcement pump waits for the wire to go idle. Session teardown
 #: cancels the pump; an active response is never overlapped just to meet a timer.
 ANNOUNCE_IDLE_POLL_S = 0.05
+#: How long one announcement may sit deferred before the operator is told.
+#: The busy predicate is a superset of the decline condition, so a predicate
+#: that never clears (a stuck continuation, a speaker that never drains)
+#: starves the pump as a silent slow poll with nothing to see. Zero disables.
+ANNOUNCE_STARVATION_WARN_S = 30.0
 #: Why a session refused BEFORE it went live. A lane that shows the operator a
 #: receipt (Discord) renders these; they are bounded codes, never exception
 #: text, because that receipt lands in a chat channel where a token, a path, or
@@ -685,8 +690,17 @@ def _announcement_sent(on_sent) -> None:
         on_sent()
 
 
+def _announcement_starved(on_starved, waited: float) -> None:
+    """Report a long deferral; reporting it must never take down the pump."""
+
+    if on_starved is None:
+        return
+    with suppress(Exception):
+        on_starved(waited)
+
+
 async def pump_announcements(
-    announce_queue, relay, ws, send_batch=None, response_busy=None
+    announce_queue, relay, ws, send_batch=None, response_busy=None, on_starved=None
 ) -> None:
     """Serialize every out-of-band announcement (Codex v0.6.1 finding 3).
 
@@ -703,6 +717,11 @@ async def pump_announcements(
     kept for tests — it has no such lock, so it remains check-then-act, and
     it drops a failed batch; provider-session sends surface failure to the
     supervisor.
+
+    ``on_starved`` is called at most once per batch when that deferral passes
+    :data:`ANNOUNCE_STARVATION_WARN_S`. Deferring is correct behaviour, so
+    this is not an error — but a predicate that never clears is
+    indistinguishable from a quiet session unless something says so.
     """
 
     while True:
@@ -711,8 +730,19 @@ async def pump_announcements(
             batch, on_sent = queued.commands, queued.on_sent
         else:
             batch, on_sent = queued, None
+        # Per BATCH, not per wait loop: a batch declined by send_batch goes
+        # round again, and its clock must keep running across that retry.
+        waiting_since: float | None = None
+        starved = False
         while True:
             while response_busy() if response_busy is not None else relay.response_active:
+                if waiting_since is None:
+                    waiting_since = time.monotonic()
+                elif not starved and ANNOUNCE_STARVATION_WARN_S > 0:
+                    waited = time.monotonic() - waiting_since
+                    if waited >= ANNOUNCE_STARVATION_WARN_S:
+                        starved = True
+                        _announcement_starved(on_starved, waited)
                 await asyncio.sleep(ANNOUNCE_IDLE_POLL_S)
             try:
                 if send_batch is None:
@@ -1324,6 +1354,26 @@ async def run_talk_session(
                 )
             )
 
+    def speaker_busy() -> bool:
+        """Whether the previous answer is still coming out of the speaker.
+
+        ``response.done`` says the SERVER stopped generating. It says nothing
+        about the audio already queued locally, so an announcement gated on it
+        alone can start while the last second of the previous response is
+        still playing — two responses overlapping at the only surface the
+        operator actually has (hermes-talk#50). This is the local half of that
+        gate; the protocol half stays exactly as it was.
+
+        Fails OPEN. An audio object without the property is treated as idle,
+        so an unfamiliar device degrades to the old timing rather than
+        starving announcements forever.
+        """
+
+        try:
+            return bool(audio.playback_pending)
+        except Exception:  # noqa: BLE001 — a gate, never a session boundary
+            return False
+
     def on_caption(text: str) -> None:
         print(text, end="", flush=True)
 
@@ -1417,11 +1467,16 @@ async def run_talk_session(
             """Serialize every provider write; keep multi-command batches contiguous.
 
             False means an announcement reached the front of the lock while a
-            response was open or about to be (``relay.response_active``) or a
+            response was open or about to be (``relay.response_active``), a
             ``StartResponse`` was sent but not yet confirmed
-            (``continuation_pending``), so it was not written. The caller
-            defers it instead of speaking over the model or racing an
-            in-flight continuation.
+            (``continuation_pending``), or the speaker had not finished the
+            previous answer (``speaker_busy``), so it was not written. The
+            caller defers it instead of speaking over the model, racing an
+            in-flight continuation, or overlapping audio at the speaker.
+
+            The speaker check belongs HERE and not only in the pump poll: the
+            poll is check-then-act, and this lock is the point where the write
+            actually happens, so the wire and the room are decided together.
             """
 
             nonlocal continuation_pending
@@ -1430,7 +1485,9 @@ async def run_talk_session(
                 # pump_announcements decides "the model is idle" BEFORE queuing
                 # for this lock, and a response can start while it waits there.
                 # Re-check at the point the write actually happens.
-                if is_announcement and (relay.response_active or continuation_pending):
+                if is_announcement and (
+                    relay.response_active or continuation_pending or speaker_busy()
+                ):
                     return False
                 if any(
                     isinstance(command, talk_realtime.StartResponse)
@@ -1771,6 +1828,10 @@ async def run_talk_session(
                     relay.response_active
                     or continuation_pending
                     or bool(tool_coordinator.outputs)
+                    or speaker_busy()
+                ),
+                lambda waited: on_error(
+                    f"an update has been waiting {waited:.0f}s for a safe opening"
                 ),
             )
         )
@@ -1938,6 +1999,7 @@ def cli_entry(args: argparse.Namespace | None = None) -> int:
 
 
 __all__ = [
+    "ANNOUNCE_STARVATION_WARN_S",
     "CONNECT_TIMEOUT_S",
     "IDLE_POLL_S",
     "STARTUP_REFUSAL_AUDIO",

--- a/talk_discord.py
+++ b/talk_discord.py
@@ -1,10 +1,11 @@
-"""Discord voice as an audio device — the same seven methods, a different room.
+"""Discord voice as an audio device — the same eight methods, a different room.
 
 :class:`DiscordAudio` implements exactly the surface
 :class:`talk_audio.DuplexAudio` exposes (``start`` / ``stop`` /
 ``read_input_chunk`` / ``queue_playback`` / ``drain_playback`` /
-``played_ms`` / ``reset_played_ms``), so the Realtime session, its tool
-calls, the steering ledger, and the announcement pump all run unchanged.
+``playback_pending`` / ``played_ms`` / ``reset_played_ms``), so the Realtime
+session, its tool calls, the steering ledger, and the announcement pump all
+run unchanged.
 Only the room changes: instead of a microphone and a speaker, the frames
 come from and go to a Discord voice channel.
 
@@ -269,6 +270,13 @@ class _RealtimeSource:
     def frames_served(self) -> int:
         with self._served_lock:
             return self._frames_served
+
+    @property
+    def carrying(self) -> bool:
+        """Whether a partial frame is still held back from the player."""
+
+        with self._carry_lock:
+            return bool(self._carry)
 
     def read(self) -> bytes:
         with self._carry_lock:
@@ -1132,6 +1140,27 @@ class DiscordAudio:
         if source is not None:
             source.cleanup()
         self._carry_sample = None
+
+    @property
+    def playback_pending(self) -> bool:
+        """Whether model audio is still waiting to reach the voice channel.
+
+        The same non-destructive question :attr:`talk_audio.DuplexAudio.
+        playback_pending` answers for the terminal, asked of the room the
+        host owns: frames still queued for the player thread, plus a partial
+        frame the source is holding back. What it cannot see is the host's
+        own player buffer — the same one-block residual the terminal has,
+        not the seconds of queued response this exists to fence.
+
+        Capture-only bridges never play, so they are never pending.
+        """
+
+        if self._capture_only:
+            return False
+        if not self._outbound.empty():
+            return True
+        source = self._source
+        return source is not None and source.carrying
 
     @property
     def played_ms(self) -> int:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -492,3 +492,42 @@ def test_concurrent_pulse_routes_restore_environment_in_either_order(
 
     assert talk_audio.os.environ["PULSE_SOURCE"] == "original-source"
     assert talk_audio.os.environ["PULSE_SINK"] == "original-sink"
+
+
+def test_playback_pending_tracks_unheard_audio_without_discarding_it():
+    """The non-destructive companion to drain_playback (hermes-talk#50).
+
+    Asking `drain_playback` "is the speaker busy?" would throw away the very
+    audio being asked about, so the announcement gate needs its own signal.
+    """
+
+    audio = talk_audio.DuplexAudio()
+    assert audio.playback_pending is False
+
+    audio.queue_playback(b"\x01\x02" * 480, "item-1")
+    assert audio.playback_pending is True
+    # Reading it again must not have consumed anything.
+    assert audio.playback_pending is True
+
+    # Nothing was PLAYED, so the heard boundary is empty — drain still clears
+    # the queue, which is exactly what playback_pending must then report.
+    assert audio.drain_playback() == (None, 0)
+    assert audio.playback_pending is False
+
+
+def test_playback_pending_stays_true_while_a_partial_packet_is_held():
+    """A residual is unheard audio too — it must not read as drained."""
+
+    audio = talk_audio.DuplexAudio()
+    audio.queue_playback(b"\x01\x02" * 480, "item-1")
+
+    with audio._lock:  # take less than one packet, as the output callback does
+        taken = audio._take_playback(talk_audio.FRAME_BYTES * 10)
+
+    assert len(taken) == talk_audio.FRAME_BYTES * 10
+    assert audio._residual is not None
+    assert audio.playback_pending is True
+
+    with audio._lock:  # drain the rest
+        audio._take_playback(talk_audio.MAX_PLAYBACK_BYTES)
+    assert audio.playback_pending is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -508,7 +508,7 @@ def test_concurrent_announcement_cannot_split_speaker_context_from_pcm(monkeypat
 
     ws = _WS()
 
-    async def competing_pump(_queue, _relay, _ws, send_batch, _response_busy):
+    async def competing_pump(_queue, _relay, _ws, send_batch, _response_busy, _on_starved=None):
         await ws.speaker_create_seen.wait()
         await send_batch(
             [
@@ -1459,7 +1459,7 @@ def test_send_outgoing_declines_a_racing_announcement_under_the_real_lock(monkey
     ws = _WS()
     declined = []
 
-    async def racing_pump(_queue, relay, _ws, send_batch, _response_busy):
+    async def racing_pump(_queue, relay, _ws, send_batch, _response_busy, _on_starved=None):
         # Simulate: pump_announcements saw idle and queued for send_lock, but
         # a response actually started before send_batch acquired the lock.
         relay._start_response("resp_1")
@@ -1505,6 +1505,393 @@ def test_send_outgoing_declines_a_racing_announcement_under_the_real_lock(monkey
     assert asyncio.run(asyncio.wait_for(talk_cli.run_talk_session(audio=_Audio()), 3.0)) == 0
     assert declined == [False]  # the real in-lock check said no
     assert not any(message.get("item", {}).get("id") == "ann-1" for message in ws.sent)
+
+
+def test_an_announcement_waits_for_the_speaker_to_drain(monkeypatch):
+    """hermes-talk#50: `response.done` is the SERVER, not the speaker.
+
+    The model streams far faster than realtime, so the terminal event can
+    arrive with a second of that answer still queued locally. An announcement
+    written on the terminal alone overlaps the previous response at the only
+    surface the operator actually has.
+    """
+
+    monkeypatch.setattr(talk_cli, "ANNOUNCE_IDLE_POLL_S", 0.01)
+
+    async def scenario():
+        announce_queue: asyncio.Queue = asyncio.Queue()
+        playing = {"value": True}  # server done, speaker still going
+        attempts: list[tuple] = []
+
+        async def send_batch(batch, *, is_announcement=False):
+            assert is_announcement
+            attempts.append(tuple(batch))
+            return True
+
+        pump = asyncio.create_task(
+            talk_cli.pump_announcements(
+                announce_queue,
+                _StubRelay(),  # response_active is False: the server is done
+                None,
+                send_batch,
+                lambda: playing["value"],
+            )
+        )
+        announce_queue.put_nowait(talk_cli.landed_note_messages("sa-0-aaaa"))
+        await asyncio.sleep(0.08)
+        while_playing = list(attempts)
+
+        playing["value"] = False  # the speaker drains
+        for _ in range(300):
+            if attempts:
+                break
+            await asyncio.sleep(0.01)
+        pump.cancel()
+        return while_playing, attempts
+
+    while_playing, attempts = asyncio.run(scenario())
+
+    assert while_playing == [], "spoke over audio the operator was still hearing"
+    assert len(attempts) == 1, "the deferred announcement was dropped, not delayed"
+
+
+def test_a_deferred_announcement_is_delivered_in_order_not_dropped(monkeypatch):
+    """Deferral must not reorder or lose the flip that marks it delivered."""
+
+    monkeypatch.setattr(talk_cli, "ANNOUNCE_IDLE_POLL_S", 0.01)
+
+    async def scenario():
+        announce_queue: asyncio.Queue = asyncio.Queue()
+        playing = {"value": True}
+        sent: list[str] = []
+        flipped: list[str] = []
+
+        async def send_batch(batch, *, is_announcement=False):
+            sent.append(batch[0].item_id)
+            return True
+
+        pump = asyncio.create_task(
+            talk_cli.pump_announcements(
+                announce_queue,
+                _StubRelay(),
+                None,
+                send_batch,
+                lambda: playing["value"],
+            )
+        )
+        for name in ("first", "second"):
+            announce_queue.put_nowait(
+                talk_cli.QueuedAnnouncement(
+                    [talk_cli.talk_realtime.AddContext(item_id=name, text=name)],
+                    lambda n=name: flipped.append(n),
+                )
+            )
+        await asyncio.sleep(0.05)
+        assert flipped == [], "a queued batch was marked delivered before the wire"
+
+        playing["value"] = False
+        for _ in range(300):
+            if len(sent) == 2:
+                break
+            await asyncio.sleep(0.01)
+        pump.cancel()
+        return sent, flipped
+
+    sent, flipped = asyncio.run(scenario())
+
+    assert sent == ["first", "second"]
+    assert flipped == ["first", "second"]
+
+
+def test_the_starvation_warning_fires_once_after_the_threshold(monkeypatch):
+    """A predicate that never clears is a silent slow poll unless it speaks."""
+
+    monkeypatch.setattr(talk_cli, "ANNOUNCE_IDLE_POLL_S", 0.01)
+    monkeypatch.setattr(talk_cli, "ANNOUNCE_STARVATION_WARN_S", 0.05)
+
+    async def scenario():
+        announce_queue: asyncio.Queue = asyncio.Queue()
+        warned: list[float] = []
+
+        async def send_batch(_batch, *, is_announcement=False):  # pragma: no cover
+            raise AssertionError("wrote while the predicate said busy")
+
+        pump = asyncio.create_task(
+            talk_cli.pump_announcements(
+                announce_queue,
+                _StubRelay(),
+                None,
+                send_batch,
+                lambda: True,  # never clears
+                warned.append,
+            )
+        )
+        announce_queue.put_nowait(talk_cli.landed_note_messages("sa-0-aaaa"))
+        await asyncio.sleep(0.02)
+        early = list(warned)
+        await asyncio.sleep(0.2)
+        pump.cancel()
+        return early, warned
+
+    early, warned = asyncio.run(scenario())
+
+    assert early == [], "warned before the threshold"
+    assert len(warned) == 1, "the warning repeated instead of firing once per batch"
+    assert warned[0] >= 0.05
+
+
+def test_a_starvation_warning_that_raises_cannot_take_down_the_pump(monkeypatch):
+    monkeypatch.setattr(talk_cli, "ANNOUNCE_IDLE_POLL_S", 0.01)
+    monkeypatch.setattr(talk_cli, "ANNOUNCE_STARVATION_WARN_S", 0.02)
+
+    async def scenario():
+        announce_queue: asyncio.Queue = asyncio.Queue()
+        busy = {"value": True}
+        attempts: list[tuple] = []
+
+        def explode(_waited):
+            raise RuntimeError("the warning sink is broken")
+
+        async def send_batch(batch, *, is_announcement=False):
+            attempts.append(tuple(batch))
+            return True
+
+        pump = asyncio.create_task(
+            talk_cli.pump_announcements(
+                announce_queue,
+                _StubRelay(),
+                None,
+                send_batch,
+                lambda: busy["value"],
+                explode,
+            )
+        )
+        announce_queue.put_nowait(talk_cli.landed_note_messages("sa-0-aaaa"))
+        await asyncio.sleep(0.08)
+        busy["value"] = False
+        for _ in range(300):
+            if attempts:
+                break
+            await asyncio.sleep(0.01)
+        alive = not pump.done()
+        pump.cancel()
+        return alive, attempts
+
+    alive, attempts = asyncio.run(scenario())
+
+    assert alive, "a broken warning sink killed the pump"
+    assert len(attempts) == 1
+
+
+def test_a_zero_threshold_disables_the_starvation_warning(monkeypatch):
+    monkeypatch.setattr(talk_cli, "ANNOUNCE_IDLE_POLL_S", 0.01)
+    monkeypatch.setattr(talk_cli, "ANNOUNCE_STARVATION_WARN_S", 0.0)
+
+    async def scenario():
+        announce_queue: asyncio.Queue = asyncio.Queue()
+        warned: list[float] = []
+
+        async def send_batch(_batch, *, is_announcement=False):  # pragma: no cover
+            raise AssertionError("wrote while busy")
+
+        pump = asyncio.create_task(
+            talk_cli.pump_announcements(
+                announce_queue, _StubRelay(), None, send_batch, lambda: True, warned.append
+            )
+        )
+        announce_queue.put_nowait(talk_cli.landed_note_messages("sa-0-aaaa"))
+        await asyncio.sleep(0.1)
+        pump.cancel()
+        return warned
+
+    assert asyncio.run(scenario()) == []
+
+
+def _speaker_gate_harness(monkeypatch, audio, pump_factory):
+    """Drive the REAL send_outgoing/send_lock with a given audio + pump."""
+
+    class _WS:
+        def __init__(self):
+            self.sent: list[dict] = []
+            self.done = asyncio.Event()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def send_json(self, message):
+            self.sent.append(message)
+            await asyncio.sleep(0)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            await self.done.wait()
+            raise StopAsyncIteration
+
+    ws = _WS()
+
+    class _ClientSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def ws_connect(self, *_args, **_kwargs):
+            return ws
+
+    host = types.SimpleNamespace(
+        resolve_auth=lambda: types.SimpleNamespace(token="token", source="test"),
+        identity_sections=lambda: {},
+    )
+    monkeypatch.setattr(talk_cli.talk_host, "host", lambda: host)
+    monkeypatch.setattr(talk_cli.talk_apiserver, "warm_in_background", lambda: None)
+    monkeypatch.setattr(
+        talk_cli,
+        "_mint_session",
+        lambda *a, **k: types.SimpleNamespace(client_secret="ephemeral"),
+    )
+    monkeypatch.setattr(talk_cli, "pump_announcements", pump_factory(ws))
+    monkeypatch.setattr(
+        talk_cli,
+        "_import_aiohttp",
+        lambda: types.SimpleNamespace(
+            ClientSession=_ClientSession,
+            WSMsgType=types.SimpleNamespace(TEXT="text"),
+        ),
+    )
+    code = asyncio.run(asyncio.wait_for(talk_cli.run_talk_session(audio=audio), 3.0))
+    return code, ws
+
+
+class _GateAudio:
+    """Audio whose speaker state the test drives directly."""
+
+    played_ms = 0
+
+    def __init__(self, pending):
+        self.playback_pending = pending
+        self.stopped = False
+
+    def start(self):
+        pass
+
+    def stop(self):
+        self.stopped = True
+
+    def read_input_packet(self):
+        return None
+
+    def queue_playback(self, _pcm):
+        pass
+
+    def drain_playback(self):
+        pass
+
+    def reset_played_ms(self):
+        pass
+
+
+def test_send_outgoing_declines_an_announcement_while_the_speaker_is_busy(monkeypatch):
+    """The in-lock re-check, not just the poll: the write point decides.
+
+    The poll is check-then-act — playback can resume between "idle" and the
+    send lock. This drives the real send_outgoing through the real lock with
+    a speaker that is still playing and a server that is idle, which is
+    exactly the window `response.done` cannot see.
+    """
+
+    declined: list[bool] = []
+
+    def pump_factory(ws):
+        async def racing_pump(_queue, _relay, _ws, send_batch, _busy, _on_starved=None):
+            ok = await send_batch(
+                [talk_cli.talk_realtime.AddContext(item_id="ann-1", text="hi")],
+                is_announcement=True,
+            )
+            declined.append(ok)
+            ws.done.set()
+            await asyncio.Event().wait()
+
+        return racing_pump
+
+    code, ws = _speaker_gate_harness(monkeypatch, _GateAudio(True), pump_factory)
+
+    assert code == 0
+    assert declined == [False], "wrote an announcement over live playback"
+    assert not any(message.get("item", {}).get("id") == "ann-1" for message in ws.sent)
+
+
+def test_send_outgoing_writes_an_announcement_once_the_speaker_is_quiet(monkeypatch):
+    """The gate must open again — a drained speaker is a safe opening."""
+
+    accepted: list[bool] = []
+
+    def pump_factory(ws):
+        async def quiet_pump(_queue, _relay, _ws, send_batch, _busy, _on_starved=None):
+            ok = await send_batch(
+                [talk_cli.talk_realtime.AddContext(item_id="ann-1", text="hi")],
+                is_announcement=True,
+            )
+            accepted.append(ok)
+            ws.done.set()
+            await asyncio.Event().wait()
+
+        return quiet_pump
+
+    code, ws = _speaker_gate_harness(monkeypatch, _GateAudio(False), pump_factory)
+
+    assert code == 0
+    assert accepted == [True]
+    assert any(message.get("item", {}).get("id") == "ann-1" for message in ws.sent)
+
+
+def test_an_audio_device_without_the_drain_signal_never_starves_the_pump(monkeypatch):
+    """Fail OPEN: an unfamiliar device degrades to the old timing."""
+
+    class _NoSignalAudio(_GateAudio):
+        def __init__(self):
+            super().__init__(False)
+            del self.playback_pending  # the property simply does not exist
+
+    accepted: list[bool] = []
+
+    def pump_factory(ws):
+        async def quiet_pump(_queue, _relay, _ws, send_batch, _busy, _on_starved=None):
+            accepted.append(
+                await send_batch(
+                    [talk_cli.talk_realtime.AddContext(item_id="ann-1", text="hi")],
+                    is_announcement=True,
+                )
+            )
+            ws.done.set()
+            await asyncio.Event().wait()
+
+        return quiet_pump
+
+    code, _ws = _speaker_gate_harness(monkeypatch, _NoSignalAudio(), pump_factory)
+
+    assert code == 0
+    assert accepted == [True]
+
+
+def test_the_production_busy_predicate_includes_the_speaker():
+    """The gate is only real if the shipped predicate carries it (#50)."""
+
+    source = inspect.getsource(talk_cli.run_talk_session)
+    start = source.index("pump = asyncio.create_task(")
+    predicate = source[start : source.index("tool_worker = asyncio.create_task(", start)]
+
+    assert "speaker_busy()" in predicate
+    # And the in-lock re-check, which is the one that owns the wire.
+    lock_check = source[
+        source.index("async def send_outgoing") : source.index("async def send_microphone")
+    ]
+    assert "speaker_busy()" in lock_check
 
 
 def test_subagent_stop_messages_cap_the_summary_tail():

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -46,14 +46,17 @@ def _tone(samples: int, *, rate: int, freq: float = 440.0, stereo: bool = False)
 
 
 def test_bridge_wears_the_audio_device_surface():
-    # The session calls exactly these seven. If DuplexAudio grows an eighth,
+    # The session calls exactly these eight. If DuplexAudio grows a ninth,
     # this test is what tells us the Discord room needs it too.
+    # playback_pending joined in hermes-talk#50: the announcement gate needs
+    # to ask whether the room is still speaking WITHOUT draining it.
     surface = (
         "start",
         "stop",
         "read_input_chunk",
         "queue_playback",
         "drain_playback",
+        "playback_pending",
         "played_ms",
         "reset_played_ms",
     )
@@ -231,6 +234,39 @@ def test_source_reassembles_across_chunk_boundaries():
     first = source.read()
     assert len(first) == talk_discord.DISCORD_FRAME_BYTES
     assert source.frames_served == 1
+
+
+def test_playback_pending_covers_the_queue_and_the_held_partial_frame():
+    """The room's own drain signal, non-destructive (hermes-talk#50)."""
+
+    bridge = talk_discord.DiscordAudio()
+    assert bridge.playback_pending is False
+
+    bridge.queue_playback(b"\x01\x02" * 600)
+    assert bridge.playback_pending is True
+    assert bridge.playback_pending is True  # reading it consumes nothing
+
+    bridge.drain_playback()
+    assert bridge.playback_pending is False
+
+
+def test_playback_pending_sees_a_partial_frame_the_source_still_holds():
+    frames: queue.Queue = queue.Queue()
+    source = talk_discord._RealtimeSource(frames)
+    assert source.carrying is False
+
+    frames.put(b"\x01\x02" * 10)  # far less than one Discord frame
+    assert source.read() == talk_discord.SILENCE_FRAME  # underrun; carry kept
+    assert source.carrying is True
+
+    source.cleanup()
+    assert source.carrying is False
+
+
+def test_a_capture_only_bridge_is_never_pending():
+    """Capture-only never plays, so it can never hold the gate shut."""
+
+    assert talk_discord.DiscordAudio(capture_only=True).playback_pending is False
 
 
 def test_source_is_not_opus():


### PR DESCRIPTION
Fixes #50 (item 1 + comment item 3; items 2-4 deliberately left open — reasoning below)

## What

An announcement can no longer start while the previous answer is still coming out of the speaker.

- `talk_audio.DuplexAudio` and `talk_discord.DiscordAudio` gain a **non-destructive** `playback_pending`.
- The announcement gate consults it in **both** places: the pump's busy predicate, and the re-check inside the send lock.
- An announcement deferred past `ANNOUNCE_STARVATION_WARN_S` (30s, `0` disables) now tells the operator once.

## Why

The "model is idle" signal driving announcements was the server terminal:

```python
lambda: (
    relay.response_active            # server says a response is open
    or continuation_pending          # a StartResponse is unconfirmed
    or bool(tool_coordinator.outputs)
),
```

All three are protocol state. None of them knows whether the *speaker* is still playing. The model streams far faster than realtime, so `response.done` routinely lands with a second of that answer still queued in `audio._playback` — and the announcement was written on top of it. #38 demanded the drain/terminal distinction; the fence work serialized the protocol layer, and this closes the audible one, which is the only layer the operator actually experiences.

**Why a new signal and not `drain_playback()`.** `drain_playback` is the *barge-in* verb: it discards unheard audio and returns the heard boundary (`talk_audio.py:439-456`). Asking it "is the speaker busy?" would throw away the very audio being asked about. `playback_pending` is the read-only companion — `_queued_playback_bytes > 0`, which already includes the partially-consumed `_residual` because those bytes were never subtracted in `_take_playback`.

**What it honestly cannot see:** bytes already handed to PortAudio (or the host's Discord player) in the output callback are subtracted but not yet physically heard. That is one output block of latency — not the seconds of queued response this exists to fence. Both docstrings say so rather than overclaiming.

**Why the gate is in two places.** The pump's poll is check-then-act; playback can resume between "idle" and acquiring the send lock. The in-lock re-check is the point where the write actually happens, so the wire and the room are now decided together. The pump's predicate remains a strict superset of `send_outgoing`'s decline condition, so the existing retry contract is unchanged: a declined batch waits and goes again, in its original order.

**Fails open.** An audio object without the property reads as idle, so an unfamiliar device degrades to the old timing instead of starving announcements forever. The starvation warning is the matching safety valve: deferring is correct behaviour, but a predicate that never clears was previously a silent slow poll with nothing to see.

The `DuplexAudio` surface grew from seven methods to eight. `test_bridge_wears_the_audio_device_surface` exists to catch exactly that ("If DuplexAudio grows an eighth, this test is what tells us the Discord room needs it too") and was updated with it, along with the `talk_discord` module docstring that names the surface.

## On #34

Re-read as asked. **This closes half of #34's "speak only at an interruption-safe opening", and I am not claiming the other half.**

- **Satisfied — the model side.** An announcement can no longer begin while the previous response is still audible. Proof line, `talk_cli.py` `send_outgoing`: `if is_announcement and (relay.response_active or continuation_pending or speaker_busy()): return False`, plus `speaker_busy()` in the pump predicate.
- **Not satisfied — the operator side.** "Never talk over the operator" needs a *speech-in-flight* flag, and nothing tracks one. `talk_relay.py` maps `input_audio_buffer.speech_started` (line 715, and `rt.SpeechStarted` at line 447) straight into barge-in, and there is **no handler at all** for `input_audio_buffer.speech_stopped` / `rt.SpeechStopped`. So the relay knows the instant the operator starts and never learns when they stop; an announcement while the operator is mid-utterance with no response open is still possible.

Leaving #34 open, per instruction. Its remaining work is the operator-side flag (and the delivery-policy taxonomy from the protoVoice recon comment).

## Items 2-4: deliberately not in this PR

- **Item 2 (idle-window fail-open)** — the safer-looking fix is worse. Refusing a stamped, non-settled id when no response is active would mute a *single*-fault case (a dropped `response.created` while a real response streams) in order to fix a *double*-fault one (both `created` and `done` missed). `_belongs_to_active` documents that trade deliberately: "muting real speech is the worse failure". I did not want to silently invert it inside an audio PR.
- **Item 3 (eviction vs replay inversion)** — same shape. Refusing a named `response.created` that arrives while a different named response is in flight closes the inversion with no extra memory, but it regresses the lost-terminal case: `_finish_response` never runs, `_response_in_flight` stays `True`, and the next genuine response is refused — muting the rest of the call. Today that case recovers by adopting the new response. `_release_lost_terminal` only fires on a second barge-in, so there is no general escape hatch to lean on. Raising `MAX_SETTLED_RESPONSES` only moves the hole, it does not close the class.
- **Item 4 (dual dispatch consolidation)** — a refactor of `handle_event`/`handle_realtime_event`, which the issue itself rates as mitigated by parity tests. It does not belong in a reliability fix.

Recommend #50 stays open for 2-4.

## How to test

```bash
uv run pytest tests/test_cli.py tests/test_audio.py tests/test_discord.py -q
uv run ruff check .
```

15 new tests:

**Gate behaviour** — an announcement waits for the speaker to drain while the server is already idle (the exact window `response.done` cannot see); a deferred announcement is delivered in order and its delivery flip fires only after the wire, never while queued.

**The in-lock boundary** — driving the **real** `send_outgoing` through the **real** send lock: declined while the speaker is busy (and `ann-1` never reaches the socket), accepted once the speaker is quiet, and accepted for a device with no `playback_pending` at all (fail-open). Plus a source-level test that the *shipped* predicate and the *shipped* in-lock check both carry `speaker_busy()` — a gate that only exists in a stub is not a gate.

**Starvation valve** — fires once after the threshold and not before; a warning sink that raises cannot take down the pump; `0` disables it.

**The signal itself** — `playback_pending` is true while queued and false after drain, and reading it consumes nothing; it stays true while a partial packet sits in `_residual`; the Discord bridge covers both its queue and the partial frame `_RealtimeSource` holds back; a capture-only bridge is never pending.

Two pre-existing test stubs that stand in for `pump_announcements` gained the new `on_starved` parameter — the production signature grew, so a stub impersonating it has to match.

## Gates

- `uv run pytest -q` → **11 failed, 1590 passed, 2 skipped**. All 11 are the pre-existing `tests/test_capabilities.py` env failures on this box. The 12th known failure (`test_cli.py::test_the_cli_lane_and_host_summary_ride_the_minted_prompt`) is order-dependent under `pytest-randomly` and passed in this run; the baseline on untouched `main` is 12 failed / 1575 passed. Net +15 tests, all green.
- `uv run ruff check .` → **All checks passed!**
- No line-ending flips: `git diff --stat` is byte-identical to `git diff --ignore-all-space --stat` for every file, and all seven verified CRLF-only (0 bare LF).

## What a live check would confirm

Not possible on this box (no audio device, no Discord gateway, no provider socket). Every test above stubs either the audio device or the wire. A live call would confirm the two things only real hardware shows: that `playback_pending` actually goes false at roughly the moment the operator stops hearing the answer — i.e. that the one output block of device-buffer residual really is inaudible rather than a perceptible clip of overlap — and that the announcement lands as a clean gap rather than a stutter on a real PortAudio device and a real Discord voice channel, where the host's player thread adds buffering this code cannot observe. It would also confirm the 30s starvation warning reads sensibly in a real call rather than firing during normal long turns.

— SmokeDev
