### PR TITLE
ci: Scorecard polish — codeql permissions, SECURITY.md, dependabot, no stack traces to dashboard clients

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Dependabot keeps the two dependency surfaces current on the same weekly
+# cadence CodeQL and Scorecard already sweep on. Minor and patch bumps arrive
+# grouped — one PR per ecosystem per week, not one per package — so review
+# cost stays flat; a major bump still gets its own PR because it deserves its
+# own read. Every action in the workflows is pinned to a commit SHA, and
+# Dependabot updates the SHA together with the version comment beside it.
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: Etc/UTC
+    groups:
+      python-minor-and-patch:
+        update-types: [minor, patch]
+    labels: [dependencies]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: Etc/UTC
+    groups:
+      actions-minor-and-patch:
+        update-types: [minor, patch]
+    labels: [dependencies]
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,9 +12,11 @@ on:
     - cron: "23 4 * * 1"  # Mondays 04:23 UTC
   workflow_dispatch:
 
+# Workflow-level grant is read-only; the one write the analyze job needs
+# (uploading its SARIF to code scanning) is granted on that job alone, so a
+# job added later starts read-only instead of inheriting a write.
 permissions:
   contents: read
-  security-events: write  # upload results to code scanning
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -25,6 +27,9 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write  # upload results to code scanning
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ named rather than smoothed.
 ## [Unreleased]
 
 ### Added
+- `SECURITY.md`: supported versions (the latest PyPI release and `main`),
+  private reporting through GitHub security advisories (private vulnerability
+  reporting is enabled on the repository), a 72-hour acknowledgement target,
+  and what counts — credential leakage, auth-store writes outside the
+  documented refresh, tool-authority bypass, redaction failures, supply chain.
+- `.github/dependabot.yml`: weekly `pip` and `github-actions` updates, minor
+  and patch bumps grouped into one PR per ecosystem, majors on their own.
 - `hermes talk check` proves the whole voice path end to end, right now
   (#97). Doctor is read-only by design, so a green doctor could still hide a
   dead mint, a refused socket, or a delegation lane that never starts. The
@@ -101,6 +108,20 @@ named rather than smoothed.
   module table now lists every shipped module.
 
 ### Fixed
+- The dashboard `/status` route no longer echoes a configuration error's
+  text into its response (CodeQL `py/stack-trace-exposure`). An unusable
+  `TALK_VOICE` or `TALK_VOICE_MODE` still keeps the tile answerable, but the
+  response now names only WHICH setting refused plus a short reference; the
+  exception text — which quotes the offending value — goes to the dashboard's
+  own log under the same reference. The mint keeps repeating the exact
+  remediation on its own refusal path, where the caller is the operator
+  pressing Start.
+- The `ci`, `plugin-guard`, and `CodeQL` workflows run on a least-privilege
+  `GITHUB_TOKEN`: `contents: read` at the workflow level (they inherited the
+  repository default, which can be read/write), with the one write CodeQL
+  needs — `security-events: write` to upload its SARIF — granted on the
+  analyze job alone. Closes CodeQL alerts #20/#21 and Scorecard's
+  Token-Permissions findings.
 - CI lints against a pinned ruff. The dev extra asked for `ruff>=0.4` and CI
   installed whatever was current, so ruff 0.16 arrived on its own and failed
   the build on `RUF100`: it stopped reporting `BLE001` where the handler logs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security policy
+
+hermes-talk holds real credentials on the operator's behalf — an OpenAI key or
+a ChatGPT (Codex) OAuth login, an xAI key or SuperGrok login, a Gemini key, an
+ElevenLabs key — and it gives a voice model the authority to run Hermes tools
+and hand work to background agents. Those two facts define what a security
+bug is here.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| The latest release on [PyPI](https://pypi.org/project/hermes-talk/) | yes — fixes ship as a new release |
+| `main` | yes — fixes land here first |
+| Anything older | no — upgrade with `hermes plugins update hermes-talk`, then restart the gateway |
+
+## Reporting a vulnerability
+
+**Report privately** through GitHub's private vulnerability reporting:
+[open a draft security advisory](https://github.com/TheSmokeDev/hermes-talk/security/advisories/new).
+Do not open a public issue for a security bug, and do not paste credentials,
+transcripts, or audio anywhere — a redacted `hermes talk diagnostics --bundle`
+is the right artifact to attach if configuration matters to the report.
+
+What to expect:
+
+- **Acknowledgement within 72 hours** of the report.
+- A fix on `main` and a PyPI release, with an advisory that credits you
+  unless you ask otherwise. Coordinated disclosure: we ask that you hold the
+  details until the release is out, and we will not sit on a fix to make that
+  wait longer than it needs to be.
+- If the problem is in Hermes Agent itself rather than this plugin, we will
+  say so and point you at the upstream process instead of leaving the report
+  in limbo.
+
+## What counts
+
+Reports in these classes get the fastest turnaround. Each one is an invariant
+the code is built to hold, so a break is a bug by definition:
+
+- **Credential leakage.** Any path where a provider key, an OAuth access or
+  refresh token, or the ephemeral session secret reaches a log line, an HTTP
+  response, a transcript, a run record, a doctor/check/diagnostics report, or
+  a spoken sentence. The rule is that the raw credential is spent on exactly
+  one upstream endpoint and appears nowhere else.
+- **Auth-store writes.** Anything that writes to a credential store outside
+  the one documented path (the Codex OAuth refresh that rewrites
+  `auth.json` atomically with the same tokens the Codex CLI itself would
+  write). `doctor`, `diagnostics`, and the core-contract availability probes
+  are read-only by contract.
+- **Tool-authority bypass.** A speaker, browser tab, or message that is not
+  the operator getting a mutating tool (`delegate_task`, `steer_agent`,
+  `redirect_agent`, `stop_work`, a spoken approval) to run: the Discord
+  speaker-binding ledger, the per-turn permit, the dashboard's
+  `TALK_DASHBOARD_TOKEN` / loopback gate, and the approval bridge's
+  never-`always` ceiling are all in scope. So is background output wearing
+  the operator's voice (a run result entering the conversation as a user
+  turn instead of a contained system item).
+- **Redaction failures.** A secret-shaped value or a filesystem path
+  surviving the redaction in `hermes talk doctor`, `check`, or
+  `diagnostics`, or a diagnostics bundle written with permissions wider than
+  owner-only.
+- **Supply chain.** Anything in the published wheel that is not in this
+  repository, or a workflow that can be made to run untrusted code with a
+  token that has write access.
+
+Provider outages, rate limits, model behaviour, and "the voice said something
+wrong" are bugs, not vulnerabilities — file them as
+[ordinary issues](https://github.com/TheSmokeDev/hermes-talk/issues/new/choose).

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -202,6 +202,22 @@ async def _json_body(request) -> dict:
     return payload if isinstance(payload, dict) else {}
 
 
+def _status_problem(setting: str, exc: Exception) -> str:
+    """Record a config refusal server-side; hand the tile a fixed line and a reference.
+
+    The exception text is the operator's remediation, but this route answers
+    any peer the gate admits, so it never rides the response: it goes to the
+    dashboard's own log under a short reference the tile repeats, and the
+    tile says only WHICH setting refused. The mint repeats the exact
+    remediation on its own refusal path, where the caller is the operator
+    pressing Start.
+    """
+
+    reference = os.urandom(4).hex()
+    _log.warning("dashboard status: %s unusable [ref %s]: %s", setting, reference, exc)
+    return f" ({setting} unusable; see the dashboard log, ref {reference})"
+
+
 def _warm_agent_lane() -> str:
     """Resolve the agent lane, paying for a cold probe. Worker thread only."""
 
@@ -284,7 +300,7 @@ async def talk_status(request: Request) -> dict:
         voice = talk_config.talk_voice()
     except talk_config.TalkConfigError as exc:
         voice = ""
-        detail_suffix = f" (TALK_VOICE unusable: {exc})"
+        detail_suffix = _status_problem("TALK_VOICE", exc)
     else:
         detail_suffix = ""
     try:
@@ -293,7 +309,7 @@ async def talk_status(request: Request) -> dict:
         # Stay answerable: the tile reads as native and the mint refuses with
         # the exact remediation when Start is pressed.
         voice_mode = ""
-        detail_suffix += f" (TALK_VOICE_MODE unusable: {exc})"
+        detail_suffix += _status_problem("TALK_VOICE_MODE", exc)
     status = talk_auth.auth_status()
     return {
         "ok": True,

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -428,6 +428,42 @@ def test_status_stays_answerable_when_the_voice_is_unusable(monkeypatch):
     assert "TALK_VOICE unusable" in body["detail"]
 
 
+def test_status_logs_the_config_refusal_and_answers_with_a_reference(monkeypatch, caplog):
+    """The exception text is remediation for the operator's log, never response body.
+
+    The status route answers any peer the gate admits, so a config error's
+    text (which quotes the offending value) must not ride it. The tile gets
+    WHICH setting refused plus a reference; the log gets the text under the
+    same reference. Both settings, both sinks.
+    """
+
+    monkeypatch.setenv("TALK_VOICE", "gilbert-the-unlisted")
+    monkeypatch.setenv("TALK_VOICE_MODE", "telepathy")
+
+    with caplog.at_level("WARNING", logger=api._log.name):
+        body = call(api.talk_status, FakeRequest())
+
+    detail = body["detail"]
+    assert "gilbert-the-unlisted" not in detail
+    assert "telepathy" not in detail
+    references = re.findall(
+        r"\((TALK_VOICE(?:_MODE)?) unusable; see the dashboard log, ref ([0-9a-f]{8})\)",
+        detail,
+    )
+    assert [setting for setting, _ in references] == ["TALK_VOICE", "TALK_VOICE_MODE"]
+    logged = {
+        record.getMessage()
+        for record in caplog.records
+        if "dashboard status" in record.getMessage()
+    }
+    assert len(logged) == 2
+    for setting, reference in references:
+        matching = [line for line in logged if f"{setting} unusable [ref {reference}]" in line]
+        assert len(matching) == 1, (setting, reference, logged)
+    assert any("gilbert-the-unlisted" in line for line in logged)
+    assert any("telepathy" in line for line in logged)
+
+
 # -- the gate -----------------------------------------------------------------
 
 


### PR DESCRIPTION
Driven by the open code-scanning alerts after #99/#108 landed.

- `codeql.yml`: workflow-level `contents: read`; `security-events: write` only on the analyze job (TokenPermissionsID)
- `SECURITY.md`: supported versions, private advisory reporting, 72h acknowledgement, what counts (SecurityPolicyID)
- `.github/dependabot.yml`: pip + github-actions weekly, minor/patch grouped (DependencyUpdateToolID)
- `dashboard/plugin_api.py`: the status tile no longer returns exception text to the client — logged server-side under a short reference the tile repeats (CodeQL `py/stack-trace-exposure` at :298); test proves the text never rides the response
- Pinned pip installs (PinnedDependenciesID) deliberately left: needs hash-pinned requirements, separate PR

Tests: `tests/test_dashboard_api.py` 35 passed; ruff 0.16.5 clean; YAML validated.

— SmokeDev