### PR TITLE
test: write the BOM as an escape so the plugin-guard scan passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,16 @@ named rather than smoothed.
   transcript and the agent's brief in the runs panel are readable rather
   than grey mush (#79). `docs/render-dashboard-gif.py` regenerates it from
   the published release asset.
+- The plugin scans `safe` again. A literal U+FEFF typed into
+  `tests/test_grok_auth.py` — the BOM fixture for the BOM-prefixed auth-store
+  test, added with the Grok subscription lane in `01518ae` — tripped the
+  upstream `plugin_guard` scanner's `invisible_unicode` check as a HIGH
+  finding, taking the whole repo to a BLOCKED verdict. That scanner gates
+  `hermes plugins install`, so the block reached users, not just CI. The BOM
+  is now written as the escape `"\ufeff"`: identical bytes on disk, pinned by
+  the same `startswith(b"ï»¿")` assertion the test already made, and
+  no invisible character left in the source for a reader or a scanner to have
+  to distinguish from an accidental one.
 - Linux terminal calls now route default audio through PulseAudio's WebRTC
   echo canceller and noise suppressor. Echo-cancelled input bypasses the
   fallback amplitude/VAD gate so barge-in does not clip quiet words.

--- a/tests/test_grok_auth.py
+++ b/tests/test_grok_auth.py
@@ -329,7 +329,11 @@ def test_file_fallback_reads_a_bom_prefixed_store(tmp_path):
     token = _jwt(time.time() + 7200)
     tokens = {"access_token": token, "refresh_token": REFRESH}
     body = json.dumps({"providers": {"xai-oauth": {"tokens": tokens}}})
-    path = _write_xai_store(tmp_path, access="ignored", raw="﻿" + body)
+    # The BOM as an escape, not as an invisible character in the source.
+    # The bytes written are identical -- the assertion below pins them --
+    # but a U+FEFF typed literally is indistinguishable from one pasted in
+    # by accident, which is why the plugin-guard scanner flags it high.
+    path = _write_xai_store(tmp_path, access="ignored", raw="\ufeff" + body)
     assert path.read_bytes().startswith(b"\xef\xbb\xbf")
     assert talk_grok_auth.resolve_grok_auth(env={}, hermes_home=tmp_path).token == token
 


### PR DESCRIPTION
## What

`tests/test_grok_auth.py` carried a literal U+FEFF as the fixture for the BOM-prefixed auth-store test. It is now written as the six-character escape sequence instead. Two lines of real change; the rest is a comment and a CHANGELOG entry.

## Why this is not cosmetic

The `plugin-guard` scanner flags a literal invisible character as `invisible_unicode` **HIGH**, which takes the whole repository to a **BLOCKED** verdict. That scanner is not just CI — the workflow's own comment records what it gates:

> The upstream plugin scanner (`tools/plugin_guard.py` in NousResearch/hermes-agent, shipped in Hermes v0.20.4) gates `hermes plugins install`: one critical finding blocks the install and `--force` does not override it.

So the block reaches users running `hermes plugins install`, not only pull requests. (This finding is HIGH rather than critical, so `--force` still overrides it — but the default install path is refused.)

It has been red since `01518ae` (2026-09-01), the Grok subscription lane that introduced the character. Release 0.10.1 did this exact cleanup once already — 17 criticals moved into `tests/fixtures/` — and added `.github/workflows/plugin-guard.yml` to keep it green. The gate caught this one; nobody noticed because **the offline half silently skips**:

```
SKIPPED [1] tests/test_plugin_guard.py:47: scanner not present locally;
            set TALK_PLUGIN_GUARD_HOME to run this gate
```

A dev box reports that gate as passing when it has not run at all. Worth knowing when reading a green local suite.

## The fix

The BOM is written as an escape rather than typed as a character. The bytes on disk are unchanged and the test's own assertion still pins them:

```python
path = _write_xai_store(tmp_path, access="ignored", raw="\ufeff" + body)
assert path.read_bytes().startswith(b"\xef\xbb\xbf")
```

The behaviour under test is untouched. What changes is that no invisible character is left in the source for a reader — or a scanner — to have to tell apart from one pasted in by accident. That indistinguishability is the whole reason the check is HIGH, so encoding the intent explicitly is the right answer rather than an allowlist entry.

## Verification

Run against the **real** pinned scanner, not reasoned about. Same scanner commit (`97f3229`) for both runs, both against current `main` (post-#88, post-#89):

| | Decision | plugin-guard |
|---|---|---|
| `main` as-is | `BLOCKED — 51 findings` | `FAIL — 1 critical/high finding(s)`<br>`high: invisible_unicode at tests/test_grok_auth.py:332` |
| with this PR | `ALLOWED — safe verdict` | `OK — zero critical/high findings` |

Reproduce locally:

```bash
mkdir -p /tmp/pg/tools && touch /tmp/pg/tools/__init__.py
sha=$(gh api repos/NousResearch/hermes-agent/commits/main --jq .sha)
for f in plugin_guard.py skills_guard.py; do
  gh api "repos/NousResearch/hermes-agent/contents/tools/$f?ref=$sha" \
    -H "Accept: application/vnd.github.raw" > "/tmp/pg/tools/$f"
done
python .github/plugin_guard_check.py /tmp/pg .
TALK_PLUGIN_GUARD_HOME=/tmp/pg uv run pytest tests/test_plugin_guard.py -q
```

The offline gate passes with the scanner present (it skips without it).

**It is the only one.** A sweep for U+FEFF, U+200B–200D, U+2060, U+00AD, U+200E/200F and U+2028/2029 across every `.py`, `.md`, `.yml` and `.toml` file in the repo now returns nothing. Before this change it returned exactly one hit, this line — so this is the whole of the problem, not the first of a series.

## Gates

- `uv run pytest -q` → **12 failed, 1615 passed, 33 skipped**. The 12 are the pre-existing env failures on this box (11 in `tests/test_capabilities.py`, 1 in `tests/test_cli.py::test_the_cli_lane_and_host_summary_ride_the_minted_prompt`); they fail identically on untouched `main`. `tests/test_grok_auth.py` is 49/49 green.
- `uv run ruff check .` → **All checks passed!**
- No line-ending flips: `git diff --stat` byte-identical to `--ignore-all-space --stat`; both blobs LF-only, and both verified to contain zero BOM bytes — including the CHANGELOG entry that talks about one.
- Fast-forward onto `main` (`1acf8eb`).

## What a live check would confirm

Nothing here needs one — the scanner *is* the artifact, and it was run directly rather than inferred. The only thing this cannot show is the end-user path: that `hermes plugins install` against a released tag actually stops refusing. That needs a Hermes host with a published version, which this box does not have.

— SmokeDev
