### PR TITLE
test: review follow-up batches (#60, #61, #56, #55)

### DIFF
--- a/tests/test_apiserver_lane.py
+++ b/tests/test_apiserver_lane.py
@@ -1026,3 +1026,95 @@ def test_no_lane_at_all_still_names_the_lanes_not_the_routing(monkeypatch, lane_
     assert "api server isn't reachable" in out
     assert "PATH" in out
     assert "I can't start that yet" not in out
+
+
+# -- PR #54 gate follow-ups (hermes-talk#56) ------------------------------------
+#
+# Both of these assert the behavior the issue ASKS FOR, and both fail today.
+# They are marked xfail(strict) rather than written to pass against current
+# behavior: a test that pinned today's shape would have to be rewritten by the
+# fix, and strict means the marker itself fails the build once the fix lands,
+# so it cannot rot into a permanently-skipped test.
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "hermes-talk#56 item 1: the call site re-derives 'was this an error' by "
+        "string-matching _speakable's 'that failed' prefix instead of the parsed "
+        "{'error': ...} shape, so a remembered FACT beginning with those words "
+        "is misread as a refusal and loses its provenance label"
+    ),
+)
+def test_a_honcho_fact_that_starts_with_that_failed_keeps_its_provenance(
+    monkeypatch, lane_on
+):
+    """A FACT is operator content Honcho may return verbatim.
+
+    The error branch in ``_speakable`` already keys on the parsed dict, but
+    what it returns is a bare string, so the caller can only look at the words.
+    A recollection that happens to open with the same two words as a minted
+    refusal is then spoken without ``REMEMBERED_PREFIX`` — the operator hears a
+    remembered fact as if it were Honcho failing.
+    """
+
+    _set_lane(monkeypatch, UP)
+    monkeypatch.setattr(talk_apiserver, "run_to_completion", lambda *a, **k: "found it")
+    fact = "that failed to release on schedule, so it slipped to Friday"
+    talk_host.bind_ctx(
+        ByToolCtx({talk_host.HONCHO_SEARCH_TOOL_NAME: json.dumps({"result": fact})})
+    )
+
+    out = talk_tools.execute_talk_tool("search_memory", {"query": "the release"})
+
+    assert out == f"{talk_host.REMEMBERED_PREFIX}{fact}"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "hermes-talk#56 item 2: _dispatch_bounded's timeout reclaims the caller's "
+        "pipeline thread but never the daemon worker it spawned, and nothing "
+        "caps them - a permanently wedged Honcho leaks one live thread per query"
+    ),
+)
+def test_a_wedged_honcho_does_not_leak_one_daemon_thread_per_query(
+    monkeypatch, lane_on
+):
+    """F4 bounded the PIPELINE; the worker itself is still unbounded.
+
+    The assertion is deliberately shape-agnostic — it says only that live
+    workers must not grow one-for-one with queries. Any bound satisfies it (a
+    semaphore, one shared worker, a join on the previous one); nothing today
+    does.
+    """
+
+    _set_lane(monkeypatch, UP)
+    monkeypatch.setattr(talk_apiserver, "run_to_completion", lambda *a, **k: "found it")
+    monkeypatch.setenv("TALK_MEMORY_SEARCH_TIMEOUT_S", "0.05")
+    release = threading.Event()
+    queries = 5
+
+    class Hang(ByToolCtx):
+        def dispatch_tool(self, name, args):
+            if name == talk_host.HONCHO_SEARCH_TOOL_NAME:
+                release.wait(30)
+                return json.dumps({"result": "too late"})
+            return super().dispatch_tool(name, args)
+
+    talk_host.bind_ctx(Hang({}))
+    try:
+        for _ in range(queries):
+            out = talk_tools.execute_talk_tool("search_memory", {"query": "x"})
+            assert "didn't answer in time" in out
+        wedged = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == "talk-memory-dispatch"
+        ]
+        assert len(wedged) < queries
+    finally:
+        release.set()
+        for thread in threading.enumerate():
+            if thread.name == "talk-memory-dispatch":
+                thread.join(5.0)

--- a/tests/test_identity_injection.py
+++ b/tests/test_identity_injection.py
@@ -961,3 +961,33 @@ def test_working_is_reported_to_diagnostics_by_file_only(_hermetic):
 
     assert diagnostic["WORKING"] == "Dograh is the voice stack."
     assert "search_memory" not in diagnostic["WORKING"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "hermes-talk#56 item 3: the upgrade-trap warning is gated on the pinned "
+        "list alone, never on whether a WORKING section exists, so a deliberate "
+        "MEMORY,PERSONA pin is a standing warning on every session mint"
+    ),
+)
+def test_a_deliberate_pin_with_no_working_section_does_not_warn(
+    _hermetic, monkeypatch, caplog
+):
+    """The warning exists to catch a pin that SILENTLY DROPS curated context.
+
+    Where there is no WORKING.md and no bound ctx, the pin drops nothing, so
+    there is no trap to warn about — and a warning that cannot be acted on is
+    one an operator learns to ignore, which costs the real case its signal.
+    """
+
+    # Measured with no pin at all, because identity_sections() filters its
+    # return value by the pin: asking the pinned call whether WORKING is in
+    # its OUTPUT would be vacuous.
+    assert "WORKING" not in talk_host.host().identity_sections()
+
+    monkeypatch.setenv("TALK_IDENTITY_INCLUDE", "MEMORY,PERSONA")
+    with caplog.at_level("WARNING", logger="talk_host"):
+        talk_host.host().identity_sections()
+
+    assert not [record for record in caplog.records if "WORKING" in record.message]

--- a/tests/test_operator_auth.py
+++ b/tests/test_operator_auth.py
@@ -11,6 +11,7 @@ import pytest
 
 import talk_cli
 import talk_operator_auth
+import talk_realtime
 import talk_relay
 
 OPERATOR_ID = 586638048133906576
@@ -1119,3 +1120,142 @@ def test_integral_float_reserialization_is_not_a_changed_argument(monkeypatch):
     event["arguments"] = '{"count": 1.0, "task": "ship it"}'
 
     assert ledger.authorize_tool("delegate_task", event) is None
+
+
+# -- spoken-target cross-check hardening (hermes-talk#55) -----------------------
+#
+# Items 1 and 2 are live weaknesses, so they assert the hardening the issue
+# asks for and fail today, marked xfail(strict). Item 3 is a documented scope
+# boundary rather than a gap, so it is pinned as passing behavior instead.
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "hermes-talk#55 item 1: _target_was_spoken is a plain substring test "
+        "over an alphanumeric collapse, so a short target is ratified by any "
+        "longer target that contains it"
+    ),
+)
+def test_a_short_target_is_not_ratified_by_a_longer_one_that_contains_it(monkeypatch):
+    """stop_work targets are run numbers, so short targets are the normal case.
+
+    The operator named run 142. The model emitted 42 — a different run that
+    was never mentioned — and "42" is a substring of "142", so the cross-check
+    ratifies it and the permit mints. The same flaw reaches across words as
+    well as inside them, because the normalizer strips spaces before matching:
+    the haystack a target is tested against is one unbroken string.
+    """
+
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(ledger)
+    _speak(ledger, "Stop run 142 for me.", response_id="resp_0")
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+
+    event = ledger.bind_tool_event(
+        {
+            "response_id": "resp_1",
+            "call_id": "call_1",
+            "name": "stop_work",
+            "arguments": '{"target": "42"}',
+        }
+    )
+
+    assert event["_talk_call_permit"] is None
+    assert ledger.authorize_tool("stop_work", event) is not None
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "hermes-talk#55 item 2: the ledger's spoken window has no barge-in or "
+        "settlement awareness, and talk_cli feeds it every transcript before "
+        "the relay fences the cancelled response's tail - so a target the "
+        "operator never heard still ratifies a permit"
+    ),
+)
+def test_a_barged_in_response_tail_does_not_ratify_a_target(monkeypatch):
+    """The two halves disagree about what the operator heard.
+
+    A cancelled response keeps emitting transcript deltas — the relay says so
+    itself, and fences them by response id so they are never played or
+    captioned. The ledger has no such fence, and in ``receive_events`` it is
+    fed FIRST, so the tail the operator was cut off from still counts as
+    spoken. This drives the real relay to prove the text was unheard, then
+    feeds that same text to the ledger exactly as the CLI does.
+    """
+
+    heard: list[tuple[str, str]] = []
+    captions: list[str] = []
+    relay = talk_relay.RealtimeRelay(
+        on_transcript_turn=lambda role, text: heard.append((role, text)),
+        on_caption=captions.append,
+    )
+    target = "sa-0-a1b2c3d4"
+    tail = talk_realtime.Transcript(
+        role=talk_realtime.TranscriptRole.ASSISTANT,
+        text=f"steer agent {target} to focus on pricing",
+        final=True,
+        provenance=talk_realtime.TranscriptProvenance.OUTPUT_AUDIO,
+        response_id="resp_0",
+    )
+
+    relay.handle_realtime_event(talk_realtime.ResponseStarted(response_id="resp_0"))
+    relay.handle_realtime_event(talk_realtime.SpeechStarted(input_id="input_1", offset_ms=0))
+    relay.handle_realtime_event(tail)
+
+    # The operator was cut off before this: never played, never captioned.
+    assert heard == []
+    assert captions == []
+
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(ledger)
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+    _speak(ledger, tail.text, response_id=tail.response_id)
+
+    event = ledger.bind_tool_event(
+        {
+            "response_id": "resp_1",
+            "call_id": "call_1",
+            "name": "steer_agent",
+            "arguments": f'{{"agent_id": "{target}", "text": "focus on pricing"}}',
+        }
+    )
+
+    assert event["_talk_call_permit"] is None
+
+
+def test_free_text_arguments_are_outside_the_cross_check_by_design(monkeypatch):
+    """Item 3 is a documented boundary, not a gap — so it is pinned, not fixed.
+
+    The cross-check can only see divergence for tools that NAME a target;
+    CHANGELOG 0.10.0 and the _CallPermit docstring both say free text is out
+    of scope. This exists so that boundary cannot move silently: a task
+    nobody ever spoke still authorizes, and the set of target-bearing tools
+    is exactly three.
+    """
+
+    ledger = talk_operator_auth.DiscordToolAuthorizationLedger()
+    ledger.record_packet(_speaker(OPERATOR_ID), _pcm(20))
+    _bind_response(ledger)
+    monkeypatch.setenv("TALK_DISCORD_OPERATOR_USER_IDS", str(OPERATOR_ID))
+    # Deliberately nothing spoken at all.
+
+    event = ledger.bind_tool_event(
+        {
+            "response_id": "resp_1",
+            "call_id": "call_1",
+            "name": "delegate_task",
+            "arguments": '{"task": "a task the operator was never read back"}',
+        }
+    )
+
+    assert event["_talk_call_permit"] is not None
+    assert ledger.authorize_tool("delegate_task", event) is None
+    assert set(talk_operator_auth._TARGET_ARGUMENT_KEYS) == {
+        "steer_agent",
+        "redirect_agent",
+        "stop_work",
+    }

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -681,3 +681,119 @@ def test_the_phase_replays_off_history_after_a_restart(history_env):
     assert mine[0]["fromHistory"] is True
     assert mine[0]["status"] == "done"
     assert mine[0]["meta"]["phase"] == "complete"
+
+
+# -- eviction caps + the same-phase detail-only run path (hermes-talk#60) ---------
+
+
+def test_run_session_eviction_drops_the_oldest_not_the_newest():
+    """FIFO, not LIFO: at the cap, the FIRST id recorded is the one that goes.
+
+    Popping the wrong end would evict the id that just arrived — so the run
+    actually executing right now would stop being findable by its session id
+    and go silent under load, which is the precise failure the cap exists to
+    prevent.
+    """
+
+    cap = talk_progress._MAX_RUN_SESSIONS
+    for index in range(cap):
+        talk_progress.note_run_session(index, f"sess-{index:04d}")
+    assert len(talk_progress._RUN_BY_SESSION) == cap
+
+    talk_progress.note_run_session(cap, "sess-newest")
+
+    assert len(talk_progress._RUN_BY_SESSION) == cap
+    assert "sess-0000" not in talk_progress._RUN_BY_SESSION  # oldest, evicted
+    assert talk_progress._RUN_BY_SESSION["sess-newest"] == cap  # newest, kept
+    assert talk_progress._RUN_BY_SESSION["sess-0001"] == 1  # runner-up, kept
+
+
+def test_re_noting_a_session_does_not_refresh_its_eviction_position():
+    """The cap is insertion-ordered, not least-recently-used.
+
+    Re-noting an id already in the index rebinds its run in place; it must not
+    move the entry to the back of the queue, or a chatty session could hold a
+    slot forever while quieter live runs are evicted around it.
+    """
+
+    cap = talk_progress._MAX_RUN_SESSIONS
+    for index in range(cap):
+        talk_progress.note_run_session(index, f"sess-{index:04d}")
+
+    talk_progress.note_run_session(999, "sess-0000")
+    assert talk_progress._RUN_BY_SESSION["sess-0000"] == 999  # rebound
+
+    talk_progress.note_run_session(cap, "sess-newest")
+    assert "sess-0000" not in talk_progress._RUN_BY_SESSION  # still first out
+
+
+def test_child_eviction_drops_the_oldest_not_the_newest():
+    """Same FIFO property for the attached-child index, and its consequence.
+
+    An evicted child stops being a progress subject, so its later tool call
+    finds no entry and speaks nothing — which is why evicting the NEWEST would
+    silence the child that just started.
+    """
+
+    events: list[dict] = []
+    _attach(events)
+    cap = talk_progress._MAX_CHILDREN
+    for index in range(cap):
+        _child_start(csid=f"cs-{index:04d}", sid=f"sa-0-{index:04d}")
+    assert len(talk_progress._CHILDREN) == cap
+
+    _child_start(csid="cs-newest", sid="sa-0-newest")
+
+    assert len(talk_progress._CHILDREN) == cap
+    assert "cs-0000" not in talk_progress._CHILDREN
+    assert "cs-newest" in talk_progress._CHILDREN
+
+    spoken = len(events)
+    talk_progress.on_post_tool_call(session_id="cs-0000", tool_name="read_file")
+    assert len(events) == spoken  # the evicted child has no subject to phase
+    talk_progress.on_post_tool_call(session_id="cs-newest", tool_name="read_file")
+    assert len(events) == spoken + 1  # the newest one still speaks
+
+
+def test_the_same_phase_detail_only_update_rides_the_run_path(monkeypatch):
+    """The run path's detail-only branch, exercised directly on a run.
+
+    The child path already covers "finer detail, same phase, no second
+    speech"; this is the same branch in ``set_run_phase``. The evidence is the
+    written FIELD SET, not the resulting meta: within a phase only
+    ``phase_detail`` may be rewritten, so ``phase_at`` keeps marking when the
+    PHASE changed instead of being pushed forward by every tool label.
+    Asserting on ``phase_at``'s value instead would prove nothing here - two
+    ``time.time()`` calls inside one phase can return the same float.
+    """
+
+    calls: list[dict] = []
+    real_annotate = talk_runs.annotate_run
+    monkeypatch.setattr(
+        talk_runs,
+        "annotate_run",
+        lambda *args, **kwargs: real_annotate(*args, **kwargs) or calls.append(kwargs),
+    )
+    run_id, release = _start_live_run()
+    try:
+        assert talk_progress.set_run_phase(run_id, "executing", detail="Reading files")
+        meta = talk_runs.get_run(run_id)["meta"]
+        assert (meta["phase"], meta["phase_detail"]) == ("executing", "Reading files")
+        assert set(calls[0]) == {"durable", "phase", "phase_at", "phase_detail"}
+
+        # Same phase, different detail: the label is replaced, and it is the
+        # ONLY field the write carries.
+        assert talk_progress.set_run_phase(run_id, "executing", detail="Searching the web")
+        assert len(calls) == 2
+        assert calls[1] == {"durable": False, "phase_detail": "Searching the web"}
+        assert talk_runs.get_run(run_id)["meta"]["phase"] == "executing"
+
+        # Same phase, same detail: not a write at all.
+        assert not talk_progress.set_run_phase(run_id, "executing", detail="Searching the web")
+        # Same phase, no detail: the tier-2 poll's blank must not erase it.
+        assert not talk_progress.set_run_phase(run_id, "executing")
+        assert len(calls) == 2
+        assert talk_runs.get_run(run_id)["meta"]["phase_detail"] == "Searching the web"
+    finally:
+        release.set()
+    _wait_terminal(run_id)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -797,3 +797,149 @@ def test_the_same_phase_detail_only_update_rides_the_run_path(monkeypatch):
     finally:
         release.set()
     _wait_terminal(run_id)
+
+
+# -- progress-speech micro coverage (hermes-talk#61) -----------------------------
+
+
+def _child_spoken(**event) -> str:
+    return _spoken_text(talk_cli.subagent_phase_commands(event))
+
+
+def test_subagent_phase_speech_names_the_agent_its_role_and_its_phase():
+    """The child milestone sentences themselves.
+
+    The run-side wording is pinned above; the child side only had "terminal
+    phases build nothing". These are the three sentences an operator actually
+    hears, including the two shapes that are easy to get wrong: an executing
+    child with no tool detail yet (the sentence must still end), and a child
+    with no role (no empty parentheses).
+    """
+
+    base = {"subagent_id": "sa-0-aaaa", "role": "researcher"}
+    assert (
+        "Background agent sa-0-aaaa (researcher) was accepted."
+        in _child_spoken(**base, phase="accepted")
+    )
+    assert (
+        "Background agent sa-0-aaaa (researcher) is executing \u2014 Reading files."
+        in _child_spoken(**base, phase="executing", detail="Reading files")
+    )
+    assert "is executing." in _child_spoken(**base, phase="executing")
+    assert "waiting on an approval" in _child_spoken(**base, phase="blocked")
+    assert (
+        "Background agent sa-0-aaaa was accepted."
+        in _child_spoken(subagent_id="sa-0-aaaa", phase="accepted")
+    )
+    # No id is no subject: nothing is spoken rather than a nameless sentence.
+    assert talk_cli.subagent_phase_commands({"phase": "accepted"}) == []
+
+
+def test_subagent_phase_speech_carries_no_routing_metadata():
+    """Positional redaction, child side: only id, role and a safe label ride."""
+
+    text = _child_spoken(
+        subagent_id="sa-0-aaaa",
+        role="researcher",
+        phase="executing",
+        detail="Reading files",
+        parent_session_id="sess-secret",
+        child_goal="exfiltrate the secrets",
+        tool_name="read_file",
+        tool_input={"path": "C:/secret.env"},
+    )
+    for leaked in ("sess-secret", "exfiltrate", "C:/secret.env", "read_file"):
+        assert leaked not in text
+
+
+def test_an_unknown_phase_is_refused_by_the_run_projection():
+    """The guard is exact membership in PHASES, not a shape or a case fold.
+
+    A phase that is not in the bounded vocabulary must not reach meta at all
+    — the vocabulary is what bounds what can ever be spoken.
+    """
+
+    run_id, release = _start_live_run()
+    try:
+        for bogus in ("gibberish", "", "EXECUTING", "running", "Accepted", None, 7):
+            assert talk_progress.set_run_phase(run_id, bogus) is False
+        assert "phase" not in talk_runs.get_run(run_id)["meta"]
+    finally:
+        release.set()
+    _wait_terminal(run_id)
+
+
+def test_spoken_labels_are_truncated_to_the_progress_label_cap():
+    """Operator-supplied run labels and tool labels are bounded before speech."""
+
+    cap = talk_cli._PROGRESS_LABEL_CHARS
+    long_label = "L" * (cap + 40)
+    long_detail = "D" * (cap + 40)
+
+    run = _run_snapshot(7, "executing", long_detail)
+    run["label"] = long_label
+    text = _spoken_text(talk_cli.run_phase_commands(run, "executing"))
+    assert "L" * cap in text and "L" * (cap + 1) not in text
+    assert "D" * cap in text and "D" * (cap + 1) not in text
+
+    # The heartbeat carries the label too, on the same cap.
+    beat = _spoken_text(talk_cli.run_phase_commands(run, "heartbeat"))
+    assert "L" * cap in beat and "L" * (cap + 1) not in beat
+
+    child = _child_spoken(subagent_id="sa-0-aaaa", phase="executing", detail=long_detail)
+    assert "D" * cap in child and "D" * (cap + 1) not in child
+
+
+def test_concurrent_producers_never_corrupt_the_progress_indexes():
+    """Both indexes are written from the poll loop AND the host's hook threads.
+
+    The caps evict while other threads insert, so this drives every producer
+    at once past both caps and asserts the invariants that a torn write would
+    break: bounded size, whole entries, and a phase still inside the bounded
+    vocabulary.
+    """
+
+    events: list[dict] = []
+    _attach(events)
+    workers = 6
+    errors: list[Exception] = []
+    barrier = threading.Barrier(workers)
+
+    def hammer(worker: int) -> None:
+        try:
+            barrier.wait(timeout=10.0)
+            for index in range(60):
+                key = f"{worker}-{index}"
+                talk_progress.note_run_session(worker * 1000 + index, f"sess-{key}")
+                _child_start(csid=f"cs-{key}", sid=f"sa-{worker}-{index}")
+                talk_progress.on_post_tool_call(session_id=f"cs-{key}", tool_name="read_file")
+                talk_progress.on_pre_approval_request(session_id=f"cs-{key}")
+                if index % 3 == 0:
+                    talk_lifecycle.on_subagent_stop(
+                        child_session_id=f"cs-{key}", child_status="ok", child_summary="done"
+                    )
+        except Exception as exc:  # noqa: BLE001 - the thread's failure IS the assertion
+            errors.append(exc)
+
+    threads = [threading.Thread(target=hammer, args=(worker,)) for worker in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30.0)
+
+    assert not [thread for thread in threads if thread.is_alive()]
+    assert errors == []
+    assert len(talk_progress._RUN_BY_SESSION) <= talk_progress._MAX_RUN_SESSIONS
+    assert len(talk_progress._CHILDREN) <= talk_progress._MAX_CHILDREN
+    for entry in list(talk_progress._CHILDREN.values()):
+        assert set(entry) == {
+            "subagent_id",
+            "parent_session_id",
+            "role",
+            "top_level",
+            "phase",
+            "detail",
+        }
+        assert entry["phase"] in talk_progress.PHASES
+    for phase in [event.get("phase") for event in list(events)]:
+        assert phase in talk_progress.PHASES


### PR DESCRIPTION
## What

The four test-batch follow-ups from past review gates, one commit per issue.
**No production code changes** — every file touched is under `tests/`.

| Issue | Items | Result |
|---|---|---|
| #60 | 2 | 4 tests, passing |
| #61 | 4 | 5 tests, passing |
| #56 | 3 | 3 tests, **all xfail** — all three are live defects |
| #55 | 3 | 2 xfail + 1 passing (item 3 is a documented boundary) |

Net: **+10 passing, +5 xfail**.

## Per-item disposition

### #60 — eviction caps + same-phase detail-only path — both done

1. **Eviction-cap FIFO correctness — done.** Both caps (`_MAX_RUN_SESSIONS=200`,
   `_MAX_CHILDREN=100`) pop `next(iter(...))`, which is the oldest key only
   because dicts are insertion-ordered — nothing was holding that. Each index is
   filled to its cap, pushed one over, and asserted to have dropped the FIRST
   entry while keeping the newest and the runner-up. A third test pins that
   re-noting an existing session rebinds it *in place* rather than moving it to
   the back: the cap is FIFO, not LRU. The child test asserts the consequence,
   not just dict state — an evicted child stops being a progress subject, so its
   later tool call speaks nothing while the newest child still does.
2. **Same-phase detail-only update on the run path — done.** Asserted on the
   written FIELD SET via an `annotate_run` spy, not on the resulting meta.

### #61 — progress-speech micro coverage — all four done

1. **`subagent_phase_commands` speech content — done.** The run-side sentences
   were already pinned; the child side only had "terminal phases build nothing".
   Covers the two shapes easiest to get wrong: an executing child with no tool
   label yet (the sentence must still end) and a child with no role (no empty
   parentheses). A second test pins containment on that path — parent session
   id, child goal, tool name and tool input are all in the event, none may reach
   the text.
2. **Invalid phase rejection — done.** Exact membership in `PHASES`, proved with
   a wrong case (`"EXECUTING"`), a near-miss (`"running"`), empty, `None`, int.
3. **Label truncation at `_PROGRESS_LABEL_CHARS` — done**, on all three slicing
   sites (run label, run `phase_detail`, child `detail`). The test reads the
   constant rather than hardcoding 60, so it pins that truncation happens at the
   named cap, not that the cap is a particular number.
4. **Concurrency stress — done.** Six threads drive every producer past both caps
   at once, asserting what a torn write would break: bounded size, whole
   entries, phases still inside the vocabulary.

### #56 — PR #54 gate follow-ups — all three are live defects, all xfail

Not fixed here, per the brief. Each asserts the behavior the issue asks for and
fails today. Verified with `--runxfail` that each fails at its *intended*
assertion:

1. **Prefix-suppression error shape — xfail.** A Honcho FACT beginning
   "that failed" loses `REMEMBERED_PREFIX`:
   `'that failed to release...' == 'from remembered context: that failed...'`.
   `_speakable`'s error branch already keys on the parsed dict, but it returns a
   bare string, so the call site can only match the words it minted.
2. **Honcho thread-leak cap — xfail.** `assert 5 < 5` — five live
   `talk-memory-dispatch` threads for five wedged queries, exactly 1:1. F4
   bounded the pipeline, not the worker. The assertion is shape-agnostic on
   purpose: a semaphore, a shared worker or a join all satisfy it.
3. **WORKING warning gating — xfail.** Fires with no `WORKING.md` and no bound
   ctx — nothing for the pin to drop, yet a standing warning every mint.

> **Worth knowing before fixing #56 item 3:** the current behavior is pinned by an
> existing **passing** test, `test_a_pinned_include_without_working_warns_at_mint`
> (`tests/test_identity_injection.py:886`), which asserts the warning fires in a
> hermetic home where no `WORKING.md` was written. That test will need to grow a
> real WORKING file to keep asserting the genuine upgrade trap. Left untouched
> here — changing it is part of the fix, not of characterizing the gap.

### #55 — spoken-target cross-check — 2 xfail, 1 documented

1. **Token-boundary match — xfail.** `_target_was_spoken` is a plain `in` over an
   alphanumeric collapse, and `stop_work` targets are run numbers, so short
   targets are the normal case: the operator says "stop run 142", the model emits
   `"42"`, and `"42"` is inside `"142"` — the permit mints for a run nobody named.
   The normalizer also strips spaces, so the same flaw reaches *across* words.
2. **Barge-in lead — xfail.** Written as a two-component test, because the bug is
   the disagreement between them: it drives the **real** relay through
   `ResponseStarted` then `SpeechStarted` then a late tail on the cancelled
   response, and asserts the operator neither heard nor saw it
   (`on_transcript_turn` and `on_caption` both silent — the relay fences settled
   response ids). It then feeds that same tail to the ledger exactly as
   `receive_events` does, and the target ratifies. Both xfails fail on the permit
   assertion, i.e. the "never heard" preconditions pass first.
3. **Free-text divergence — not applicable, documented.** This is a scope
   boundary, stated in three places (CHANGELOG 0.10.0, the `_CallPermit`
   docstring, `docs/REALTIME-ORCHESTRATOR.md`), not a gap. Pinned as a **passing**
   test so it cannot move silently: a `delegate_task` nobody spoke still
   authorizes, and the set of target-bearing tools is asserted to be exactly the
   three.

## On the xfail markers

There was no `xfail` precedent in this suite; these five are the first. All are
`strict=True` deliberately — a strict xfail **fails the build when it starts
passing**, so the marker cannot rot into a permanently-skipped test and the fix
is forced to remove it. Each reason names its issue and item.

## Verification

The brief's rule was that a test which passes without touching its target is
worse than none. Every passing test here was run against a deliberately broken
build and confirmed to fail:

| Mutation | Tests that caught it |
|---|---|
| evict the newest instead of the oldest (both caps) | 3 |
| detail-only write also bumps `phase_at` | 1 |
| `phase not in PHASES` guard removed | 1 |
| child cap removed | 2 |
| `[:_PROGRESS_LABEL_CHARS]` slices removed | 1 |
| child speech reworded | 1 |

One of these was earned the hard way: the first version of the detail-only test
asserted `phase_at`'s *value* and **survived** the mutation — two `time.time()`
calls inside one phase can return the same float on Windows. It was rewritten to
assert the written field set instead.

## How to test

```
uv run pytest -q
uv run pytest -q -rxX
uv run pytest -q --runxfail tests/test_apiserver_lane.py tests/test_operator_auth.py tests/test_identity_injection.py
```

## Gates

Rebased onto `1acf8eb` (main moved twice during this work — #84, #87, #88 and
#89 merged), so these numbers are against current main:

| | baseline (`origin/main` @ `1acf8eb`) | this branch |
|---|---|---|
| passed | 1615 | **1626** (+10, +1 flake below) |
| failed | 12 | **11** |
| skipped | 33 | 33 |
| xfailed | 0 | **5** |

Both measured on this box, the baseline on a clean detached worktree at
`origin/main` rather than assumed.

Two notes on those failure counts, neither caused by this PR (which adds only
files under `tests/` and changes no module any of them import):

- **11 of them are constant** — all in `tests/test_capabilities.py`,
  pre-existing environment failures here.
- **The 12th is an environment-dependent flake**, not a regression this branch
  fixed: `test_cli.py::test_the_cli_lane_and_host_summary_ride_the_minted_prompt`
  asserts a host summary, and on clean `main` this box produces
  `'0 skills enabled, 13 toolsets'` on one run and `'123 skills enabled, 14
  toolsets'` on the next, depending on what the installed Hermes host reports.
  It failed on clean `main` both in the full suite and running `test_cli.py`
  alone; it happened to pass on this branch's run. Worth a separate issue —
  the test reads live host state.

`#88` landed on the ledger this PR's #55 tests target, so all five xfails were
re-checked against it: **all five still xfail, none XPASS**, i.e. that fix did
not close these gaps.

- `uv run ruff check .` gives **All checks passed!**
- No line-ending flips: `git diff origin/main --stat` equals
  `git diff origin/main --ignore-all-space --stat` (4 files, 524 insertions, 0
  deletions).

### CI

CI is red on this PR, and it is red on `main` too — for the same reason, which
is neither PR's doing. Every `test` job fails at the **Lint** step on three
`RUF100` errors in `talk_core_provider.py` (lines 498, 557, 630): a `noqa:
BLE001` on `except Exception:` that a newer ruff no longer needs. CI installs
whatever ruff is current (the ruleset is pinned in `pyproject.toml`, the version
is not), so ruff 0.16.5 flags them while the older local ruff does not. Same
failure on `main` at `1acf8eb`, `d775a96` and `23351be`. Fix is to drop those
three directives — a separate change, not folded in here.

Lint runs AFTER Test in `ci.yml`, so pytest did run, and the per-step results
are the useful part:

> `Test` step: **success on all five completed jobs** — ubuntu 3.12/3.13 and
> windows 3.11/3.12/3.13. `Lint`: failure (the three inherited errors above).

That is the cross-platform result this PR actually wanted: the 15 new tests pass
on Linux and Windows across 3.11-3.13, and **no strict xfail XPASSes anywhere** —
an XPASS would have failed the Test step, and it did not.

The `scan` check (plugin-guard) is red for the same inherited reason: it fails
on `main` at `1acf8eb` and `d775a96` too, on pre-existing `supply_chain`
findings in `docs/OPERATING.md` and two test files. Neither PR adds a finding.

Verified with the latest ruff (0.16.5) against this branch: **3 errors, all in
`talk_core_provider.py`, none in any file this PR touches.** The one
`# noqa: BLE001` this PR adds (in the concurrency test) is still a live
suppression under 0.16.5, not a RUF100.

Fixes #60
Fixes #61
Fixes #56
Fixes #55

— SmokeDev
