### PR TITLE
chore: pin ruff so CI and dev boxes lint the same source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ named rather than smoothed.
   already produced work nobody wanted.
 
 ### Fixed
+- CI lints against a pinned ruff. The dev extra asked for `ruff>=0.4` and CI
+  installed whatever was current, so ruff 0.16 arrived on its own and failed
+  the build on `RUF100`: it stopped reporting `BLE001` where the handler logs
+  the exception through a name it treats as a logger, which retired three
+  `noqa: BLE001` directives in `talk_core_provider.py` — the only module that
+  both names its logger `logger` (the other fourteen use `_log`, which ruff
+  does not recognise) and carries those directives. The trap was that the two
+  versions wanted opposite source: deleting the directives fixed CI and broke
+  every dev box still on 0.15.x. `ruff==0.16.5` is now pinned in the dev extra
+  (which is what CI installs), the three retired directives are gone with
+  their reasons kept as plain comments, and the `[tool.ruff]` comment no
+  longer claims CI runs whatever ruff is current.
 - A Discord `talk join` that refuses before going live now says WHAT
   refused instead of "session exited unsuccessfully". The session already
   knew — it printed the reason to the gateway's stderr and returned a bare

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,9 @@ pip install -e ".[dev]"        # add ,audio if you want a real mic locally
 
 ```bash
 pytest -q          # the whole suite — seconds, not minutes
-ruff check .       # the exact check CI runs
+ruff check .       # the exact check CI runs, on the pinned ruff
+                   # (`pip install -e ".[dev]"` gets that version; a
+                   # different ruff can disagree in BOTH directions)
 ```
 
 **The suite is offline by design**: no secrets, no network, no audio
@@ -70,7 +72,12 @@ the fix is usually the sentence, sometimes the code, never the standard.
   `pytest -q` and `ruff check .`).
 - One logical change per PR; tests ride with the change, not behind it.
 - Broad `except` clauses are house style at the voice boundary (a live
-  call must not die on a stack trace) — each carries a `noqa: BLE001`
-  with the reason. Don't "fix" them; do justify new ones.
+  call must not die on a stack trace) — each states its reason. Don't
+  "fix" them; do justify new ones. Whether the reason also needs a
+  `noqa: BLE001` depends on the pinned ruff and, surprisingly, on what the
+  module calls its logger: since 0.16 ruff drops BLE001 when the handler
+  logs the exception through a name it treats as a logger (`logger` yes,
+  `_log` no), and a directive it no longer needs fails `RUF100`. Let
+  `ruff check .` decide rather than copying a neighbouring handler.
 - Bug reports: the issue form asks for your `talk_status` output — that
   one paste answers version, auth lane, agent lane, and audio in one go.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = ["httpx>=0.27", "aiohttp>=3.9"]
 
 [project.optional-dependencies]
 audio = ["sounddevice>=0.4.6", "numpy>=1.26"]
-dev = ["pytest>=8", "ruff>=0.4"]
+dev = ["pytest>=8", "ruff==0.16.5"]
 
 [build-system]
 requires = ["setuptools>=61"]
@@ -69,10 +69,19 @@ pythonpath = ["."]
 line-length = 100
 target-version = "py311"
 
-# Pinned explicitly: CI installs whatever ruff is current, and an implicit
-# default set turns every ruff release into a possible red build. BLE is on
-# because this codebase catches broadly on purpose (a live voice call must not
-# die on a stack trace) — each one carries a noqa stating why.
+# Two pins, because either one alone still lets a ruff release turn the build
+# red. The RULE SET is pinned here so a new default rule cannot arrive
+# unannounced; the ruff VERSION is pinned in the dev extra above, because the
+# same rule set does not mean the same thing across versions. ruff 0.16 stopped
+# reporting BLE001 when the handler logs the exception through a name it
+# recognises as a logger — it recognises `logger`, not `_log` — so the three
+# handlers in talk_core_provider.py (the only module here that both names its
+# logger `logger` and carries BLE001 directives) had their `noqa` retired and
+# failed CI on RUF100, while every dev box on 0.15.x still required them. Bump
+# both pins together, in their own PR, and expect directives to move. BLE stays
+# on because this codebase catches broadly on purpose (a live voice call must
+# not die on a stack trace) — each one says why, whether or not the current
+# ruff still needs a directive to allow it.
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM", "RUF", "BLE"]
 

--- a/talk_core_provider.py
+++ b/talk_core_provider.py
@@ -495,7 +495,7 @@ if _CORE_IMPORT_ERROR is None:
                 self.default_voice()
                 model = self.default_model()
                 auth = talk_auth.auth_diagnostic()
-            except Exception:  # noqa: BLE001 - readiness never raises
+            except Exception:  # readiness never raises
                 logger.debug("hermes-talk/openai readiness probe failed", exc_info=True)
                 return False
             return bool(model and auth.get("configured"))
@@ -554,7 +554,7 @@ if _CORE_IMPORT_ERROR is None:
                 self.default_voice()
                 model = self.default_model()
                 diagnostic = talk_grok_auth.grok_auth_diagnostic()
-            except Exception:  # noqa: BLE001 - readiness never raises
+            except Exception:  # readiness never raises
                 logger.debug("hermes-talk/grok readiness probe failed", exc_info=True)
                 return False
             return bool(model and diagnostic.get("configured"))
@@ -627,7 +627,7 @@ if _CORE_IMPORT_ERROR is None:
                 self.default_voice()
                 model = self.default_model()
                 configured = bool(talk_config.resolve_gemini_key())
-            except Exception:  # noqa: BLE001 - readiness never raises
+            except Exception:  # readiness never raises
                 logger.debug("hermes-talk/gemini readiness probe failed", exc_info=True)
                 return False
             return bool(model and configured)

--- a/tests/test_repository_hygiene.py
+++ b/tests/test_repository_hygiene.py
@@ -37,3 +37,30 @@ def test_every_version_surface_matches_pyproject():
     assert manifest["version"] == version, (
         f"dashboard/manifest.json version drifted from pyproject ({version})"
     )
+
+
+def test_the_ruff_version_is_pinned_not_floating():
+    """A floating ruff makes every upstream release a possible red build.
+
+    The rule set was already pinned; the VERSION was not, and CI installs
+    ruff from this extra (`pip install -e ".[dev]"`). ruff 0.16 narrowed
+    BLE001 to bound handlers, which retired three directives and failed CI on
+    RUF100 while older dev boxes still required them — the two versions
+    wanted opposite source, so only a pin makes one answer correct.
+    """
+
+    import re
+
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    dev = re.search(r"^dev = \[(?P<deps>[^\]]*)\]", pyproject, re.MULTILINE)
+    assert dev is not None, "the dev extra moved; this guard needs updating"
+
+    ruff = re.search(r'"ruff(?P<spec>[^"]*)"', dev.group("deps"))
+    assert ruff is not None, "ruff left the dev extra; CI installs it from here"
+    assert ruff.group("spec").startswith("=="), (
+        f'ruff must be pinned exactly, found "ruff{ruff.group("spec")}"'
+    )
+
+    # And CI must still be installing from that extra, or the pin is decorative.
+    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert 'pip install -e ".[dev]"' in ci


### PR DESCRIPTION
Fixes the red `ci` on `main`.

## What

- `pyproject.toml` dev extra: `ruff>=0.4` → **`ruff==0.16.5`** (the version CI runs today).
- The three now-retired `# noqa: BLE001` in `talk_core_provider.py` are dropped, each reason kept as a plain comment.
- `[tool.ruff]` comment corrected — it claimed CI installs whatever ruff is current, which is the thing that broke the build.
- CONTRIBUTING note + one hygiene test.

**No workflow change was needed, and here is the line that shows why** — `.github/workflows/ci.yml:33` already installs ruff from the pinned extra:

```yaml
      - name: Install
        run: |
          python -m pip install --upgrade pip
          pip install -e ".[dev]"      # <- line 33: this is where ruff comes from
      - name: Lint
        run: ruff check .
```

Pinning the extra therefore pins CI; the lint step stays `ruff check .`. Adding a second `pip install ruff==0.16.5` would give the version two sources of truth that can silently disagree, so I left it. The new hygiene test asserts *both* halves — the pin is exact **and** ci.yml still installs from that extra — because a pin CI does not use is decorative.

## Why

`ci` on main: SUCCESS at `23351be`, then FAILURE at `d775a96` (#89) and `1acf8eb` (#88). Every branch cut after #89 inherited it, including #92. ruff 0.16 arrived on its own and failed the build on three `RUF100 unused noqa` in `talk_core_provider.py`.

**The correction worth reading.** My first diagnosis — reported earlier as "ruff 0.16 narrowed BLE001 to bound handlers" — was **wrong**. A hygiene test I wrote to encode it immediately flagged `talk_apiserver.py:492`, an *unbound* handler whose directive ruff 0.16.5 happily accepts. So I probed both versions against the same three shapes instead of theorising again:

| handler | ruff 0.15.10 | ruff 0.16.5 |
|---|---|---|
| `except Exception:` + `logger.debug(..., exc_info=True)` | directive needed | **directive unused (RUF100)** |
| `except Exception:` + `_log.debug(..., exc_info=True)` | directive needed | directive needed |
| `except Exception as exc:` + `logger.debug(...)` | directive needed | **directive unused (RUF100)** |

Bound vs unbound is not the axis. **ruff 0.16 stopped reporting BLE001 when the handler logs the exception through a name it treats as a logger — it recognises `logger`, not `_log`.** `talk_core_provider.py` is the only module here that both names its logger `logger` and carries BLE001 directives; the other fourteen use `_log`, which is why their identical-looking handlers were untouched.

## Why deleting the directives is not the fix on its own

The two versions want **opposite source**:

| | ruff 0.15.10 | ruff 0.16.5 |
|---|---|---|
| directives present | clean | 3 × `RUF100` |
| directives removed | 3 × `BLE001` | clean |

There is no `talk_core_provider.py` that satisfies both. Removing them alone just moves the red from CI onto every dev box still on 0.15.x, and the next ruff release can flip it back again. The pin is what makes one answer correct — which is what the `[tool.ruff]` comment already said it wanted ("an implicit default set turns every ruff release into a possible red build"); it pinned the rule set and left the version open, so a ruff release still turned the build red. This is that failure mode arriving.

## On the dropped second test

I also wrote a guard asserting which handlers may carry a directive, and then deleted it. It hand-rolled ruff's own heuristic, the probe above showed that heuristic is subtler than the guard assumed, and `RUF100` already enforces exactly this in CI using ruff's real semantics on the pinned version. A worse copy would only go stale on the next bump. The pin guard stays because it checks something ruff cannot check about itself.

## Verification

```
uv run --with ruff==0.16.5 ruff check .   → All checks passed!
uv run --with ruff==0.15.10 ruff check .  → Found 3 errors.
```

**Dev boxes must be on the pinned version**; `pip install -e ".[dev]"` gets it (`uv sync` also works — `uv.lock` is gitignored and regenerates from `pyproject.toml`). That consequence is recorded in CONTRIBUTING, next to the `ruff check .` line and in the broad-`except` house-style note, with the logger-name subtlety spelled out — copying a neighbouring handler's directive is precisely what goes wrong.

## Gates

- `uv run pytest -q` → **12 failed, 1626 passed, 33 skipped, 5 xfailed**. The 12 are the pre-existing env failures on this box (11 in `tests/test_capabilities.py`, 1 in `tests/test_cli.py::test_the_cli_lane_and_host_summary_ride_the_minted_prompt`); they fail identically on untouched `main`.
- `ruff check .` on the pinned version → **All checks passed!**
- No line-ending flips: `git diff --stat` byte-identical to `--ignore-all-space --stat`; all five blobs LF-only.
- Rebased onto `637366d` (post-#91) — fast-forward.

## What a live check would confirm

Nothing beyond CI, which is the artifact here: this PR's whole claim is "the lint step goes green and stays green", and the CI run on this branch tests it directly on all six matrix jobs. The one thing neither CI nor I can prove is the next bump — the pin makes a ruff upgrade a deliberate PR that will likely have to move directives again, rather than a surprise red build.

— SmokeDev
