### PR TITLE
fix(core): enforce the ledger-presence invariant at session setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@ named rather than smoothed.
 - An announcement deferred for longer than `ANNOUNCE_STARVATION_WARN_S`
   (30s, 0 disables) now tells the operator once. Deferring is correct, but a
   gate that never opens was previously a silent slow poll with nothing to see.
+- A voice session whose transport declares remote speakers
+  (`discord_speaker_authorization`) but carries no authorization ledger is now
+  REFUSED at session setup, before a secret is minted or a socket is opened.
+  That equivalence held by construction and was asserted only in a comment
+  several hundred lines from where it is relied on — and the branch relying on
+  it silently selects the allow-all `local_operator_authorizer`, so a
+  construction bug would have handed every speaker in a voice channel full
+  operator authority with nothing anywhere refusing. It refuses through the
+  same bounded-reason sink every other startup refusal uses, so a Discord
+  `talk join` says what happened instead of "session exited unsuccessfully" —
+  and that sentence does not offer `/talk core join`, which would take the
+  same channel with the same speakers and refuse identically.
+- An unnamed tool call is now identified the same way on every path. The two
+  authorizer call sites disagreed (`"tool"` when revoking a permit, `""` when
+  authorizing one), so the identity a nameless event was revoked under was not
+  the identity it would have been authorized under. One helper answers for
+  both, and it returns `""` — which cannot collide with a registered tool, a
+  classification set, or a permit's recorded action.
 - Linux terminal calls now route default audio through PulseAudio's WebRTC
   echo canceller and noise suppressor. Echo-cancelled input bypasses the
   fallback amplitude/VAD gate so barge-in does not clip quiet words.

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -229,12 +229,18 @@ STARTUP_REFUSAL_CONFIGURATION = "configuration"
 STARTUP_REFUSAL_TOOLS = "tools"
 STARTUP_REFUSAL_AUDIO = "audio"
 STARTUP_REFUSAL_PROVIDER = "provider"
+#: The transport hears speakers the session cannot authorize. Unlike the four
+#: above this is not a knob the operator forgot to set — it is a wiring
+#: contradiction inside this process, so its sentence points at the host, not
+#: at a setting.
+STARTUP_REFUSAL_AUTHORIZATION = "authorization"
 STARTUP_REFUSAL_REASONS = frozenset(
     {
         STARTUP_REFUSAL_CONFIGURATION,
         STARTUP_REFUSAL_TOOLS,
         STARTUP_REFUSAL_AUDIO,
         STARTUP_REFUSAL_PROVIDER,
+        STARTUP_REFUSAL_AUTHORIZATION,
     }
 )
 TOOL_SESSION_QUEUE_SIZE = 1
@@ -515,6 +521,25 @@ class ToolResponseCoordinator:
                     self.queue.task_done()
 
 
+def _event_tool_name(event: dict) -> str:
+    """The provider's tool name for this event, or "" when it gave none.
+
+    Empty, never a stand-in like ``"tool"``. Every downstream comparison is
+    exact-match — ``READ_ONLY_TALK_TOOLS`` / ``MUTATING_TALK_TOOLS``
+    membership, ``classify_host_tool``, and the ledger's ``permit.action !=
+    name`` rename tripwire — so an unnamed call has to be matched as the
+    unknown it is. A synthetic name could one day BE a registered tool and
+    would then be classified as one.
+
+    Both authorizer call sites read the name through here: they disagreed
+    (``"tool"`` in :meth:`HostExecutionRelay._consume_tool_attempt`, ``""``
+    in the batch path), which meant the same nameless event was revoked under
+    a different identity than it would have been authorized under.
+    """
+
+    return str(event.get("name") or "")
+
+
 def local_operator_authorizer(tool_name: str, event: dict) -> None:
     """Grant speaker authority for a session with no remote speakers.
 
@@ -588,7 +613,7 @@ class HostExecutionRelay:
     def _consume_tool_attempt(self, event: dict) -> None:
         """Consume a bound call permit on any terminal non-execution path."""
 
-        self.tool_authorizer(str(event.get("name") or "tool"), event)
+        self.tool_authorizer(_event_tool_name(event), event)
 
     def discard_tool_event(self, event: dict) -> None:
         """Revoke a queued tool event that session teardown will never execute."""
@@ -623,7 +648,7 @@ class HostExecutionRelay:
             # event["arguments"] string read below — nothing rewrites the
             # dict in between, so the authorized and executed arguments
             # cannot diverge.
-            name = str(event.get("name") or "")
+            name = _event_tool_name(event)
             denial = self.tool_authorizer(name, event)
             if denial is None:
                 # WHO may act is settled; WHAT may run on this thread is a
@@ -1314,6 +1339,23 @@ async def run_talk_session(
         if discord_authorization
         else None
     )
+    # ENFORCED, not documented: `authorization_ledger is None` has to mean
+    # "this transport declared no remote speakers". It holds by construction
+    # three lines up, but the place that RELIES on it is the tool-authorizer
+    # wiring far below, where a None ledger silently selects the allow-all
+    # `local_operator_authorizer`. A transport that hears a whole voice
+    # channel must never reach that branch, so the contradiction is refused
+    # here — before a secret is minted or a socket is opened — instead of
+    # being trusted across a few hundred lines (hermes-talk#47).
+    if discord_authorization and authorization_ledger is None:
+        print(
+            "talk: refusing a multi-speaker session with no authorization "
+            "ledger — every speaker would inherit operator authority",
+            file=sys.stderr,
+        )
+        if host_execution_attachment is not None:
+            host_execution_attachment.close()
+        return refuse(STARTUP_REFUSAL_AUTHORIZATION)
     try:
         audio.start()
     except talk_audio.TalkAudioError as exc:
@@ -1584,9 +1626,11 @@ async def run_talk_session(
                         authorization_ledger.authorize_tool
                         if authorization_ledger is not None
                         # No ledger means the transport declared no remote
-                        # speakers (audio.discord_speaker_authorization is
-                        # False): the local operator is the only voice, so
-                        # the allow-all is named, not accidental.
+                        # speakers: session setup above REFUSES the session
+                        # outright when discord_speaker_authorization is true
+                        # and the ledger is absent, so reaching this branch
+                        # proves the local operator is the only voice and the
+                        # allow-all is named, not accidental.
                         else local_operator_authorizer
                     ),
                 )
@@ -2003,6 +2047,7 @@ __all__ = [
     "CONNECT_TIMEOUT_S",
     "IDLE_POLL_S",
     "STARTUP_REFUSAL_AUDIO",
+    "STARTUP_REFUSAL_AUTHORIZATION",
     "STARTUP_REFUSAL_CONFIGURATION",
     "STARTUP_REFUSAL_PROVIDER",
     "STARTUP_REFUSAL_REASONS",

--- a/talk_discord.py
+++ b/talk_discord.py
@@ -1266,6 +1266,13 @@ _STARTUP_REFUSAL_FAILURES = {
     ),
     "audio": "the voice channel would not open",
     "tools": "the session's tools could not be prepared",
+    # No `/talk core join` pointer: this refusal is a wiring contradiction in
+    # this process, not a setting the operator got wrong, and core join takes
+    # the same channel with the same speakers — it would refuse identically.
+    "authorization": (
+        "I can't tell this channel's speakers apart, so I won't take voice "
+        "authority from them — this needs a fix on the host, not a retry"
+    ),
 }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -218,6 +218,120 @@ def test_a_session_with_no_refusal_hook_still_exits_one(monkeypatch):
     assert asyncio.run(talk_cli.run_talk_session()) == 1
 
 
+class _RemoteSpeakerAudio:
+    """A transport that declares it hears speakers other than the operator."""
+
+    played_ms = 0
+    discord_speaker_authorization = True
+
+    def __init__(self):
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        pass
+
+    def read_input_chunk(self):  # pragma: no cover - the session never runs
+        return None
+
+    def queue_playback(self, _pcm):  # pragma: no cover - the session never runs
+        pass
+
+    def drain_playback(self):
+        pass
+
+    def reset_played_ms(self):
+        pass
+
+
+def test_a_multi_speaker_transport_without_a_ledger_is_refused(monkeypatch, capsys):
+    """hermes-talk#47 item 1: enforce the wiring invariant, do not document it.
+
+    `authorization_ledger is None` has to mean "no remote speakers", because
+    a None ledger silently selects the allow-all `local_operator_authorizer`
+    hundreds of lines below. It holds by construction today; a construction
+    bug that broke it would hand every Discord speaker operator authority
+    with nothing anywhere refusing.
+    """
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("TALK_VOICE", raising=False)
+    monkeypatch.setattr(
+        talk_cli.talk_operator_auth, "DiscordToolAuthorizationLedger", lambda: None
+    )
+
+    def never():  # pragma: no cover - must not be reached
+        raise AssertionError("dialled the provider for an unauthorized transport")
+
+    monkeypatch.setattr(talk_cli, "_import_aiohttp", never)
+    audio = _RemoteSpeakerAudio()
+    seen: list[str] = []
+
+    assert asyncio.run(talk_cli.run_talk_session(audio=audio, on_refusal=seen.append)) == 1
+    assert not audio.started, "opened the channel before refusing"
+    err = capsys.readouterr().err
+    assert "authorization ledger" in err
+    assert "operator authority" in err
+    # It refuses through the SAME bounded-reason sink every other startup
+    # refusal uses (#58), so the Discord lane can speak it instead of
+    # collapsing it into "session exited unsuccessfully".
+    assert seen == [talk_cli.STARTUP_REFUSAL_AUTHORIZATION]
+    assert talk_cli.STARTUP_REFUSAL_AUTHORIZATION in talk_cli.STARTUP_REFUSAL_REASONS
+
+
+def test_a_multi_speaker_transport_with_its_ledger_is_not_refused(monkeypatch):
+    """The refusal must be the contradiction, not the transport."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("TALK_VOICE", raising=False)
+    audio = _RemoteSpeakerAudio()
+
+    class _RefusingSession:
+        async def connect(self, _setup):
+            raise ConnectionRefusedError("stop here, past the ledger check")
+
+        async def close(self):
+            pass
+
+    code = asyncio.run(
+        talk_cli.run_talk_session(
+            audio=audio, session_factory=lambda _auth: _RefusingSession()
+        )
+    )
+
+    assert code == 1  # refused at the provider, not at the ledger gate
+    assert audio.started, "the ledger gate rejected a correctly wired transport"
+
+
+def test_a_single_speaker_transport_still_needs_no_ledger(monkeypatch):
+    """The named allow-all stays reachable for the operator's own microphone."""
+
+    class _LocalAudio(_RemoteSpeakerAudio):
+        discord_speaker_authorization = False
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("TALK_VOICE", raising=False)
+    audio = _LocalAudio()
+
+    class _RefusingSession:
+        async def connect(self, _setup):
+            raise ConnectionRefusedError("stop here, past the ledger check")
+
+        async def close(self):
+            pass
+
+    code = asyncio.run(
+        talk_cli.run_talk_session(
+            audio=audio, session_factory=lambda _auth: _RefusingSession()
+        )
+    )
+
+    assert code == 1
+    assert audio.started
+
+
 def test_slow_tool_does_not_block_inbound_barge_in(monkeypatch):
     """Receive and cancel keep moving while the serialized tool worker is busy."""
 

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -619,6 +619,38 @@ def test_every_startup_refusal_reason_has_exactly_one_speakable_line():
     assert talk_discord._startup_refusal_failure("not-a-reason") is None
 
 
+def test_only_the_reasons_core_join_can_route_around_offer_core_join():
+    """Which sentences point at `/talk core join` is a judgement, so pin it.
+
+    Core voice resolves its provider through the HOST, so it routes around a
+    plugin-side configuration or connect refusal. It opens the SAME channel
+    with the SAME speakers, so it cannot route around an audio failure or an
+    authorization one — offering it there just costs the operator a retry.
+    """
+
+    routable = {
+        talk_cli.STARTUP_REFUSAL_CONFIGURATION,
+        talk_cli.STARTUP_REFUSAL_PROVIDER,
+    }
+    for reason, line in talk_discord._STARTUP_REFUSAL_FAILURES.items():
+        offers_core_join = "core join" in line.lower()
+        assert offers_core_join is (reason in routable), reason
+
+
+def test_the_authorization_refusal_names_the_host_not_a_retry():
+    """A wiring contradiction is not something the operator can retry away."""
+
+    line = talk_discord._startup_refusal_failure(
+        talk_cli.STARTUP_REFUSAL_AUTHORIZATION
+    )
+
+    assert line is not None
+    assert "core join" not in line.lower()
+    assert "host" in line.lower()
+    # It must not leak WHY the ledger is missing; the receipt is a chat message.
+    assert "ledger" not in line.lower()
+
+
 def test_both_session_call_sites_pass_the_discord_lane(monkeypatch):
     """The lane line is only true if every path names its own room (#64)."""
 

--- a/tests/test_host_authority.py
+++ b/tests/test_host_authority.py
@@ -22,14 +22,16 @@ def _pcm(ms):
     return bytes(ms * 24 * 2)
 
 
-def _bind_response(ledger, *, response_id="resp-1", start_ms=0, end_ms=20):
+def _bind_response(
+    ledger, *, response_id="resp-1", start_ms=0, end_ms=20, input_item="input-1"
+):
     ledger.note_speech_started(
-        {"item_id": "input-1", "audio_start_ms": start_ms}
+        {"item_id": input_item, "audio_start_ms": start_ms}
     )
     ledger.note_speech_stopped(
-        {"item_id": "input-1", "audio_end_ms": end_ms}
+        {"item_id": input_item, "audio_end_ms": end_ms}
     )
-    create = ledger.response_for_commit({"item_id": "input-1"})
+    create = ledger.response_for_commit({"item_id": input_item})
     ledger.note_response_created(
         {
             "response": {
@@ -48,10 +50,11 @@ def _make_tool_event(
     arguments='{"task":"ship it"}',
     response_id="resp-1",
     call_id="call-1",
+    item_id="item-1",
 ):
     raw = {
         "response_id": response_id,
-        "item_id": "item-1",
+        "item_id": item_id,
         "call_id": call_id,
         "name": tool_name,
         "arguments": arguments,
@@ -225,7 +228,7 @@ def test_provider_metadata_cannot_satisfy_authority(monkeypatch):
     assert any("not run" in cmd.output for cmd in results[0])
 
 
-# ---------- 8a. discard_tool_event consumes permit ----------
+# ---------- 8. discard_tool_event consumes permit ----------
 
 
 def test_discard_consumes_permit_through_host_path(monkeypatch):
@@ -246,7 +249,7 @@ def test_discard_consumes_permit_through_host_path(monkeypatch):
     assert any("not run" in cmd.output for cmd in results[0])
 
 
-# ---------- 8b. tool_queue_full_commands consumes permit ----------
+# ---------- 9. tool_queue_full_commands consumes permit ----------
 
 
 def test_queue_full_consumes_permit_through_host_path(monkeypatch):
@@ -267,7 +270,7 @@ def test_queue_full_consumes_permit_through_host_path(monkeypatch):
     assert any("not run" in cmd.output for cmd in results[0])
 
 
-# ---------- 8. Replayed proof denied on second use ----------
+# ---------- 10. Replayed proof denied on second use ----------
 
 
 def test_replayed_proof_denied_through_host_path(monkeypatch):
@@ -289,7 +292,7 @@ def test_replayed_proof_denied_through_host_path(monkeypatch):
     assert any("not run" in cmd.output for cmd in results[0])
 
 
-# ---------- 9. Session reconnect invalidates old proofs ----------
+# ---------- 11. Session reconnect invalidates old proofs ----------
 
 
 def test_reconnect_invalidates_old_proofs(monkeypatch):
@@ -311,7 +314,7 @@ def test_reconnect_invalidates_old_proofs(monkeypatch):
     assert any("not run" in cmd.output for cmd in results[0])
 
 
-# ---------- 10. Relay refuses to exist without an explicit authorizer ----------
+# ---------- 12. Relay refuses to exist without an explicit authorizer ----------
 
 
 def test_relay_requires_explicit_authorizer():
@@ -330,7 +333,7 @@ def test_relay_requires_explicit_authorizer():
         raise AssertionError("tool_authorizer=None must raise")
 
 
-# ---------- 11. Named single-speaker authorizer permits the host path ----------
+# ---------- 13. Named single-speaker authorizer permits the host path ----------
 
 
 def test_local_operator_authorizer_permits_host_path():
@@ -353,7 +356,7 @@ def test_local_operator_authorizer_permits_host_path():
     assert any("exact host output" in cmd.output for cmd in results[0])
 
 
-# ---------- 12. Malformed event without call_id cannot crash the batch ----------
+# ---------- 14. Malformed event without call_id cannot crash the batch ----------
 
 
 def test_missing_call_id_is_dropped_not_crashed(monkeypatch):
@@ -377,7 +380,130 @@ def test_missing_call_id_is_dropped_not_crashed(monkeypatch):
     assert results == [[]]
 
 
-# ---------- 13. Reading the capability catalog grants no authority ----------
+# ---------- 16. One batch carrying both an authorized and a denied event ----------
+
+
+def test_a_mixed_batch_authorizes_each_event_on_its_own_merits(monkeypatch):
+    """Authorization is per EVENT, not per batch (Archon LOW, #47).
+
+    Every other batch test carries events that all pass or all fail, so a
+    relay that decided once and applied the verdict to the whole tuple would
+    have looked identical. Here one event is the operator's and one is a
+    stranger's, in the same batch, under the same permit-minting span.
+    """
+
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(
+        ledger, response_id="resp-1", start_ms=0, end_ms=20, input_item="in-1"
+    )
+    permitted = _make_tool_event(
+        ledger, response_id="resp-1", call_id="call-ok", item_id="item-1"
+    )
+
+    ledger.record_packet(_speaker(OTHER_ID), _pcm(20))
+    _bind_response(
+        ledger, response_id="resp-2", start_ms=20, end_ms=40, input_item="in-2"
+    )
+    denied = _make_tool_event(
+        ledger, response_id="resp-2", call_id="call-no", item_id="item-2"
+    )
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    results = _run_batch(relay, [permitted, denied])
+
+    # Exactly one permit reached the host, and it is the operator's.
+    assert len(attachment.minted) == 1
+    assert attachment.minted[0][0]["call_id"] == "call-ok"
+
+    assert any("exact host output" in cmd.output for cmd in results[0])
+    assert results[1], "the denied event produced no result at all"
+    assert not any("exact host output" in cmd.output for cmd in results[1])
+    # Denied for its SPEAKER, not incidentally: the same wording every other
+    # non-operator denial in this file asserts.
+    assert any("not run" in cmd.output for cmd in results[1])
+    assert any("Discord operator" in cmd.output for cmd in results[1])
+    # Each result is addressed to its own call, not merged.
+    assert results[0][0].call_id == "call-ok"
+    assert results[1][0].call_id == "call-no"
+
+
+def test_a_mixed_batch_consumes_the_denied_events_permit_too(monkeypatch):
+    """A denied event must not leave a replayable permit behind."""
+
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(
+        ledger, response_id="resp-1", start_ms=0, end_ms=20, input_item="in-1"
+    )
+    permitted = _make_tool_event(
+        ledger, response_id="resp-1", call_id="call-ok", item_id="item-1"
+    )
+
+    ledger.record_packet(_speaker(OTHER_ID), _pcm(20))
+    _bind_response(
+        ledger, response_id="resp-2", start_ms=20, end_ms=40, input_item="in-2"
+    )
+    denied = _make_tool_event(
+        ledger, response_id="resp-2", call_id="call-no", item_id="item-2"
+    )
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=ledger.authorize_tool
+    )
+    _run_batch(relay, [permitted, denied])
+
+    # Replay the once-denied event now that the operator has spoken again:
+    # its permit was consumed on the denial, so it cannot come back.
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    replay = _run_batch(relay, [denied], batch_id="batch-2")
+
+    assert len(attachment.minted) == 1, "a consumed permit was replayed"
+    assert not any("exact host output" in cmd.output for cmd in replay[0])
+
+
+# ---------- 17. An unnamed call is matched as the unknown it is ----------
+
+
+def test_an_unnamed_call_is_revoked_under_the_same_name_it_is_authorized_under():
+    """#47 item 3: the two authorizer call sites disagreed on the fallback.
+
+    `_consume_tool_attempt` said "tool" and the batch path said "" for the
+    same nameless event, so the identity used to revoke a permit was not the
+    identity used to authorize it. One owner now answers for both.
+    """
+
+    seen: list[str] = []
+
+    def recording_authorizer(name, _event):
+        seen.append(name)
+        return None
+
+    attachment = HostExecutionAttachment()
+    relay = talk_cli.HostExecutionRelay(
+        attachment, tool_authorizer=recording_authorizer
+    )
+    nameless = {"call_id": "call-1", "arguments": "{}", "response_id": "r", "item_id": "i"}
+
+    relay.discard_tool_event(dict(nameless))
+    relay.tool_queue_full_commands(dict(nameless))
+    _run_batch(relay, [dict(nameless)])
+
+    assert seen == ["", "", ""], "an unnamed call took a different identity per path"
+    assert talk_cli._event_tool_name({}) == ""
+    assert talk_cli._event_tool_name({"name": None}) == ""
+    assert talk_cli._event_tool_name({"name": "delegate_task"}) == "delegate_task"
+
+
+# ---------- 15. Reading the capability catalog grants no authority ----------
 
 
 def test_capability_catalog_is_readable_by_a_non_operator(monkeypatch):


### PR DESCRIPTION
Fixes #47 (items 1 and 3 + the Archon LOW; item 2 is a design question — reasoning below)

## What

1. **Item 1 — enforce the wiring invariant.** A session whose transport declares remote speakers but carries no authorization ledger is now refused at session setup.
2. **The refusal rides #58's bounded-reason sink**, not a bare exit code: a new `STARTUP_REFUSAL_AUTHORIZATION` with one fixed sentence in `talk_discord._STARTUP_REFUSAL_FAILURES`.
3. **Item 3 (fallback name) — fixed at the class level.** `_event_tool_name()` is the single owner of "what did the provider call this?", used by both authorizer call sites.
4. **Item 3 (numbering)** — `tests/test_host_authority.py` sections renumbered sequentially.
5. **The Archon LOW** — the mixed-event batch tests it named.

## Why item 1 matters

The invariant `authorization_ledger is None` ⟺ "no remote speakers" holds by construction:

```python
discord_authorization = bool(getattr(audio, "discord_speaker_authorization", False))
authorization_ledger = (
    talk_operator_auth.DiscordToolAuthorizationLedger() if discord_authorization else None
)
```

But the place that **relies** on it is ~250 lines further down, in the `HostExecutionRelay` wiring:

```python
tool_authorizer=(
    authorization_ledger.authorize_tool
    if authorization_ledger is not None
    else local_operator_authorizer   # allow-all
),
```

`local_operator_authorizer` returns `None` for everything — it grants speaker authority unconditionally, correctly, because a terminal session hears exactly one person and shell access to the box already carries host authority. If a Discord transport ever reached that branch with a `None` ledger, **every speaker in the voice channel would inherit operator authority**, and nothing anywhere would refuse. The only thing standing between that and production was a comment sitting next to the branch asserting the invariant.

The refusal is at setup, not at the wiring, for the same reason the audio and auth checks are there: it happens before a secret is minted or the voice channel is taken. It also fails closed and loud rather than degrading.

**Proven fail-without-fix.** With the new gate removed, `test_a_multi_speaker_transport_without_a_ledger_is_refused` fails on `AssertionError: opened the channel before refusing` — i.e. the session sails past the contradiction and starts taking the channel.

## Why the refusal speaks, and why it does not offer core join

#84 landed the bounded-reason sink after this branch was first written, so the refusal now uses it: `refuse(STARTUP_REFUSAL_AUTHORIZATION)` instead of a bare `return 1`. Without that, a Discord `talk join` hitting this gate would say "session exited unsuccessfully" — exactly the defect #58 just fixed for the other four refusals.

Its sentence deliberately withholds two things:

- **No `/talk core join` pointer.** Core voice routes around a *plugin-side* configuration or connect refusal because it resolves its provider through the host. It takes the **same channel with the same speakers**, so it would refuse this identically — offering it here only costs the operator a retry. A test now pins which reasons may offer it (`configuration` and `provider`, and only those), because that judgement is easy to get wrong when a fifth reason is added.
- **No mention of the ledger.** The receipt is a chat message. The operator cannot fix a wiring contradiction inside the process, so the sentence names the host as the place to fix it rather than describing internals in a Discord channel.

## Why item 3's name fix is a class fix, not a rename

The two authorizer call sites disagreed on the fallback for a nameless event:

- `HostExecutionRelay._consume_tool_attempt`: `str(event.get("name") or "tool")`
- the batch path: `str(event.get("name") or "")`

That is not cosmetic in one respect worth naming: every downstream comparison is exact-match — `READ_ONLY_TALK_TOOLS` / `MUTATING_TALK_TOOLS` membership, `classify_host_tool`, and the ledger's `renamed = permit.action != name` tripwire — so the same nameless event was **revoked under a different identity than it would have been authorized under**.

Both now read the name through `_event_tool_name()`, which returns `""`. That is the safe direction, not just the consistent one: `""` can never be a registered tool, can never be in a classification set, and can never equal a permit's recorded `action`, so an unnamed call is matched as the unknown it is. A synthetic stand-in like `"tool"` could one day be a real tool name and would then be classified as one.

## Item 2: deliberately not implemented

> *Session-generation enforcement at execution time. Permits minted before a mid-dispatch `ledger.clear()` still execute afterward — inherent to mint-then-dispatch. If generation checks at execution are wanted, they belong in the host attachment, not the relay seam.*

This is a design question with its own answer already in it, not a defect: it states the property is inherent to mint-then-dispatch, and it states where a fix would belong if wanted — the host attachment, which is not this repo's seam. Nothing here can implement it without putting the check in exactly the place the issue says it does not belong.

Worth adding for whoever picks it up: the window is already narrow by construction. The authorize-then-mint span in `handle_tool_batch_async` is synchronous with no `await` between authorization and minting, and `ledger.clear()` can only interleave at an await boundary — so `clear()` cannot land *inside* a permit's authorization. What it cannot do is recall permits already handed to `execute_tool_batch`. Recommend #47 stays open for it.

## How to test

```bash
uv run pytest tests/test_cli.py tests/test_host_authority.py -q
uv run ruff check .
```

8 new tests:

**`tests/test_discord.py` (2)** — which reasons may offer `/talk core join` is pinned to exactly `configuration` and `provider`; and the authorization sentence names the host, offers no core join, and does not leak the word "ledger" into a chat message.

**`tests/test_cli.py` (3)** — a multi-speaker transport with no ledger is refused, with the channel never opened and both halves of the reason in the message; the same transport **with** its ledger is *not* refused (the gate rejects the contradiction, not the transport — it proceeds and dies at the provider instead); and a single-speaker transport still needs no ledger, so the named allow-all stays reachable for the operator's own microphone.

**`tests/test_host_authority.py` (3)** — the Archon LOW: one batch carrying the operator's call and a stranger's call together, asserting exactly one permit is minted, each result is addressed to its own `call_id` rather than merged, and the denial is the *speaker* denial (`"Discord operator"` / `"not run"`) rather than an incidental one; a follow-up proving the denied event's permit was consumed, so it cannot be replayed once the operator speaks again; and a test that an unnamed call takes the same identity on all three paths (`discard_tool_event`, `tool_queue_full_commands`, and the batch path all record `""`).

Two shared helpers gained additive keyword arguments (`_bind_response(..., input_item=)` and `_make_tool_event(..., item_id=)`) so a test can build two distinct responses in one ledger; no existing caller changed.

## Gates

- `uv run pytest -q` → **11 failed, 1609 passed, 2 skipped**. The 12 are the pre-existing env failures on this box (11 in `tests/test_capabilities.py`, 1 in `tests/test_cli.py::test_the_cli_lane_and_host_summary_ride_the_minted_prompt`), the same set as the baseline on untouched `main` (12 failed / 1600 passed now that #84 and #87 have landed); `test_the_cli_lane_and_host_summary_ride_the_minted_prompt` is order-dependent under `pytest-randomly` and passed in this run. Net +8, all green.
- CI on this head: all 6 `test` jobs pass (ubuntu + windows × 3.11/3.12/3.13). The `scan` job fails, but it fails on `main` itself and on every other open branch — its one blocking finding is `high: invisible_unicode at tests/test_grok_auth.py:332`, a file this PR does not touch.
- `uv run ruff check .` → **All checks passed!**
- No line-ending flips: `git diff --stat` is byte-identical to `git diff --ignore-all-space --stat` for every file, and all four verified CRLF-only (0 bare LF).

## What a live check would confirm

Not possible on this box (no Discord gateway, no voice channel, no provider socket). The refusal test forces the contradiction by monkeypatching the ledger constructor to return `None`, because the real wiring cannot produce it — that is the point of the fix, and it is also the limit of what a unit test can show. A live check would confirm the complementary half: that a **real** `DiscordAudio` bridge reports `discord_speaker_authorization` truthy in an actual voice channel and therefore takes the ledger branch rather than the allow-all one, and that a real terminal `DuplexAudio` session still starts normally with no ledger and no refusal. It would also confirm the refusal text reads sensibly on the operator's stderr in a real gateway start.

## Rebase note

Rebuilt on `main` after #84 and #87 merged. A straight `git rebase` interleaved this branch's tests with #84's mid-function — both had appended before the same anchor in `tests/test_cli.py`, and git found spurious common lines inside the test bodies — so the change was re-applied onto the new `main` rather than untangled by hand. Equivalence checked, not assumed: `tests/test_host_authority.py` is byte-identical to the pre-rebase branch (`main` never touched that file), the net diff is 6 files / 360 insertions / 18 deletions (the two extra files are the bounded-reason routing added since), and #84's `refuse()` sites and #87's `speaker_busy()` gates are both still intact in `talk_cli.py`.

— SmokeDev
