### PR TITLE
ci: CodeQL, OpenSSF Scorecard, dependency review, and release attestations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+# Static analysis over the plugin's Python and over these workflow files
+# themselves. Runs on every PR and push to main, plus a weekly sweep so a
+# newly published query still lands on an idle repo.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 1"  # Mondays 04:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write  # upload results to code scanning
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,29 @@
+name: Dependency review
+
+# Diffs the dependency graph of a PR against its base and fails on a known
+# vulnerability (moderate or worse) or a license outside the allowlist. The
+# runtime deps are two (httpx, aiohttp); this is mostly here so a future
+# addition cannot arrive with a CVE attached.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, PSF-2.0, 0BSD, Unlicense

--- a/.github/workflows/plugin-guard.yml
+++ b/.github/workflows/plugin-guard.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,17 +2,25 @@ name: publish
 
 # Publishes to PyPI via trusted publishing (OIDC) — no API token stored
 # anywhere. Trigger: push a version tag (git tag v0.8.0 && git push --tags).
+# The release ships with provenance twice over: a PEP 740 attestation on
+# PyPI (Trusted Publishing signs it) and a GitHub build-provenance
+# attestation on the same dist files, visible on the repo's Attestations tab.
 on:
   push:
     tags: ["v*"]
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -36,7 +44,7 @@ jobs:
           print(f"all {len(expected)} declared modules present in {wheel}")
           EOF
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -46,11 +54,22 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      id-token: write  # required for PyPI trusted publishing
+      id-token: write      # PyPI trusted publishing + signing both attestations
+      attestations: write  # write the GitHub build-provenance attestation
+      contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Attest build provenance (GitHub)
+        # Runs BEFORE the upload so a failed attestation stops the release
+        # rather than leaving an unattested version on PyPI.
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: dist/*
+
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          attestations: true  # PEP 740 — stated explicitly so it can't drift

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: OpenSSF Scorecard
+
+# Supply-chain hygiene score (pinned deps, branch protection, token perms,
+# dangerous workflow patterns…). publish_results makes the badge render and
+# feeds the public API at https://scorecard.dev/viewer/?uri=github.com/TheSmokeDev/hermes-talk.
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "37 5 * * 2"  # Tuesdays 05:37 UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write         # required by publish_results
+      security-events: write  # upload the SARIF to code scanning
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ named rather than smoothed.
   tool call mid-turn; until now that was recorded silently and only visible as a
   dropped result on the send path, which told policy nothing until it had
   already produced work nobody wanted.
+- A visible trust surface on the repository (#95). Three new workflows:
+  CodeQL over the Python and over the workflow files themselves (PR, push,
+  weekly), OpenSSF Scorecard (push, weekly, results published so the badge
+  and the public viewer render), and dependency review on every PR (fails
+  on a moderate-or-worse advisory or a license outside the permissive
+  allowlist). Releases now carry provenance twice: `publish.yml` attests the
+  built dist with `actions/attest-build-provenance` before uploading, and the
+  PyPI upload passes `attestations: true` (PEP 740). Every third-party action
+  in every workflow is pinned to a full commit SHA with its version alongside
+  — the standard `plugin-guard.yml` already set for the upstream scanner —
+  which also moves `checkout` and `setup-python` from their floating `v4`/`v5`
+  majors to current releases. The README header gained CodeQL, Scorecard, and
+  PyPI badges.
 
 ### Fixed
 - CI lints against a pinned ruff. The dev extra asked for `ruff>=0.4` and CI

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 **Realtime voice as an orchestrator for [Hermes Agent](https://github.com/NousResearch/hermes-agent) — talk to it, it runs agents, it reports back out loud.**
 
+<p>
+  <a href="https://github.com/TheSmokeDev/hermes-talk/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/TheSmokeDev/hermes-talk/actions/workflows/codeql.yml/badge.svg"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/TheSmokeDev/hermes-talk"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/TheSmokeDev/hermes-talk/badge"></a>
+  <a href="https://pypi.org/project/hermes-talk/"><img alt="PyPI" src="https://img.shields.io/pypi/v/hermes-talk"></a>
+</p>
+
 <!-- Regenerate this GIF (needs ffmpeg): python docs/render-dashboard-gif.py -->
 ![The Talk tab in the Hermes dashboard — a live voice session, a background agent delegated mid-conversation, its result landing in the runs panel (8× speed)](docs/dashboard.gif)
 


### PR DESCRIPTION
Closes #95.

## What

Three new workflows plus provenance on releases — the trust surface the repo page was missing.

| File | Trigger | What it proves |
|---|---|---|
| `codeql.yml` | PR, push to main, Mondays | CodeQL over `python` **and** `actions` (the workflow files themselves) |
| `scorecard.yml` | push to main, Tuesdays | OpenSSF Scorecard, `publish_results: true` so the badge + public viewer render, SARIF into code scanning |
| `dependency-review.yml` | PR | fails on a moderate+ advisory or a license outside the permissive allowlist |
| `publish.yml` | tag | `actions/attest-build-provenance` on the dist **before** upload (a failed attestation stops the release), `attestations: true` on the PyPI step (PEP 740), `attestations: write` added to the publish job |

Every third-party action in every workflow is now pinned to a full commit SHA with the version alongside — the standard `plugin-guard.yml` already set for the upstream scanner. `checkout`/`setup-python` move from floating `v4`/`v5` to `v7.0.1`/`v7.0.0` as part of the pin. All SHAs resolved from the GitHub API against the tag named in each comment.

README header gets CodeQL / Scorecard / PyPI badges (the full badge row lands with #96). CHANGELOG `[Unreleased]` → Added.

## Receipts

- Every workflow file parses (`yaml.safe_load`, all six).
- `uv run --extra dev ruff check .` — `ruff 0.16.5`, all checks passed.
- `uv run --extra dev pytest -q` — 1480 passed, 39 skipped, 5 xfailed; one flake on this box (`test_transcript.py::test_force_killed_sweeper_claim_is_recovered_by_next_process`) that passes 3/3 in isolation. No Python changed in this PR.
- CodeQL and dependency review run on this PR itself — see the checks below. Scorecard runs on merge to main.

## Not in this PR

- Repo settings, not files: secret scanning + push protection are **disabled** on this repo (`security_and_analysis` via the API). Scorecard will flag it; flipping it is a one-click setting.

— SmokeDev
