### PR TITLE
docs: README leads with what works today; CONTRIBUTING covers uv + #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,23 @@ named rather than smoothed.
   majors to current releases. The README header gained CodeQL, Scorecard, and
   PyPI badges.
 
+### Changed
+- README leads with what works today (#96). The first screen is now: what it
+  is, the three surfaces and three providers as facts, a one-line install,
+  the demo GIF with the with-sound cut on its own line, a full badge row (CI,
+  CodeQL, Scorecard, PyPI version and downloads, license), and an "Is it
+  working?" block that puts `hermes talk doctor` before any narrative. New
+  Surfaces and Providers tables, a "Current boundaries" section that states
+  the no-self-hosted-lane limit and the other honest gaps ourselves, and a
+  "Where this sits upstream" section for RFC #77111, core PR #101808, and
+  docs PR #97325. The stale "650+ offline tests" receipt is now 1,400+ across
+  46 files, and the Status block no longer hardcodes a stale version — the
+  PyPI badge carries it.
+  Every existing section survives — reorganized, none deleted. CONTRIBUTING
+  gains the `uv sync --extra dev` path, the `ruff==0.16.5` pin's reason, the
+  #93 twelve-test baseline on a box where Hermes is importable, and the
+  module table now lists every shipped module.
+
 ### Fixed
 - CI lints against a pinned ruff. The dev extra asked for `ruff>=0.4` and CI
   installed whatever was current, so ruff 0.16 arrived on its own and failed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,18 @@ cd hermes-talk
 pip install -e ".[dev]"        # add ,audio if you want a real mic locally
 ```
 
+Or with [uv](https://docs.astral.sh/uv/), which keeps the whole thing in a
+project-local `.venv`:
+
+```bash
+uv sync --extra dev            # --extra audio too, for a real mic
+uv run pytest -q
+uv run ruff check .
+```
+
+Either way you get the pinned `ruff==0.16.5` from the dev extra — the pin is
+load-bearing, see below.
+
 ## Tests and lint
 
 ```bash
@@ -26,32 +38,59 @@ host against a stub plugin context, audio against fakes. That's why CI
 needs nothing from you — no keys, no env, no fixtures — and why a test
 that wants the network is a test shaped wrong for this repo.
 
+**One trap on a box that runs the plugin for real** ([#93](https://github.com/TheSmokeDev/hermes-talk/issues/93)):
+if `hermes-agent` is importable from the interpreter running the tests —
+which it is when `pytest` resolves to the Hermes install's own venv, e.g.
+`%LOCALAPPDATA%\hermes\hermes-agent\venv` on Windows — twelve tests in
+`tests/test_capabilities.py` and `tests/test_cli.py` fail, because the
+capability catalog answers in-process from the live install instead of
+staying inert. CI never sees it (no Hermes there). A project-local venv
+(`uv sync` above, or `python -m venv .venv && pip install -e ".[dev]"`)
+side-steps it; until the tests are hermetic, those twelve are the known
+baseline on such a box and anything else red is yours.
+
 ## Layout — flat modules, on purpose
 
 Top-level `talk_*` modules, no package nesting. Hermes loads plugins by
 file path, and the flat layout with a collision-proof prefix is the shape
 that survives both that loader and `pip install`. Don't restructure it.
+Every shipped module is listed in `pyproject.toml` under `py-modules` —
+setuptools silently drops a name with no file behind it, and `publish.yml`
+fails the release if a declared module is missing from the wheel.
 
 | Module | One line |
 |---|---|
 | `talk_wire.py` | Pure OpenAI Realtime protocol — payloads and ephemeral mints, zero host knowledge |
 | `talk_auth.py` | The three credential lanes, resolved fail-closed |
+| `talk_grok_auth.py` | Grok (xAI) credential resolution — subscription login or key, fail-closed |
 | `talk_doctor.py` | Read-only detect/decide/verify diagnostics and renderers |
 | `talk_setup.py` | Interactive missing-decision prompts, per-write confirmation, and post-write doctor verification |
 | `talk_realtime.py` | Typed provider-neutral session setup, events, commands, lifecycle states, and adapter protocol |
 | `talk_openai_realtime.py` | OpenAI ephemeral-mint/WebSocket adapter and neutral-to-wire translation |
+| `talk_grok_realtime.py` | Grok (xAI) implementation of the provider-neutral Realtime session contract |
+| `talk_gemini_realtime.py` | Gemini Live implementation of the provider-neutral Realtime session contract |
+| `talk_core_provider.py` | The three lanes published on the Hermes core `RealtimeVoiceProvider` contract |
+| `talk_core_realtime.py` | Defensive Hermes core API-v2 OpenAI Realtime adapter |
+| `talk_core_session.py` | Transport-neutral admission primitives for canonical Talk sessions |
 | `talk_config.py` | Every knob, resolved at call time — never cached at import |
 | `talk_identity.py` | Identity sections → session instructions, budgeted |
 | `talk_relay.py` | Realtime event loop — transport-agnostic, fully testable offline |
-| `talk_audio.py` | Duplex mic/speaker (sounddevice) |
+| `talk_audio.py` | Duplex mic/speaker (sounddevice), echo gate, PulseAudio AEC on Linux |
+| `talk_discord.py` | Discord voice as an audio device — the same methods, a different room |
+| `talk_cascade_voice.py` | Custom-voice cascade — the provider thinks in text, ElevenLabs speaks |
 | `talk_cli.py` | `hermes talk` — transport, lifecycle, the announcement pump |
-| `talk_tools.py` | The 9 model-facing tools and their speakable-error contract |
+| `talk_tools.py` | The 11 model-facing tools and their speakable-error contract |
+| `talk_operator_auth.py` | Fail-closed Discord authorization for state-changing Talk tools |
+| `talk_approvals.py` | The spoken approval bridge — voice resolves run approvals out loud |
 | `talk_host.py` | The host adapter — agent lanes, steer/redirect/stop verbs |
 | `talk_runs.py` | Async-run registry with the durable history tail |
+| `talk_progress.py` | Bounded progress phases for background work |
 | `talk_steer.py` | The receipt ledger and both delivery-artifact watchers |
 | `talk_lifecycle.py` | subagent start/stop hooks → roster, ledger, announcements |
 | `talk_apiserver.py` | The api-server agent lane |
 | `talk_capabilities.py` | Live capability catalog — in-process probe first, REST fallback, TTL-cached |
+| `talk_transcript.py` | Durable transcript capture and crash-safe memory handoff |
+| `talk_vault.py` | Vault recall — the durable-notes lookup a voice session can make |
 | `talk_providers.py` | Optional REST TTS/STT providers |
 
 ## How changes ship here
@@ -69,7 +108,10 @@ the fix is usually the sentence, sometimes the code, never the standard.
 ## Pull requests
 
 - Keep the suite green on ubuntu + windows × 3.11–3.13 (CI runs exactly
-  `pytest -q` and `ruff check .`).
+  `pytest -q` and `ruff check .`). CodeQL and dependency review run on the
+  PR as well; every third-party action in `.github/workflows/` is pinned to
+  a commit SHA with its version in a comment — keep it that way when you
+  bump one.
 - One logical change per PR; tests ride with the change, not behind it.
 - Broad `except` clauses are house style at the voice boundary (a live
   call must not die on a stack trace) — each states its reason. Don't
@@ -81,3 +123,4 @@ the fix is usually the sentence, sometimes the code, never the standard.
   `ruff check .` decide rather than copying a neighbouring handler.
 - Bug reports: the issue form asks for your `talk_status` output — that
   one paste answers version, auth lane, agent lane, and audio in one go.
+  `hermes talk doctor --json` is the fuller receipt.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,72 @@
 # hermes-talk
 
-**Realtime voice as an orchestrator for [Hermes Agent](https://github.com/NousResearch/hermes-agent) — talk to it, it runs agents, it reports back out loud.**
+**Realtime duplex voice for [Hermes Agent](https://github.com/NousResearch/hermes-agent) — talk to it, it runs agents, it reports back out loud.**
 
 <p>
+  <a href="https://github.com/TheSmokeDev/hermes-talk/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/TheSmokeDev/hermes-talk/actions/workflows/ci.yml/badge.svg"></a>
   <a href="https://github.com/TheSmokeDev/hermes-talk/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/TheSmokeDev/hermes-talk/actions/workflows/codeql.yml/badge.svg"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/TheSmokeDev/hermes-talk"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/TheSmokeDev/hermes-talk/badge"></a>
   <a href="https://pypi.org/project/hermes-talk/"><img alt="PyPI" src="https://img.shields.io/pypi/v/hermes-talk"></a>
+  <a href="https://pypi.org/project/hermes-talk/"><img alt="PyPI downloads" src="https://img.shields.io/pypi/dw/hermes-talk"></a>
+  <a href="LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-16a34a"></a>
 </p>
+
+Works today: a native mic session in the terminal (`hermes talk`), a Discord voice channel (`/talk join`), and a **Talk** tab in the Hermes dashboard — on OpenAI Realtime, xAI Grok Voice, or Gemini Live. The voice model calls Hermes's own tools, hands work to real background agents while you keep talking, and when a delegated run hits an approval gate it asks you out loud and your spoken answer resolves it. A ChatGPT or SuperGrok subscription is enough — no API key required.
+
+```bash
+hermes plugins install TheSmokeDev/hermes-talk --enable && pip install "hermes-talk[audio]" && hermes talk
+```
 
 <!-- Regenerate this GIF (needs ffmpeg): python docs/render-dashboard-gif.py -->
 ![The Talk tab in the Hermes dashboard — a live voice session, a background agent delegated mid-conversation, its result landing in the runs panel (8× speed)](docs/dashboard.gif)
 
-*Real session, 8× speed. 🔊 [Watch it with sound](https://github.com/TheSmokeDev/hermes-talk/releases/download/v0.3.0/hermes-talk-dashboard-cut.mp4) — 2:27: delegate, keep talking, hear the result land. This is a voice demo; the sound is the point. Recorded at v0.3.0 — the flow is unchanged.*
+### 🔊 [Watch the 2:27 cut with sound](https://github.com/TheSmokeDev/hermes-talk/releases/download/v0.3.0/hermes-talk-dashboard-cut.mp4) — delegate, keep talking, hear the result land.
+
+*Real session, 8× speed in the GIF. This is a voice demo; the sound is the point. Recorded at v0.3.0 — the flow is unchanged.*
+
+## Is it working?
+
+```bash
+hermes plugins list        # → hermes-talk · enabled · current version
+hermes talk --help         # → registration proof: the command only exists if the plugin loaded
+hermes talk setup          # → guided, confirmation-gated setup plus doctor verification
+hermes talk doctor         # → read-only diagnostics: auth lane, provider, model/voice, audio, host lanes
+hermes talk doctor --json  # → the same versioned receipt for scripts and issue reports
+# then, in any session: say "status report" — talk_status answers with
+# version, auth lane, agent lane, and audio state.
+```
+
+Doctor is read-only by design: it names which lane came up and what is
+missing, and never writes, probes, or refreshes a token (the one exception is
+`--probe`, Grok-only, which makes two live calls to `api.x.ai` and says so).
+`hermes talk check` — next release — goes one step further: a real provider
+session plus one bounded Hermes run that must echo a token, so a green report
+proves the live path and not just the configuration.
+
+**Upgrade** with `hermes plugins update hermes-talk` — not a second
+`install` (it refuses on an existing plugin) — then **restart the
+gateway**: a running process keeps executing the old code until you do.
+Full runbook, wire canary included: [docs/OPERATING.md](docs/OPERATING.md#verify--the-receipts).
+
+## Surfaces
+
+| Surface | Start it | Audio | Providers |
+|---|---|---|---|
+| Terminal | `hermes talk` | native duplex mic + speaker (`sounddevice`, the `[audio]` extra) | OpenAI, Grok, Gemini; cascade voice |
+| Inside a Hermes session | `/talk` | same as terminal | the one surface with an **attached** agent loop — memory lookups and delegation answer inline |
+| Discord voice channel | `/voice join`, then `/talk join` | borrows the host's own voice connection — never opens a second one | OpenAI, Grok; speaker-bound authority via `TALK_DISCORD_OPERATOR_USER_IDS` |
+| Dashboard **Talk** tab | `hermes dashboard` | browser-native WebRTC, no mic drivers | OpenAI only today; loopback-only until `TALK_DASHBOARD_TOKEN` is set |
+
+## Providers
+
+| Provider | `TALK_PROVIDER` | Auth | Notes |
+|---|---|---|---|
+| OpenAI Realtime | `openai` (default) | your ChatGPT subscription through the Codex CLI login (`codex login`) — **no API key** — or `TALK_OPENAI_API_KEY` / `OPENAI_API_KEY` | every surface; the only lane the dashboard tab and the cascade voice speak today |
+| xAI Grok Voice | `grok` | SuperGrok / X Premium+ login (`hermes auth add xai-oauth`) — **no API key** — or `TALK_XAI_API_KEY` / `XAI_API_KEY` | terminal + Discord; five voices |
+| Gemini Live | `gemini` | `GEMINI_API_KEY` / `TALK_GEMINI_API_KEY` — free-tier AI Studio keys work | terminal + `hermes realtime`; no client-side cancel/truncate on the wire, so barge-in drops playback locally; Discord refuses it for now |
+
+The knob is fail-closed and never inferred from which keys exist. Full
+per-lane detail: [Provider details](#provider-details--openai-default-grok-or-gemini).
 
 ## What this actually is
 
@@ -46,12 +101,6 @@ integrations don't have:
    and the first thing you say lands on an agent that already has context. No
    tool call, no "let me look that up", no warm-up turn.
 
-**Why this exists:** OpenAI shipped this exact pattern for Codex on 2026-07-23
-— voice as a control layer over concurrent agents. It's excellent, and it's
-closed: paid ChatGPT plans only, and GPT-Live has no developer API. Their own
-docs point builders back at the Realtime API. So that's what this is built on,
-for an agent you actually own.
-
 Hermes's built-in voice mode is good and this doesn't replace it — turn-based
 STT → inference → TTS is the right shape for plenty of work. This is the other
 shape.
@@ -69,12 +118,13 @@ that property, announcements are suppressed rather than guessed. Details are in
 
 ```bash
 hermes plugins install TheSmokeDev/hermes-talk --enable
-pip install "hermes-talk[audio]"   # mic + speaker support (sounddevice)
+pip install "hermes-talk[audio]"   # mic + speaker support (sounddevice); skip if dashboard-only
 hermes talk
 ```
 
 Zero core edits — pure `register(ctx)` plugin surface, proven on a stock
-v0.17.0 install. 650+ offline tests, CI on ubuntu + windows × py3.11–3.13.
+v0.17.0 install. 1,400+ offline tests across 46 files in [`tests/`](tests/),
+CI on ubuntu + windows × py3.11–3.13.
 
 ## Quickstart — your first call on each surface
 
@@ -108,28 +158,6 @@ In every case, `hermes talk doctor` (or saying "status report" on the call)
 tells you which lane came up and what is missing. If a surface shows
 nothing, run doctor first — it names the gap.
 
-## Verify your install
-
-```bash
-hermes plugins list    # → hermes-talk · enabled · current version
-hermes talk --help     # → registration proof: the command only exists if the plugin loaded
-hermes talk setup      # → guided, confirmation-gated setup plus doctor verification
-hermes talk doctor     # → read-only human diagnostics
-hermes talk doctor --json  # → the same versioned receipt for scripts/issues
-# then, in any session: say "status report" — talk_status answers with
-# version, auth lane, agent lane, and audio state.
-```
-
-**Upgrade** with `hermes plugins update hermes-talk` — not a second
-`install` (it refuses on an existing plugin) — then **restart the
-gateway**: a running process keeps executing the old code until you do.
-Full runbook, wire canary included: [docs/OPERATING.md](docs/OPERATING.md#verify--the-receipts).
-
-Contributors adapting The Homie's v1.7.0 capability-plugin lessons to Hermes
-should use the [capability-kernel port plan](docs/CAPABILITY-KERNEL-PORT.md).
-It maps the reusable safety and lifecycle contracts onto Hermes-owned APIs;
-it does not claim that hot lifecycle support already exists here.
-
 ## Auth — no API key needed if you have ChatGPT
 
 Signed into the [Codex CLI](https://github.com/openai/codex) (`codex login`)?
@@ -162,7 +190,7 @@ Whatever the lane, the session is minted server-side into an **ephemeral
 client secret** — the raw key or OAuth token touches exactly one OpenAI
 endpoint and never reaches the socket, a log line, or a client.
 
-## Providers — OpenAI (default), Grok, or Gemini
+## Provider details — OpenAI (default), Grok, or Gemini
 
 `TALK_PROVIDER` picks the realtime voice transport: `openai` (default,
 everything above), `grok` (xAI Grok Voice), or `gemini` (Gemini Live). The
@@ -680,19 +708,82 @@ The three that shaped everything else:
 - **Hermes owns the tools and the session.** The Realtime layer is ears, mouth,
   and turn-taking. It never owns the agent loop.
 
+## Current boundaries
+
+Stated here so nobody has to discover them on a call:
+
+- **No self-hosted realtime lane.** All three providers are hosted. The
+  provider contract (`talk_realtime.py`) is where a local model plugs in, and
+  the core registration already declares capabilities per lane — so a local
+  lane can ship honestly as talk-without-tools the day a model can carry it.
+  Today none is shipped.
+- **The dashboard tab is OpenAI-only**, and the cascade voice is OpenAI-only.
+  Grok has no WebRTC offer endpoint; only OpenAI's text-output mode is wired
+  and verified for the cascade.
+- **Discord refuses Gemini.** The gated-response authorization flow has no
+  Live wire equivalent, so connect fails closed rather than answering
+  unvetted speakers.
+- **Memory writeback covers terminal and Discord, not the dashboard tab**
+  (its Realtime events stay in the browser).
+- **Result delivery is bound to the session that started the work.** Same
+  Hermes session reconnecting: spoken exactly once. A different session, or a
+  run from a previous process: reported `lost`, never "still running".
+- **Steering reaches subagents only.** api-server and detached runs are
+  stop-only; the refusal says so and offers the stop that works.
+- **Open mic with server-side turn detection.** No wake word, no push-to-talk.
+  `TALK_SESSION_KEY` is a shared memory scope, not a speaker boundary — leave
+  it unset in multi-user channels.
+- **No latency instrumentation.** The plugin emits no first-audio metric; the
+  timings quoted in the cascade section are not something it measures for you
+  on a call.
+
+## Where this sits upstream
+
+- [RFC NousResearch/hermes-agent#77111](https://github.com/NousResearch/hermes-agent/issues/77111)
+  — filed from this repo: a `RealtimeVoiceProvider` ABC for Hermes core, because
+  four open PRs were building duplex voice independently and the category
+  deserves an interface rather than a merge queue. This plugin is the working
+  reference implementation for that discussion, not a bid to be merged.
+- [PR NousResearch/hermes-agent#101808](https://github.com/NousResearch/hermes-agent/pull/101808)
+  — the core contract, orchestrator, and first built-in provider, ported from
+  this plugin's orchestrator and OpenAI transport. hermes-talk already
+  publishes its three lanes on that contract (see
+  [Hermes core realtime contract](#hermes-core-realtime-contract)).
+- [PR NousResearch/hermes-agent#97325](https://github.com/NousResearch/hermes-agent/pull/97325)
+  — a pointer to this plugin on the official Voice Mode docs page.
+
+## Background — why this exists
+
+OpenAI shipped this exact pattern for Codex on 2026-07-23 — voice as a control
+layer over concurrent agents. It's excellent, and it's closed: paid ChatGPT
+plans only, and GPT-Live has no developer API. Their own docs point builders
+back at the Realtime API. So that's what this is built on, for an agent you
+actually own.
+
 ## Status
 
-v0.7.0 — under active development. Changes, all seven versions with their
-receipts: [CHANGELOG.md](CHANGELOG.md). Roadmap: barge-in latch + spoken-text
-normalizer, Gemini Live backend
-([#3](https://github.com/TheSmokeDev/hermes-talk/issues/3)), `computer_use`
-relay, session-end memory debrief, gateway platform adapter.
+Under active development; the PyPI badge above is the released version.
+Every version with its receipts: [CHANGELOG.md](CHANGELOG.md). Open epics and
+threads:
+[#19](https://github.com/TheSmokeDev/hermes-talk/issues/19) provider-neutral
+Realtime voice platform,
+[#32](https://github.com/TheSmokeDev/hermes-talk/issues/32) operator-grade
+orchestration UX,
+[#43](https://github.com/TheSmokeDev/hermes-talk/issues/43) Talk over the Bot
+Mode roster,
+[#44](https://github.com/TheSmokeDev/hermes-talk/issues/44) channel-neutral
+voice transport.
 
-Related: [RFC #77111](https://github.com/NousResearch/hermes-agent/issues/77111)
-proposes a `RealtimeVoiceProvider` ABC in Hermes core — four open PRs are
-building duplex voice independently, and the category deserves an interface
-rather than a merge queue. This plugin is a working reference implementation
-for that discussion, not a bid to be merged.
+## Contributing
+
+Clone, `pip install -e ".[dev]"` (or `uv sync --extra dev`), `pytest -q`,
+`ruff check .` — the whole thing is in [CONTRIBUTING.md](CONTRIBUTING.md),
+including the one test trap on a box that has Hermes installed.
+
+Contributors adapting The Homie's v1.7.0 capability-plugin lessons to Hermes
+should use the [capability-kernel port plan](docs/CAPABILITY-KERNEL-PORT.md).
+It maps the reusable safety and lifecycle contracts onto Hermes-owned APIs;
+it does not claim that hot lifecycle support already exists here.
 
 ## License
 


### PR DESCRIPTION
Closes #96. **Stacked on #99** (base is `ci/trust-surface`, so the diff here is only the docs change; GitHub retargets to `main` when #99 merges — merge #99 first).

## What the first screen says now

1. What it is — one line.
2. Badge row: CI · CodeQL · Scorecard · PyPI version · PyPI downloads · license.
3. What works **today**, as facts: terminal mic, Discord voice channel, dashboard Talk tab; OpenAI Realtime / xAI Grok Voice / Gemini Live; the voice model calls Hermes's own tools; delegated runs that hit an approval gate ask out loud and a spoken answer resolves it; ChatGPT or SuperGrok subscription, no API key.
4. One-line install: `hermes plugins install TheSmokeDev/hermes-talk --enable && pip install "hermes-talk[audio]" && hermes talk` (the audio extra stays in the line — `hermes talk` needs `sounddevice`; `talk_doctor.py:659` is the receipt).
5. The GIF (`docs/dashboard.gif`, 1280 px), then the with-sound cut on its own line.
6. **Is it working?** — `hermes plugins list` / `hermes talk --help` / `setup` / `doctor` / `doctor --json`, doctor's read-only contract, and `hermes talk check` named as next-release.

Then **Surfaces** and **Providers** tables, then the existing narrative.

## New sections
- **Current boundaries** — no self-hosted lane (stated by us, pointing at `talk_realtime.py` as where one plugs in), dashboard + cascade OpenAI-only, Discord refuses Gemini, memory writeback not on the dashboard tab, session-bound result delivery, subagent-only steering, open mic (no wake word / push-to-talk), no latency metric.
- **Where this sits upstream** — RFC #77111, core PR #101808, docs PR #97325.
- **Background — why this exists** — the OpenAI/Codex paragraph, moved out of the top third.
- **Contributing** — one line to CONTRIBUTING.md; the capability-kernel port paragraph moved here.

## Nothing deleted
Every H2/H3 from `main` survives: "Verify your install" is absorbed into "Is it working?" (same commands, fuller comments), "Providers — OpenAI (default), Grok, or Gemini" is retitled "Provider details — …" so the table owns the short name. All three anchors other text links to (`#reaching-a-real-agent--the-three-lanes`, `#redirecting-work-thats-already-running`, `#turning-the-api-server-lane-on`) are unchanged; every relative link and anchor in the new README was checked against the tree.

## Corrected receipts
- "650+ offline tests" → **1,400+ across 46 files** (`grep -c "def test_"` over `tests/` = 1445; 46 `test_*.py`).
- Status no longer hardcodes `v0.7.0`; the PyPI badge carries the version.
- CONTRIBUTING said "9 model-facing tools" — `talk_tools.py` has 11; the module table listed 19 of the 32 shipped modules — now all of them.

## CONTRIBUTING additions
`uv sync --extra dev` path, why `ruff==0.16.5` is load-bearing, and the #93 note: on a box where `hermes-agent` is importable (Hermes's own venv), 12 tests in `test_capabilities.py` / `test_cli.py` fail; a project-local venv side-steps it.

## Gates
`uv run --extra dev ruff check .` clean (0.16.5). No Python touched. `git diff --stat` == `git diff --ignore-all-space --stat`.

— SmokeDev

