### PR TITLE
ci: least-privilege GITHUB_TOKEN on ci and plugin-guard workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
   # created). This lets an operator run the suite against any ref by hand.
   workflow_dispatch:
 
+# Least-privilege GITHUB_TOKEN. The suite only checks out the tree, installs
+# from PyPI, and runs pytest/ruff — it writes nothing back to GitHub, so
+# contents:read (what actions/checkout needs) is the whole grant. Without this
+# block the token inherits the repository default, which can be read/write.
+permissions:
+  contents: read
+
 jobs:
   test:
     # No secrets, no network: the suite runs against scripted Realtime

--- a/.github/workflows/plugin-guard.yml
+++ b/.github/workflows/plugin-guard.yml
@@ -8,6 +8,15 @@ on:
   # ref by hand when event delivery drops.
   workflow_dispatch:
 
+# Least-privilege GITHUB_TOKEN. The job checks out this tree and reads two
+# files from a PUBLIC upstream repository through `gh api`; a token scoped to
+# contents:read on this repository can still read public repositories, and
+# the authenticated call is only there for the rate limit. Nothing is written
+# back to GitHub. Without this block the token inherits the repository
+# default, which can be read/write.
+permissions:
+  contents: read
+
 jobs:
   scan:
     # The upstream plugin scanner (tools/plugin_guard.py in


### PR DESCRIPTION
## What

Adds a top-level `permissions: contents: read` block to `.github/workflows/ci.yml` and `.github/workflows/plugin-guard.yml`. Nothing at job level — neither job needs more.

## Why

Both workflows ran with the repository's default `GITHUB_TOKEN` grant, which can be read/write. CodeQL (the `actions` analysis from #99) flagged both as `actions/missing-workflow-permissions` — alerts #20 and #21 on `main`. Least privilege is the fix, and it is what the sibling workflows (`codeql.yml`, `dependency-review.yml`, `publish.yml`) already do.

## What each job actually needs (read, not assumed)

- **ci / `test`**: `actions/checkout` (needs `contents: read`), `actions/setup-python`, `pip install -e ".[dev]"` from PyPI, `pytest -q`, `ruff check .`. Writes nothing to GitHub.
- **plugin-guard / `scan`**: `actions/checkout` (`contents: read`), then `gh api repos/NousResearch/hermes-agent/...` with `GITHUB_TOKEN` to resolve a commit and download two scanner files from a **public** upstream repository. A token scoped to `contents: read` on this repository still reads public repositories; the authenticated call is there for the rate limit, not for access. Writes nothing to GitHub.

## Verification

- YAML parsed with PyYAML: both files → `permissions == {'contents': 'read'}`, single job each, no job-level `permissions`.
- Diff parity: `git diff --stat` equals `git diff --ignore-all-space --stat` (+16 lines, comments included).
- This PR's own `ci`, `plugin-guard`, and CodeQL (actions) checks run under the new grant — see the checks below. If the `plugin-guard` fetch had needed more than public read, it would fail right here.

Closes CodeQL alerts #20 and #21.

— SmokeDev
