### PR TITLE
fix(cascade): let ElevenLabs buffer the turn instead of forcing a generation per chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,13 +105,25 @@ named rather than smoothed.
   It compounded with the chunker: `SentenceChunker` ends a chunk on an
   ellipsis run, so a line written with "..." pacing markers became a
   separate forced generation per marker, and a multi-sentence answer read as
-  a series of unrelated fragments. Chunks now go out as bare text and the
-  turn's FINAL frame carries `flush: true`, the documented end-of-turn
-  trigger ("we advise using `flush: true` along with the text at the end of
-  conversation turn to ensure timely audio generation"). Latency is
-  unchanged where it is audible: that frame already ended the turn, and the
-  close it rides on flushed the buffer regardless. All three cascade
+  a series of unrelated fragments. Chunks now go out as bare text and
+  nothing replaces the trigger: the model buffers on its own
+  `chunk_length_schedule`, and the empty-text EOS frame the turn already
+  ended on closes the socket — which ElevenLabs documents as forcing
+  generation of whatever is still buffered. The cascade opens and closes one
+  socket per RESPONSE, so that close happens on every turn regardless.
+  Latency where it is audible is therefore unchanged. All three cascade
   surfaces — terminal, Discord, dashboard relay — change together.
+
+  Deliberately NOT added: an explicit `flush: true` on the EOS frame. Their
+  flush example attaches the flag to a frame carrying real text, `text` is a
+  required field on `SendText`, and an empty-text frame is `CloseConnection`
+  — a different message in the same schema. A combined
+  `{"text": "", "flush": true}` appears nowhere in their documentation, and
+  on this endpoint there is no schema-legal way to force generation without
+  either real text or the close. Their sibling `multi-stream-input` endpoint
+  does define a purpose-built `FlushContextClient` frame with optional
+  `text`, which is what a persistent-socket design would need; this lane
+  does not, because its socket is per-turn.
 - The cascade socket now states `enable_ssml_parsing` instead of relying on
   a default ElevenLabs does not document. Every neighbouring query parameter
   declares a default in their schema and this one declares none, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ named rather than smoothed.
 
 ## [Unreleased]
 
+### Added
+- `TALK_CASCADE_SPEED` — delivery pace for the cascade voice, `0.7`–`1.2`
+  (`1.0` is normal), resolved at call time so an operator's edit lands on
+  the next session rather than the next process. Fail-closed like the rest
+  of the cascade knobs: junk and out-of-range values refuse with the range
+  rather than clamping, because a silently clamped pace is audible on every
+  word and never says why. Unset sends no `speed` field at all, so a cascade
+  that does not use the knob puts exactly the same bytes on the wire as
+  before it existed. `CascadeVoice` grew a `voice_settings` argument to
+  carry it; omitting it reproduces the previous BOS frame exactly.
 ### Changed
 - `starlette` is now a **dev/test** dependency. It is where
   `StreamingResponse` and `ClientDisconnect` actually live (fastapi
@@ -86,6 +96,28 @@ named rather than smoothed.
   the same `.catch()`. "Silently" was half of the bug above: a mute voice
   and a working one were indistinguishable. A deliberate abort (barge-in,
   hang-up) stays quiet, because that is not a failure.
+- The cascade voice no longer forces a generation per chunk, which is what
+  flattened its prosody. Every text frame carried
+  `try_trigger_generation: true`, defeating the buffer whose entire purpose
+  is giving ElevenLabs enough context to carry intonation across a sentence
+  boundary — their own reference calls forcing generation on small amounts
+  of text "lower quality audio" and recommends leaving the flag at `false`.
+  It compounded with the chunker: `SentenceChunker` ends a chunk on an
+  ellipsis run, so a line written with "..." pacing markers became a
+  separate forced generation per marker, and a multi-sentence answer read as
+  a series of unrelated fragments. Chunks now go out as bare text and the
+  turn's FINAL frame carries `flush: true`, the documented end-of-turn
+  trigger ("we advise using `flush: true` along with the text at the end of
+  conversation turn to ensure timely audio generation"). Latency is
+  unchanged where it is audible: that frame already ended the turn, and the
+  close it rides on flushed the buffer regardless. All three cascade
+  surfaces — terminal, Discord, dashboard relay — change together.
+- The cascade socket now states `enable_ssml_parsing` instead of relying on
+  a default ElevenLabs does not document. Every neighbouring query parameter
+  declares a default in their schema and this one declares none, so a
+  `<break time="0.4s" />` was as likely to be dropped as spoken, with
+  nothing in the response saying which. Break tags are supported on this
+  lane's model and cap at 3 seconds.
 
 ## [0.17.0] — 2026-09-03
 

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -535,8 +535,13 @@ _PCM_END = object()
 _FEED_DONE = object()
 
 
-def _resolve_cascade_relay_config() -> tuple[str, str, str]:
-    """The cascade triple for one relay call — fail-closed, HTTP-shaped.
+def _resolve_cascade_relay_config() -> tuple[str, str, str, dict]:
+    """The cascade config for one relay call — fail-closed, HTTP-shaped.
+
+    Delivery settings resolve HERE, beside the key and the voice, so a bad
+    ``TALK_CASCADE_SPEED`` refuses as a 400 with remediation before the
+    stream opens. Resolved inside the streaming body it would surface as a
+    torn response instead — HTTP 200, then nothing.
 
     The browser only calls this route for a session minted with
     ``voiceMode: "cascade"``, so a server no longer in cascade mode means the
@@ -553,7 +558,10 @@ def _resolve_cascade_relay_config() -> tuple[str, str, str]:
             ),
         )
     try:
-        return talk_config.cascade_voice_config(talk_config.talk_provider())
+        api_key, voice_id, model = talk_config.cascade_voice_config(
+            talk_config.talk_provider()
+        )
+        return (api_key, voice_id, model, talk_config.elevenlabs_voice_settings())
     except talk_config.TalkConfigError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -608,7 +616,9 @@ def _relay_transcript(text: str, *, final: bool) -> talk_realtime.Transcript:
     )
 
 
-async def _cascade_pcm_stream(request, config: tuple[str, str, str]) -> AsyncIterator[bytes]:
+async def _cascade_pcm_stream(
+    request, config: tuple[str, str, str, dict]
+) -> AsyncIterator[bytes]:
     """Feed one response's relayed text through CascadeVoice; yield its PCM.
 
     A fresh CascadeVoice per request: one POST == one response's speech. The
@@ -622,7 +632,7 @@ async def _cascade_pcm_stream(request, config: tuple[str, str, str]) -> AsyncIte
     """
 
     audio_queue: asyncio.Queue = asyncio.Queue()
-    api_key, voice_id, model = config
+    api_key, voice_id, model, voice_settings = config
     voice = talk_cascade_voice.CascadeVoice(
         api_key=api_key,
         voice_id=voice_id,
@@ -630,6 +640,7 @@ async def _cascade_pcm_stream(request, config: tuple[str, str, str]) -> AsyncIte
         on_audio=audio_queue.put_nowait,
         on_error=lambda text: _log.warning("dashboard cascade relay: %s", text),
         on_stream_end=lambda: audio_queue.put_nowait(_PCM_END),
+        voice_settings=voice_settings,
     )
     voice.start()
     state = {"completed": False, "speakable": False}

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -258,6 +258,7 @@ all of them. Canonical source: `talk_config.py` and `talk_auth.py`.
 | `TALK_ELEVENLABS_API_KEY` / `ELEVENLABS_API_KEY` | unset | ElevenLabs key for the cascade lane, Talk-scoped first. Set-but-blank is a hard refusal, same rule as the other provider keys. The key rides the `xi-api-key` WebSocket header — never the URL, never a log line, never an error string. |
 | `TALK_ELEVENLABS_VOICE_ID` | unset | Voice the cascade speaks with. **Required in cascade mode** — unset or blank refuses with remediation, because a cascade with no voice would have nothing to synthesize against and guessing at an account's voices would speak with a voice the operator did not choose. Voice ids are semi-public identifiers (printing them is fine; the KEY is the secret). Stock and cloned voices both work; cloning is done in ElevenLabs VoiceLab, not here. |
 | `TALK_ELEVENLABS_MODEL` | `eleven_flash_v2_5` | ElevenLabs TTS model for the cascade lane. `eleven_flash_v2_5` probed at ~490ms to first audio on PCM 24kHz (2026-08-28), which is the cascade's latency trade: roughly one extra half-second on the first sentence versus native; later sentences pipeline under playback. |
+| `TALK_CASCADE_SPEED` | unset | Delivery pace for the cascade voice, `0.7`–`1.2` (`1.0` is normal). **Fail-closed**: junk and out-of-range values refuse with the range rather than clamping, because a silently clamped pace is audible on every word and never says why. Unset sends no `speed` field at all — the wire frame stays byte-identical to a cascade that never had the knob, so turning it on is the only thing that changes what ElevenLabs receives. The bounds are the stream-input `RealtimeVoiceSettings` schema's own; the REST endpoint's wider `0.25`–`4.0` belongs to a different schema this lane never speaks. |
 
 Cascade mode applies to every Talk surface — terminal, Discord, and the
 dashboard tab share the same knobs and the same fail-closed resolution. On the
@@ -267,6 +268,26 @@ deltas to `POST /api/plugins/hermes-talk/cascade-tts` (same
 streams back. One NDJSON `{"delta": ...}` line per text delta, one terminal
 `{"done": ...}` line per response; an aborted stream (barge-in, tab closed)
 cancels the answer's TTS rather than flushing it.
+
+Generation is triggered once per TURN, not once per sentence: chunks go out as
+bare text and the turn's final frame carries the flush. That is what lets
+ElevenLabs buffer enough context to carry intonation across a sentence
+boundary — forcing a generation per chunk is documented as producing lower
+quality audio, and it is why a multi-sentence answer used to read as a series
+of unrelated fragments. Latency where it is audible is unchanged: the final
+frame already ended the turn. SSML parsing is enabled explicitly on the
+socket, so `<break time="0.4s" />` in an answer is a real pause (up to 3s)
+instead of being silently dropped.
+
+One trap that is not fixable here: `eleven_flash_v2_5` ships with number
+normalization DISABLED for latency, and re-enabling it
+(`apply_text_normalization: "on"`) is Enterprise-gated on v2.5 models. Their
+own worked example is `$1,000,000` read as "one thousand thousand dollars". A
+lane that speaks currency, phone numbers, or times should tell the model to
+emit number-words in its instructions, or run `eleven_multilingual_v2` where
+latency matters less. Tracked in
+[#116](https://github.com/TheSmokeDev/hermes-talk/issues/116) — it needs a
+live listen, not a code change.
 
 ### Audio (terminal lane)
 

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -269,15 +269,25 @@ streams back. One NDJSON `{"delta": ...}` line per text delta, one terminal
 `{"done": ...}` line per response; an aborted stream (barge-in, tab closed)
 cancels the answer's TTS rather than flushing it.
 
-Generation is triggered once per TURN, not once per sentence: chunks go out as
-bare text and the turn's final frame carries the flush. That is what lets
-ElevenLabs buffer enough context to carry intonation across a sentence
-boundary — forcing a generation per chunk is documented as producing lower
-quality audio, and it is why a multi-sentence answer used to read as a series
-of unrelated fragments. Latency where it is audible is unchanged: the final
-frame already ended the turn. SSML parsing is enabled explicitly on the
-socket, so `<break time="0.4s" />` in an answer is a real pause (up to 3s)
-instead of being silently dropped.
+Generation happens once per TURN, not once per sentence: chunks go out as bare
+text with no generation trigger, so ElevenLabs buffers on its own
+`chunk_length_schedule` and gets enough context to carry intonation across a
+sentence boundary. Forcing a generation per chunk is documented as producing
+lower quality audio, and it is why a multi-sentence answer used to read as a
+series of unrelated fragments.
+
+Nothing replaces that trigger, and nothing needs to. The cascade opens and
+closes one socket per RESPONSE, and closing is documented to generate whatever
+is still buffered — so the empty-text EOS frame that already ended every turn
+is the end-of-turn flush. Latency where it is audible is unchanged. (There is
+deliberately no explicit `flush: true` frame: on this endpoint `text` is
+required on `SendText` and an empty-text frame means `CloseConnection`, so a
+combined frame is not a documented shape. A lane that held ONE socket across
+turns would need the sibling `multi-stream-input` endpoint and its
+`FlushContextClient` message instead.)
+
+SSML parsing is enabled explicitly on the socket, so `<break time="0.4s" />`
+in an answer is a real pause (up to 3s) instead of being silently dropped.
 
 One trap that is not fixable here: `eleven_flash_v2_5` ships with number
 normalization DISABLED for latency, and re-enabling it

--- a/talk_cascade_voice.py
+++ b/talk_cascade_voice.py
@@ -93,17 +93,25 @@ def _import_aiohttp():
     return aiohttp
 
 
-def stream_input_url(voice_id: str, model: str) -> str:
+def stream_input_url(voice_id: str, model: str, *, enable_ssml: bool = True) -> str:
     """The ElevenLabs stream-input endpoint for one voice and model.
 
     Voice id and model are identifiers, not secrets — they ride the URL
     query/path. The KEY never does: it is an ``xi-api-key`` header.
+
+    ``enable_ssml_parsing`` is sent EXPLICITLY because its default is the one
+    thing ElevenLabs does not state: every neighbouring query parameter
+    declares a default in their schema and this one declares none. Unparsed,
+    a ``<break time="0.4s" />`` is not a pause — it is dropped, silently, and
+    the sentence runs on. Break tags are supported on this lane's model
+    (Flash v2.5) and cap at 3 seconds.
     """
 
     return (
         "wss://api.elevenlabs.io/v1/text-to-speech/"
         f"{quote(voice_id, safe='')}/stream-input"
         f"?model_id={quote(model, safe='')}&output_format=pcm_24000"
+        f"&enable_ssml_parsing={'true' if enable_ssml else 'false'}"
     )
 
 
@@ -260,9 +268,17 @@ class CascadeVoice:
         aiohttp_module: Any = None,
         ws_connect: Callable[..., Any] | None = None,
         chunk_budget: int = CLAUSE_BUDGET_CHARS,
+        voice_settings: dict | None = None,
+        enable_ssml: bool = True,
     ) -> None:
         self._api_key = api_key
-        self._url = stream_input_url(voice_id, model)
+        self._url = stream_input_url(voice_id, model, enable_ssml=enable_ssml)
+        #: Resolved by the CALLER and copied here, never read from a module
+        #: default at send time, so an operator's live edit to the pace knob
+        #: takes effect on the next session rather than the next process.
+        self._voice_settings = (
+            dict(voice_settings) if voice_settings else dict(_VOICE_SETTINGS)
+        )
         self._on_audio = on_audio
         self._on_error = on_error
         self._on_stream_end = on_stream_end
@@ -485,9 +501,14 @@ class CascadeVoice:
         ws = await self._connect()
         try:
             await ws.send_json(
-                {"text": _BOS_TEXT, "voice_settings": dict(_VOICE_SETTINGS)}
+                {"text": _BOS_TEXT, "voice_settings": dict(self._voice_settings)}
             )
-            await ws.send_json({"text": first_chunk, "try_trigger_generation": True})
+            # Deliberately NO generation trigger: forcing one per chunk
+            # defeats the buffer that gives the model its prosodic context,
+            # which ElevenLabs calls lower quality audio and recommends
+            # against. End-of-turn generation is triggered once, by the
+            # final frame in _send_rest.
+            await ws.send_json({"text": first_chunk})
             sender = asyncio.create_task(self._send_rest(ws))
             try:
                 await self._read_audio(ws, generation)
@@ -526,9 +547,14 @@ class CascadeVoice:
         while True:
             item = await self._queue.get()
             if item is _FLUSH:
-                await ws.send_json({"text": ""})
+                # The turn's final frame carries the ONE generation trigger:
+                # "we advise using `flush: true` along with the text at the
+                # end of conversation turn to ensure timely audio
+                # generation". Latency is unchanged where it is audible —
+                # this frame already ended the turn.
+                await ws.send_json({"text": "", "flush": True})
                 return
-            await ws.send_json({"text": item, "try_trigger_generation": True})
+            await ws.send_json({"text": item})
 
     async def _read_audio(self, ws: Any, generation: int) -> None:
         """Emit stream-input audio frames until the terminal isFinal frame."""

--- a/talk_cascade_voice.py
+++ b/talk_cascade_voice.py
@@ -506,8 +506,11 @@ class CascadeVoice:
             # Deliberately NO generation trigger: forcing one per chunk
             # defeats the buffer that gives the model its prosodic context,
             # which ElevenLabs calls lower quality audio and recommends
-            # against. End-of-turn generation is triggered once, by the
-            # final frame in _send_rest.
+            # against. Nothing replaces it — the model now buffers on its own
+            # chunk_length_schedule, and the EOS frame _send_rest ends on
+            # closes the socket, which is documented to generate whatever is
+            # still buffered. One socket per response makes that the whole
+            # end-of-turn story.
             await ws.send_json({"text": first_chunk})
             sender = asyncio.create_task(self._send_rest(ws))
             try:

--- a/talk_cascade_voice.py
+++ b/talk_cascade_voice.py
@@ -547,12 +547,16 @@ class CascadeVoice:
         while True:
             item = await self._queue.get()
             if item is _FLUSH:
-                # The turn's final frame carries the ONE generation trigger:
-                # "we advise using `flush: true` along with the text at the
-                # end of conversation turn to ensure timely audio
-                # generation". Latency is unchanged where it is audible —
-                # this frame already ended the turn.
-                await ws.send_json({"text": "", "flush": True})
+                # The documented CloseConnection frame, which also flushes:
+                # ElevenLabs generates whatever is still buffered when the
+                # context closes. That is the whole end-of-turn trigger — no
+                # `flush` key rides along, because their `flush: true` is
+                # documented only ON a frame carrying real text, and an
+                # empty-text frame with `flush` appears nowhere in their
+                # schema (SendText requires `text`). Mixing the two variants
+                # would work by accident today and break on their next
+                # deploy.
+                await ws.send_json({"text": ""})
                 return
             await ws.send_json({"text": item})
 

--- a/talk_cli.py
+++ b/talk_cli.py
@@ -1690,6 +1690,7 @@ async def run_talk_session(
             model=cascade_config[2],
             on_audio=audio.queue_playback,
             on_error=on_error,
+            voice_settings=talk_config.elevenlabs_voice_settings(),
         )
     session = None
     result = 0

--- a/talk_config.py
+++ b/talk_config.py
@@ -63,6 +63,18 @@ DEFAULT_CASCADE_TTS = "elevenlabs"
 #: ElevenLabs TTS model for the cascade lane, probed against the live
 #: stream-input endpoint 2026-08-28 (first audio ~490ms, PCM 24kHz out).
 DEFAULT_ELEVENLABS_MODEL = "eleven_flash_v2_5"
+#: Delivery pace for the cascade voice. The bounds are the stream-input
+#: ``RealtimeVoiceSettings`` schema's own, not a house rule — that schema
+#: documents "Values range from 0.7 to 1.2, with 1.0 being the default
+#: speed", and the REST endpoint's wider 0.25-4.0 range belongs to a
+#: DIFFERENT schema that this lane never speaks.
+ELEVENLABS_SPEED_MIN = 0.7
+ELEVENLABS_SPEED_MAX = 1.2
+DEFAULT_ELEVENLABS_SPEED = 1.0
+#: Delivery defaults for the cascade voice, probed against the live
+#: stream-input endpoint (2026-08-28). ``style`` stays unsent: ElevenLabs
+#: recommends keeping it at 0, and an unsent field is the documented 0.
+DEFAULT_ELEVENLABS_VOICE_SETTINGS = {"stability": 0.5, "similarity_boost": 0.75}
 
 #: Where Hermes's api_server gateway platform listens by default
 #: (gateway/platforms/api_server.py DEFAULT_HOST/DEFAULT_PORT).
@@ -657,6 +669,55 @@ def elevenlabs_model() -> str:
     )
 
 
+def elevenlabs_speed() -> float | None:
+    """Cascade delivery pace (``TALK_CASCADE_SPEED``), or ``None`` when unset.
+
+    ``None`` means "send no ``speed`` field", which is not the same as
+    sending ``1.0``: an omitted field leaves the wire frame byte-identical
+    to the pre-knob cascade, so turning the knob on is the only thing that
+    changes what ElevenLabs receives.
+
+    Fail-closed like every other cascade knob. Junk and out-of-range values
+    REFUSE rather than clamping: a silently clamped 2.0 would speak at a
+    pace the operator did not ask for and never say why, and pace is
+    audible on every single word.
+    """
+
+    raw = (os.environ.get("TALK_CASCADE_SPEED") or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = float(raw)
+    except ValueError:
+        raise TalkConfigError(
+            f"TALK_CASCADE_SPEED '{raw}' is not a number — set it between "
+            f"{ELEVENLABS_SPEED_MIN} and {ELEVENLABS_SPEED_MAX} "
+            f"({DEFAULT_ELEVENLABS_SPEED} is normal pace), or unset it"
+        ) from None
+    if not ELEVENLABS_SPEED_MIN <= parsed <= ELEVENLABS_SPEED_MAX:
+        raise TalkConfigError(
+            f"TALK_CASCADE_SPEED {parsed:g} is outside the range ElevenLabs "
+            f"accepts on this lane ({ELEVENLABS_SPEED_MIN}-"
+            f"{ELEVENLABS_SPEED_MAX}, {DEFAULT_ELEVENLABS_SPEED} is normal pace)"
+        )
+    return parsed
+
+
+def elevenlabs_voice_settings() -> dict:
+    """The cascade's BOS ``voice_settings``, resolved at CALL time.
+
+    Rule 1: this is rebuilt per session start, never bound to a default
+    argument, so an operator's live edit to ``TALK_CASCADE_SPEED`` takes
+    effect on the next call instead of the next process.
+    """
+
+    settings = dict(DEFAULT_ELEVENLABS_VOICE_SETTINGS)
+    speed = elevenlabs_speed()
+    if speed is not None:
+        settings["speed"] = speed
+    return settings
+
+
 def cascade_voice_config(provider: str) -> tuple[str, str, str]:
     """The resolved cascade TTS triple — (key, voice id, model). Fail-closed.
 
@@ -897,6 +958,8 @@ __all__ = [
     "DEFAULT_CASCADE_TTS",
     "DEFAULT_CATALOG_STARTUP_WAIT_S",
     "DEFAULT_ELEVENLABS_MODEL",
+    "DEFAULT_ELEVENLABS_SPEED",
+    "DEFAULT_ELEVENLABS_VOICE_SETTINGS",
     "DEFAULT_GEMINI_MODEL",
     "DEFAULT_GEMINI_VOICE",
     "DEFAULT_GROK_MODEL",
@@ -907,6 +970,8 @@ __all__ = [
     "DEFAULT_TALK_VOICE",
     "DEFAULT_VOICE_MODE",
     "DUPLEX_TOOL_COMPATIBLE_MODELS",
+    "ELEVENLABS_SPEED_MAX",
+    "ELEVENLABS_SPEED_MIN",
     "GEMINI_LIVE_VOICES",
     "GROK_REALTIME_VOICES",
     "KNOWN_INCOMPATIBLE_REALTIME_MODELS",
@@ -933,7 +998,9 @@ __all__ = [
     "detect_agent_profile",
     "discord_operator_user_ids",
     "elevenlabs_model",
+    "elevenlabs_speed",
     "elevenlabs_voice_id",
+    "elevenlabs_voice_settings",
     "get_hermes_home",
     "identity_include",
     "memory_search_timeout_s",

--- a/tests/test_cascade_voice.py
+++ b/tests/test_cascade_voice.py
@@ -260,7 +260,7 @@ async def _stream_lifecycle_bos_chunks_eos_isfinal():
         await _wait_for(lambda: len(ws.sent) == 3)
         # EOS ends the response's text AND carries the turn's one generation
         # trigger — the documented end-of-turn flush.
-        assert ws.sent[2] == {"text": "", "flush": True}
+        assert ws.sent[2] == {"text": ""}
 
         ws.feed_audio(b"pcm-one")
         ws.feed_audio(b"pcm-two")
@@ -466,7 +466,7 @@ async def _unflushed_tail_speaks_at_response_finished():
         ws = harness.connect.sockets[0]
         await _wait_for(lambda: len(ws.sent) == 3)
         assert ws.sent[1]["text"] == "a tail without punctuation"
-        assert ws.sent[2] == {"text": "", "flush": True}
+        assert ws.sent[2] == {"text": ""}
     finally:
         await voice.aclose()
 
@@ -521,13 +521,15 @@ async def _no_chunk_ever_forces_its_own_generation():
         ws = harness.connect.sockets[0]
         voice.handle_event(_delta("And a fourth sentence. "))
         voice.handle_event(_final(response_id="resp_1"))
-        await _wait_for(lambda: ws.sent and ws.sent[-1].get("flush") is True)
+        await _wait_for(lambda: ws.sent and ws.sent[-1] == {"text": ""})
 
         assert not any("try_trigger_generation" in frame for frame in ws.sent)
-        # Exactly one flush, and it is the LAST frame — the end of the turn.
-        flushed = [i for i, frame in enumerate(ws.sent) if frame.get("flush")]
-        assert flushed == [len(ws.sent) - 1]
-        assert ws.sent[-1] == {"text": "", "flush": True}
+        # No frame carries a `flush` key at all: the close IS the flush.
+        assert not any("flush" in frame for frame in ws.sent)
+        # The EOS is the LAST frame and appears exactly once.
+        assert [i for i, f in enumerate(ws.sent) if f == {"text": ""}] == [
+            len(ws.sent) - 1
+        ]
         # Everything between BOS and EOS is a bare text frame.
         assert all(set(frame) == {"text"} for frame in ws.sent[1:-1])
     finally:

--- a/tests/test_cascade_voice.py
+++ b/tests/test_cascade_voice.py
@@ -258,8 +258,8 @@ async def _stream_lifecycle_bos_chunks_eos_isfinal():
 
         voice.handle_event(_final(response_id="resp_1"))
         await _wait_for(lambda: len(ws.sent) == 3)
-        # EOS ends the response's text AND carries the turn's one generation
-        # trigger — the documented end-of-turn flush.
+        # The documented CloseConnection frame, and nothing else: closing is
+        # what generates the buffered text, so no `flush` key rides along.
         assert ws.sent[2] == {"text": ""}
 
         ws.feed_audio(b"pcm-one")
@@ -503,13 +503,18 @@ def test_no_chunk_ever_forces_its_own_generation():
 
 
 async def _no_chunk_ever_forces_its_own_generation():
-    """Every text frame is text ONLY; the turn ends with exactly one flush.
+    """Every text frame is text ONLY; the turn ends on the documented close.
 
     ``try_trigger_generation`` per chunk is what flattened prosody: it
     defeats the buffer whose entire purpose is giving the model enough
     context to carry intonation across a sentence boundary. An ellipsis-
     heavy line is the worst case — the chunker ends a chunk on each pause
     marker, so the old path produced a forced generation per marker.
+
+    Nothing replaces it: no frame carries a ``flush`` key, because closing
+    is documented to generate whatever is buffered and this lane closes its
+    socket once per response. The assertions below pin BOTH halves — no
+    per-chunk trigger, and no undocumented empty-text-plus-flush frame.
     """
 
     harness = _Harness()
@@ -532,6 +537,50 @@ async def _no_chunk_ever_forces_its_own_generation():
         ]
         # Everything between BOS and EOS is a bare text frame.
         assert all(set(frame) == {"text"} for frame in ws.sent[1:-1])
+    finally:
+        await voice.aclose()
+
+
+def test_each_response_opens_and_closes_its_own_socket():
+    asyncio.run(_each_response_opens_and_closes_its_own_socket())
+
+
+async def _each_response_opens_and_closes_its_own_socket():
+    """The fact the end-of-turn design rests on: the socket is PER RESPONSE.
+
+    Dropping the per-chunk trigger is only safe without an explicit flush
+    because closing generates whatever is buffered, and this lane closes
+    once per turn — so every turn gets that flush for free. A future change
+    that held one socket across turns would silently lose the last partial
+    chunk of every answer until the NEXT answer pushed it out, and single-
+    context ``/stream-input`` has no schema-legal frame to force it (``text``
+    is required on ``SendText``). That change would need the sibling
+    ``multi-stream-input`` endpoint's ``FlushContextClient``. This test is
+    what fails first if anyone tries it.
+    """
+
+    harness = _Harness()
+    voice = harness.voice
+    try:
+        for n in (1, 2):
+            rid = f"resp_{n}"
+            voice.handle_event(rt.ResponseStarted(response_id=rid))
+            voice.handle_event(_delta(f"Answer {n}. ", response_id=rid))
+            await _wait_for(lambda n=n: len(harness.connect.sockets) == n)
+            ws = harness.connect.sockets[n - 1]
+            voice.handle_event(_final(response_id=rid))
+            await _wait_for(lambda ws=ws: ws.sent and ws.sent[-1] == {"text": ""})
+            ws.feed_audio(b"pcm")
+            ws.feed_final()
+            await _wait_for(lambda ws=ws: ws.closed)
+
+        # Two responses, two sockets, each one closed — never one reused.
+        assert len(harness.connect.sockets) == 2
+        assert all(sock.closed for sock in harness.connect.sockets)
+        assert harness.connect.sockets[0] is not harness.connect.sockets[1]
+        # And each socket ended on the documented close frame.
+        for sock in harness.connect.sockets:
+            assert sock.sent[-1] == {"text": ""}
     finally:
         await voice.aclose()
 

--- a/tests/test_cascade_voice.py
+++ b/tests/test_cascade_voice.py
@@ -36,6 +36,7 @@ def _scrub_elevenlabs_env(monkeypatch):
     monkeypatch.delenv("TALK_VOICE_MODE", raising=False)
     monkeypatch.delenv("TALK_CASCADE_TTS", raising=False)
     monkeypatch.delenv("TALK_ELEVENLABS_MODEL", raising=False)
+    monkeypatch.delenv("TALK_CASCADE_SPEED", raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -183,7 +184,7 @@ class _FakeConnect:
 
 
 class _Harness:
-    def __init__(self) -> None:
+    def __init__(self, **overrides) -> None:
         self.audio: list[bytes] = []
         self.errors: list[str] = []
         self.connect = _FakeConnect()
@@ -195,6 +196,7 @@ class _Harness:
             on_error=self.errors.append,
             aiohttp_module=aiohttp,
             ws_connect=self.connect,
+            **overrides,
         )
         self.voice.start()
 
@@ -242,10 +244,12 @@ async def _stream_lifecycle_bos_chunks_eos_isfinal():
         await _wait_for(lambda: len(harness.connect.sockets) == 1)
         ws = harness.connect.sockets[0]
         await _wait_for(lambda: len(ws.sent) == 2)
-        # BOS opens the stream with voice settings; the chunk asks for generation.
+        # BOS opens the stream with voice settings; the chunk is text ONLY —
+        # no per-chunk generation trigger, so the buffer keeps its prosodic
+        # context across the sentence boundary.
         assert ws.sent[0]["text"] == " "
         assert "voice_settings" in ws.sent[0]
-        assert ws.sent[1] == {"text": "Hello there.", "try_trigger_generation": True}
+        assert ws.sent[1] == {"text": "Hello there."}
         # The key rides the header; identifiers ride the URL; never the reverse.
         assert harness.connect.calls[0]["headers"] == {"xi-api-key": FAKE_KEY}
         assert FAKE_VOICE_ID in harness.connect.calls[0]["url"]
@@ -254,7 +258,9 @@ async def _stream_lifecycle_bos_chunks_eos_isfinal():
 
         voice.handle_event(_final(response_id="resp_1"))
         await _wait_for(lambda: len(ws.sent) == 3)
-        assert ws.sent[2] == {"text": ""}  # EOS ends the response's text
+        # EOS ends the response's text AND carries the turn's one generation
+        # trigger — the documented end-of-turn flush.
+        assert ws.sent[2] == {"text": "", "flush": True}
 
         ws.feed_audio(b"pcm-one")
         ws.feed_audio(b"pcm-two")
@@ -460,7 +466,7 @@ async def _unflushed_tail_speaks_at_response_finished():
         ws = harness.connect.sockets[0]
         await _wait_for(lambda: len(ws.sent) == 3)
         assert ws.sent[1]["text"] == "a tail without punctuation"
-        assert ws.sent[2] == {"text": ""}
+        assert ws.sent[2] == {"text": "", "flush": True}
     finally:
         await voice.aclose()
 
@@ -471,6 +477,164 @@ def test_stream_input_url_carries_identifiers_only():
     assert "voice%20abc" in url
     assert "model_id=model%2F1" in url
     assert "output_format=pcm_24000" in url
+
+
+def test_stream_input_url_states_ssml_parsing_explicitly():
+    """The one query parameter ElevenLabs documents no default for.
+
+    Left off, a ``<break time="0.4s" />`` is dropped rather than spoken, and
+    nothing in the response says so — which is why the flag is sent either
+    way instead of relying on an unstated default.
+    """
+
+    assert "enable_ssml_parsing=true" in cascade.stream_input_url("v", "m")
+    assert "enable_ssml_parsing=false" in cascade.stream_input_url(
+        "v", "m", enable_ssml=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prosody: one generation per TURN, never one per chunk
+# ---------------------------------------------------------------------------
+
+
+def test_no_chunk_ever_forces_its_own_generation():
+    asyncio.run(_no_chunk_ever_forces_its_own_generation())
+
+
+async def _no_chunk_ever_forces_its_own_generation():
+    """Every text frame is text ONLY; the turn ends with exactly one flush.
+
+    ``try_trigger_generation`` per chunk is what flattened prosody: it
+    defeats the buffer whose entire purpose is giving the model enough
+    context to carry intonation across a sentence boundary. An ellipsis-
+    heavy line is the worst case — the chunker ends a chunk on each pause
+    marker, so the old path produced a forced generation per marker.
+    """
+
+    harness = _Harness()
+    voice = harness.voice
+    try:
+        voice.handle_event(rt.ResponseStarted(response_id="resp_1"))
+        voice.handle_event(_delta("First... second... third. "))
+        await _wait_for(lambda: len(harness.connect.sockets) == 1)
+        ws = harness.connect.sockets[0]
+        voice.handle_event(_delta("And a fourth sentence. "))
+        voice.handle_event(_final(response_id="resp_1"))
+        await _wait_for(lambda: ws.sent and ws.sent[-1].get("flush") is True)
+
+        assert not any("try_trigger_generation" in frame for frame in ws.sent)
+        # Exactly one flush, and it is the LAST frame — the end of the turn.
+        flushed = [i for i, frame in enumerate(ws.sent) if frame.get("flush")]
+        assert flushed == [len(ws.sent) - 1]
+        assert ws.sent[-1] == {"text": "", "flush": True}
+        # Everything between BOS and EOS is a bare text frame.
+        assert all(set(frame) == {"text"} for frame in ws.sent[1:-1])
+    finally:
+        await voice.aclose()
+
+
+def test_voice_settings_are_a_caller_argument_with_unchanged_defaults():
+    asyncio.run(_voice_settings_are_a_caller_argument())
+
+
+async def _voice_settings_are_a_caller_argument():
+    """The caller owns delivery; omitting it reproduces the old BOS exactly."""
+
+    default = _Harness()
+    try:
+        default.voice.handle_event(rt.ResponseStarted(response_id="resp_1"))
+        default.voice.handle_event(_delta("Hello. "))
+        await _wait_for(lambda: len(default.connect.sockets) == 1)
+        ws = default.connect.sockets[0]
+        await _wait_for(lambda: len(ws.sent) >= 1)
+        assert ws.sent[0]["voice_settings"] == {
+            "stability": 0.5,
+            "similarity_boost": 0.75,
+        }
+    finally:
+        await default.voice.aclose()
+
+    custom = _Harness(voice_settings={"stability": 0.4, "speed": 1.1})
+    try:
+        custom.voice.handle_event(rt.ResponseStarted(response_id="resp_1"))
+        custom.voice.handle_event(_delta("Hello. "))
+        await _wait_for(lambda: len(custom.connect.sockets) == 1)
+        ws = custom.connect.sockets[0]
+        await _wait_for(lambda: len(ws.sent) >= 1)
+        assert ws.sent[0]["voice_settings"] == {"stability": 0.4, "speed": 1.1}
+    finally:
+        await custom.voice.aclose()
+
+
+# ---------------------------------------------------------------------------
+# TALK_CASCADE_SPEED
+# ---------------------------------------------------------------------------
+
+
+def test_speed_unset_sends_no_speed_field(monkeypatch):
+    """Unset must be byte-identical on the wire, not an explicit 1.0."""
+
+    _scrub_elevenlabs_env(monkeypatch)
+    assert talk_config.elevenlabs_speed() is None
+    assert talk_config.elevenlabs_voice_settings() == {
+        "stability": 0.5,
+        "similarity_boost": 0.75,
+    }
+    assert "speed" not in talk_config.elevenlabs_voice_settings()
+
+
+@pytest.mark.parametrize("raw,expected", [("0.7", 0.7), ("1", 1.0), ("1.2", 1.2)])
+def test_speed_in_range_is_threaded_into_voice_settings(monkeypatch, raw, expected):
+    _scrub_elevenlabs_env(monkeypatch)
+    monkeypatch.setenv("TALK_CASCADE_SPEED", raw)
+    assert talk_config.elevenlabs_speed() == pytest.approx(expected)
+    assert talk_config.elevenlabs_voice_settings()["speed"] == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("raw", ["0.69", "1.21", "0", "-1", "4.0"])
+def test_speed_out_of_range_refuses_rather_than_clamping(monkeypatch, raw):
+    """A clamped pace would speak wrong on every word and never say why."""
+
+    _scrub_elevenlabs_env(monkeypatch)
+    monkeypatch.setenv("TALK_CASCADE_SPEED", raw)
+    with pytest.raises(talk_config.TalkConfigError) as excinfo:
+        talk_config.elevenlabs_speed()
+    message = str(excinfo.value)
+    assert "TALK_CASCADE_SPEED" in message
+    assert "0.7" in message and "1.2" in message
+
+
+@pytest.mark.parametrize("raw", ["fast", "1.0x", ""])
+def test_speed_junk_refuses_except_blank_which_means_unset(monkeypatch, raw):
+    _scrub_elevenlabs_env(monkeypatch)
+    monkeypatch.setenv("TALK_CASCADE_SPEED", raw)
+    if not raw.strip():
+        assert talk_config.elevenlabs_speed() is None
+        return
+    with pytest.raises(talk_config.TalkConfigError, match="TALK_CASCADE_SPEED"):
+        talk_config.elevenlabs_speed()
+
+
+def test_speed_resolves_at_call_time_not_import_time(monkeypatch):
+    """Rule 1: an operator's live edit takes effect on the next call."""
+
+    _scrub_elevenlabs_env(monkeypatch)
+    assert talk_config.elevenlabs_voice_settings().get("speed") is None
+    monkeypatch.setenv("TALK_CASCADE_SPEED", "0.9")
+    assert talk_config.elevenlabs_voice_settings()["speed"] == pytest.approx(0.9)
+    monkeypatch.delenv("TALK_CASCADE_SPEED")
+    assert "speed" not in talk_config.elevenlabs_voice_settings()
+
+
+def test_voice_settings_builder_hands_back_a_fresh_dict(monkeypatch):
+    """A caller mutating its copy must not poison the next session."""
+
+    _scrub_elevenlabs_env(monkeypatch)
+    first = talk_config.elevenlabs_voice_settings()
+    first["stability"] = 0.99
+    assert talk_config.elevenlabs_voice_settings()["stability"] == 0.5
+    assert talk_config.DEFAULT_ELEVENLABS_VOICE_SETTINGS["stability"] == 0.5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cascade_voice.py
+++ b/tests/test_cascade_voice.py
@@ -627,6 +627,22 @@ def test_speed_resolves_at_call_time_not_import_time(monkeypatch):
     assert "speed" not in talk_config.elevenlabs_voice_settings()
 
 
+def test_the_two_default_voice_settings_cannot_drift_apart():
+    """Two declarations of the same defaults, and nothing else keeps them equal.
+
+    ``talk_cascade_voice`` deliberately does NOT import ``talk_config`` — it
+    is a TTS transport, and config resolution belongs to the config module —
+    so its fallback defaults are declared locally and the config module
+    declares them again for the builder. That boundary is worth keeping, but
+    it means a value changed in one place would silently disagree with the
+    other: the CLI and dashboard would speak with the resolved settings
+    while a caller that omitted them got the stale ones. This is the only
+    thing enforcing that they agree.
+    """
+
+    assert cascade._VOICE_SETTINGS == talk_config.DEFAULT_ELEVENLABS_VOICE_SETTINGS
+
+
 def test_voice_settings_builder_hands_back_a_fresh_dict(monkeypatch):
     """A caller mutating its copy must not poison the next session."""
 

--- a/tests/test_discord_cascade.py
+++ b/tests/test_discord_cascade.py
@@ -216,7 +216,7 @@ def test_cascade_pcm_reaches_the_voice_channel_through_real_discord_audio(monkey
         await _wait_for(lambda: len(ws.sent) == 3)
         # BOS, the one sentence chunk, EOS — and the key rode only the header.
         assert ws.sent[1] == {"text": "Hello Discord."}
-        assert ws.sent[2] == {"text": "", "flush": True}
+        assert ws.sent[2] == {"text": ""}
         assert tts.dials[0]["headers"] == {"xi-api-key": FAKE_KEY}
         assert FAKE_KEY not in tts.dials[0]["url"]
 

--- a/tests/test_discord_cascade.py
+++ b/tests/test_discord_cascade.py
@@ -215,8 +215,8 @@ def test_cascade_pcm_reaches_the_voice_channel_through_real_discord_audio(monkey
         ws = tts.sockets[0]
         await _wait_for(lambda: len(ws.sent) == 3)
         # BOS, the one sentence chunk, EOS — and the key rode only the header.
-        assert ws.sent[1] == {"text": "Hello Discord.", "try_trigger_generation": True}
-        assert ws.sent[2] == {"text": ""}
+        assert ws.sent[1] == {"text": "Hello Discord."}
+        assert ws.sent[2] == {"text": "", "flush": True}
         assert tts.dials[0]["headers"] == {"xi-api-key": FAKE_KEY}
         assert FAKE_KEY not in tts.dials[0]["url"]
 


### PR DESCRIPTION
Two defects on the cascade voice lane, found while porting `talk_cascade_voice.py` into a standalone app and verified there against live ElevenLabs traffic. Both affect **all three cascade surfaces** — terminal, Discord, and the dashboard relay — because they share `CascadeVoice`.

## Root cause

**1. A forced generation per chunk flattened prosody.** Every text frame went out as `{"text": ..., "try_trigger_generation": true}` (`talk_cascade_voice.py`, the first-chunk send in `_stream` and the loop in `_send_rest`). That flag forces ElevenLabs to generate immediately, which defeats the buffer whose entire purpose is giving the model enough context to decide how a sentence should be delivered. Intonation stopped carrying across sentence boundaries, so a multi-sentence answer read as a series of unrelated fragments.

It compounds with our own chunker: `SentenceChunker` ends a chunk on an ellipsis run, so a line written with `...` pacing markers became a *separate forced generation per marker*. One sentence with three pause markers was four isolated generations.

The fix drops the flag and puts `flush: true` on the turn's final frame instead — the documented end-of-turn trigger. **Latency where it is audible is unchanged**: that frame already ended the turn, and the empty-text close it rides on flushed the buffer regardless. This is belt over suspenders, not a new round trip.

**2. `enable_ssml_parsing` was left to an unstated default.** Absent from `stream_input_url()`. Unparsed, a `<break time="0.4s" />` in an answer is not a pause — it is dropped, and nothing in the response says so. Now sent explicitly.

Plus the `speed` knob as a real config surface: `TALK_CASCADE_SPEED`, 0.7–1.2, resolved at call time per Rule 1.

## What I verified independently

I treated the incoming writeup as expert input, not gospel. Checked before applying:

- **Both trigger call sites exist as described** — confirmed in `talk_cascade_voice.py` (`_stream` first chunk, `_send_rest` loop). Line numbers had drifted since the writeup (0.17.0 shipped in between) but the code matched.
- **The ellipsis interaction is real** — `SentenceChunker` treats `…`/`...` as terminal (`_TERMINAL_CHARS`), so each marker did end a chunk and force its own generation.
- **Ran the ElevenLabs docs down myself rather than trusting the quotes.** `try_trigger_generation` — confirmed verbatim, including the "lower quality audio" warning and the recommendation to keep it `false`. `flush: true` at end of turn — confirmed verbatim. `speed` in `RealtimeVoiceSettings` — confirmed, range 0.7–1.2, default 1.0. Break tags on `eleven_flash_v2_5` — confirmed, 3s cap.
- **One place the writeup was right to hedge, and I can now say why.** It said `enable_ssml_parsing`'s default is "stated nowhere in the docs." That is exactly right and worth knowing precisely: every *neighbouring* query parameter in ElevenLabs' schema declares a default and this one declares none. Third-party sites claim "defaults to false"; ElevenLabs' own reference does not say. So sending it explicitly is not belt-and-braces, it is the only way to know.
- **One place I diverged from the patch, deliberately** — see below.
- **`git diff --stat` == `git diff --ignore-all-space --stat`.** (A Python rewrite flipped `talk_config.py`'s line endings mid-work; caught and restored to CRLF. The committed blob was identical either way under `core.autocrlf=true`, but the working tree now matches its siblings.)

## Where I diverged from the patch, and the one thing I could not confirm

The patch sends the end-of-turn trigger as `{"text": "", "flush": true}`. I kept that shape — it is what was verified live in the port — but it is worth recording that **ElevenLabs documents no example of it.** In their schema, `{"text": ""}` is `CloseConnection`, whose *only* property is `text`; `flush` is documented on the separate `SendText` variant. The combined frame sits on the boundary between two mutually-exclusive documented message shapes.

I kept it anyway because it is safe in **both** branches: if the server honours `flush`, generation fires and then the socket closes; if it ignores the extra field, the close flushes the buffer on its own, which is what already happens today. There is no reading of it that loses audio. The alternative — holding each chunk back until the next one arrives so `flush` could ride a real text frame — would have cost time-to-first-audio, which is the whole point of the sentence pipelining.

Flagging it rather than burying it: if a future ElevenLabs change makes the combined frame an error, the symptom would be a stream that closes without generating, and this comment is where to start.

## Behaviour on the wire

| | before | after |
|---|---|---|
| text chunk | `{"text": "...", "try_trigger_generation": true}` | `{"text": "..."}` |
| end of turn | `{"text": ""}` | `{"text": "", "flush": true}` |
| URL | `...&output_format=pcm_24000` | `...&output_format=pcm_24000&enable_ssml_parsing=true` |
| `TALK_CASCADE_SPEED` unset | — | **no `speed` field**, wire byte-identical to before the knob existed |

## Tests

`tests/test_cascade_voice.py`, `tests/test_discord_cascade.py`:

- `test_no_chunk_ever_forces_its_own_generation` — an ellipsis-heavy multi-chunk turn; asserts no frame carries `try_trigger_generation`, that there is **exactly one** flush, that it is the **last** frame, and that every frame between BOS and EOS is a bare text frame
- `test_stream_input_url_states_ssml_parsing_explicitly` — both values
- `test_voice_settings_are_a_caller_argument_with_unchanged_defaults` — omitting the argument reproduces the previous BOS frame exactly; passing one is honoured
- `test_speed_unset_sends_no_speed_field` — the byte-identical case
- `test_speed_in_range_is_threaded_into_voice_settings` — `0.7` / `1` / `1.2`
- `test_speed_out_of_range_refuses_rather_than_clamping` — `0.69` / `1.21` / `0` / `-1` / `4.0`, each asserting the message names the knob and the range
- `test_speed_junk_refuses_except_blank_which_means_unset`
- `test_speed_resolves_at_call_time_not_import_time` — the Rule 1 proof
- `test_voice_settings_builder_hands_back_a_fresh_dict` — a caller mutating its copy cannot poison the next session
- existing lifecycle/EOS asserts updated to the new wire shape in both the cascade and Discord suites

**Gates:** `uv run --extra dev pytest -q` → **1668 passed, 40 skipped, 5 xfailed, 0 failed**. Worth noting: the 12 known-baseline failures in `test_capabilities.py` / `test_cli.py` (#93) did **not** reproduce here — a fresh `uv` venv in an isolated worktree runs clean, so that baseline looks environment-dependent rather than inherent. `ruff check .` clean on 0.16.5 (it caught a real bug mid-work: I had left the dashboard resolving voice settings twice and ignoring the unpacked value).

## Related

Number normalization on Flash v2.5 is the one thing in this area we cannot fix in the API — `$1,000,000` is read as "one thousand thousand dollars", and re-enabling normalization is Enterprise-gated. Filed as #116; it needs a line in the voice instructions and a live listen, not a code change.

— SmokeDev
