### PR TITLE
test: give node 60s to cold-start in the dashboard JS tests

### DIFF
--- a/tests/test_dashboard_js.py
+++ b/tests/test_dashboard_js.py
@@ -8,6 +8,11 @@ from subprocess import run
 ROOT = Path(__file__).resolve().parents[1]
 DASHBOARD_JS = ROOT / "dashboard" / "dist" / "index.js"
 
+#: Outer guard on the `node` subprocess. Every script below bounds its own
+#: waits at 1s (`waitFor`), so this only has to cover node's cold start — which
+#: on a cold windows-latest runner has exceeded 10s and failed main for nothing.
+NODE_TIMEOUT_S = 60
+
 
 def test_dashboard_serializes_tool_calls_and_continues_once_after_response_done():
     script = r"""
@@ -86,7 +91,7 @@ const waitFor = async (predicate, timeoutMs = 1000) => {
         cwd=ROOT,
         capture_output=True,
         text=True,
-        timeout=10,
+        timeout=NODE_TIMEOUT_S,
         check=False,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
@@ -254,7 +259,7 @@ const respond = (pcmChunks) => {
         cwd=ROOT,
         capture_output=True,
         text=True,
-        timeout=10,
+        timeout=NODE_TIMEOUT_S,
         check=False,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr


### PR DESCRIPTION
The two dashboard transport tests spawn `node -e` with a 10s outer timeout. Every script bounds its own waits at 1s, so the outer guard only covers node's startup — which on a cold windows-latest runner has exceeded 10s and turned main red (run 33747535439, windows-3.11, both `test_dashboard_js` tests `TimeoutExpired`). One named constant, `NODE_TIMEOUT_S = 60`. `tests/test_dashboard_js.py` 2 passed locally; ruff clean.

— SmokeDev