### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,17 @@ but 0.4.0's release title named only the steering verb. They are recorded
 below under 0.4.0 — the first version that shipped them — with the gap
 named rather than smoothed.
 
-## [Unreleased]
+## [0.17.0] — 2026-09-03
+
+Prove it, then pause it. `hermes talk check` runs the whole path — doctor,
+one live provider turn, one bounded Hermes run that has to echo a token —
+so a green report means the lane works right now, not that the config
+parses. `hermes talk diagnostics --bundle` turns a bug report into one
+redacted file. The model can pause the microphone without hanging up, two
+delegated jobs that touch the same thing can no longer race each other, and
+an announcement waits for the speaker to finish instead of talking over the
+answer you are still hearing. First release with the Hermes core realtime
+contract adapter, a security policy, and a contributing guide.
 
 ### Added
 - `pause_voice_input` — the model can pause listening without ending the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,10 +317,13 @@ contract adapter, a security policy, and a contributing guide.
 
 ## [0.16.0] — 2026-09-01
 
-Grok voice on a SuperGrok / X Premium+ subscription. `hermes auth add
-xai-oauth` once, `TALK_PROVIDER=grok`, no API key — the last provider that
-still forced a metered key now rides the host login the way the OpenAI
-lane rides the Codex CLI's.
+Grok voice on an X subscription. `hermes auth add xai-oauth` once,
+`TALK_PROVIDER=grok`, no API key — the last provider that still forced a
+metered key now rides the host login the way the OpenAI lane rides the
+Codex CLI's. Verified live on **X Premium** (the $8 tier) on 2026-09-03:
+`POST /v1/realtime/client_secrets` → 200, the realtime socket → 101,
+`session.created`. A tier without realtime access still gets the honest
+403 line instead of a traceback.
 
 ### Added
 - **`xai-oauth` auth lane for Grok** (`talk_grok_auth.py`). Resolved

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Full runbook, wire canary included: [docs/OPERATING.md](docs/OPERATING.md#verify
 | Provider | `TALK_PROVIDER` | Auth | Notes |
 |---|---|---|---|
 | OpenAI Realtime | `openai` (default) | your ChatGPT subscription through the Codex CLI login (`codex login`) — **no API key** — or `TALK_OPENAI_API_KEY` / `OPENAI_API_KEY` | every surface; the only lane the dashboard tab and the cascade voice speak today |
-| xAI Grok Voice | `grok` | SuperGrok / X Premium+ login (`hermes auth add xai-oauth`) — **no API key** — or `TALK_XAI_API_KEY` / `XAI_API_KEY` | terminal + Discord; five voices |
+| xAI Grok Voice | `grok` | an X Premium or SuperGrok login (`hermes auth add xai-oauth`) — **no API key** — or `TALK_XAI_API_KEY` / `XAI_API_KEY` | terminal + Discord; five voices |
 | Gemini Live | `gemini` | `GEMINI_API_KEY` / `TALK_GEMINI_API_KEY` — free-tier AI Studio keys work | terminal + `hermes realtime`; no client-side cancel/truncate on the wire, so barge-in drops playback locally; Discord refuses it for now |
 
 The knob is fail-closed and never inferred from which keys exist. Full
@@ -234,8 +234,10 @@ knob is fail-closed and never inferred from which keys exist — an operator
 holding several gets the provider they named or an error, not a silent
 switch.
 
-The Grok lane runs on a **SuperGrok / X Premium+ subscription** — no key:
-`hermes auth add xai-oauth` once, then `TALK_PROVIDER=grok`. Talk consumes
+The Grok lane runs on an **X subscription** — no key: `hermes auth add
+xai-oauth` once, then `TALK_PROVIDER=grok`. Verified live on X Premium (the
+$8 tier); a tier without realtime access is told so in one line rather than
+a traceback. Talk consumes
 the host's `xai-oauth` login the way the OpenAI lane consumes the Codex
 CLI's (the host refreshes and stores; Talk never writes an auth store).
 Bring an xAI key instead if you'd rather (`TALK_XAI_API_KEY`, falling back

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Talk",
   "description": "Realtime speech-to-speech voice in the browser — duplex audio over WebRTC, live tool calls, background runs spoken when they land.",
   "icon": "MessageSquare",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "tab": { "path": "/talk", "position": "end" },
   "entry": "dist/index.js",
   "css": "dist/style.css",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-talk
-version: 0.16.0
+version: 0.17.0
 manifest_version: 1
 kind: standalone
 description: "OpenAI Realtime speech-to-speech voice for Hermes: duplex talk with live tool calling."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-talk"
-version = "0.16.0"
+version = "0.17.0"
 description = "Realtime speech-to-speech voice for Hermes Agent — OpenAI, xAI Grok, or Gemini Live — duplex talk with live tool calling."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts `[Unreleased]` to `[0.17.0]` and bumps the three version surfaces the hygiene test pins together.

**What ships:** `hermes talk check`, `hermes talk diagnostics --bundle`, `pause_voice_input`, run admission control, announcements gated on playback drain, the cross-platform echo-gate knobs, PulseAudio AEC on Linux (thanks @kvnloo), the Hermes core realtime contract adapter, Discord startup-refusal reasons, the ledger-presence invariant, SECURITY.md + CONTRIBUTING + trust CI.

**Note:** 0.16.0 was built but never published (PyPI is on 0.15.1), so this release also carries its Grok subscription lane.

Hygiene test 3 passed; ruff clean; no line-ending flips.

— SmokeDev