### PR TITLE
fix(dashboard): stream the cascade relay on servers that advertise ASGI 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,49 @@ but 0.4.0's release title named only the steering verb. They are recorded
 below under 0.4.0 — the first version that shipped them — with the gap
 named rather than smoothed.
 
+## [Unreleased]
+
+### Fixed
+- The dashboard cascade relay no longer deadlocks on the servers Hermes
+  actually runs on. `POST /api/plugins/hermes-talk/cascade-tts` returned
+  HTTP 200 and then zero bytes of PCM, followed by a `ClientDisconnect` in
+  the log once the browser gave up — so the dashboard's cloned voice
+  silently degraded to text-only with no error anywhere.
+
+  Starlette's `StreamingResponse` only trusts `send()` for disconnect
+  signalling when the server advertises ASGI `spec_version` 2.4 or above.
+  Below that it races the body generator against a disconnect listener, and
+  that listener calls `receive()` first — taking the browser's
+  `http.request` messages off the channel. The relay's own
+  `request.stream()` then only ever saw `http.disconnect`, so it waited
+  forever for text that had already arrived. **Uvicorn advertises 2.3 for
+  HTTP**, hardcoded in both `h11_impl.py` and `httptools_impl.py`, so this
+  was the branch every dashboard took; only its websocket protocols say
+  2.4, which is why the websocket lanes never showed it.
+
+  The relay now returns a `RelayResponse` that owns the request body
+  channel and takes Starlette's own `>= 2.4` path verbatim. A browser that
+  vanishes mid-upload raises `ClientDisconnect` into the feeder, which is
+  now handled as an abort — the same path as a stream that ends without its
+  `done` line — rather than escaping as an error.
+
+  The existing tests could not have caught this: they drive the route with
+  a fake request and never touch an ASGI server, and Starlette's own
+  `TestClient` omits `spec_version` from the scope, so a test written
+  through it takes the same broken branch and HANGS instead of failing. The
+  new coverage drives the real relay body over a real single-consumer ASGI
+  channel and asserts on the scope VALUE rather than on a version string,
+  so a future uvicorn that advertises 2.4 leaves it meaningful.
+
+### Changed
+- `starlette` is now a **dev/test** dependency. It is where
+  `StreamingResponse` and `ClientDisconnect` actually live (fastapi
+  re-exports them), and the relay's behavior above is starlette behavior —
+  untestable in CI without the real class, which is exactly how the
+  deadlock shipped. `dashboard/plugin_api.py` still falls back to its own
+  stub when starlette is absent, so the plugin installs with no web
+  dependency of its own.
+
 ## [0.17.0] — 2026-09-03
 
 Prove it, then pause it. `hermes talk check` runs the whole path — doctor,

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -66,9 +66,36 @@ import talk_runs  # noqa: E402
 import talk_tools  # noqa: E402
 import talk_wire  # noqa: E402
 
+# Two tiers, because the streaming half of this module and the routing half
+# come from different packages. ``StreamingResponse`` and ``ClientDisconnect``
+# are STARLETTE's — fastapi only re-exports them — and the relay's ASGI
+# behavior below is starlette behavior. Importing them from their real home
+# lets the dev extra install starlette ALONE, so that behavior is covered in
+# CI without pulling a whole web framework into a plugin that has no web
+# dependency of its own.
+try:
+    from starlette.requests import ClientDisconnect
+    from starlette.responses import StreamingResponse
+except ImportError:  # pragma: no cover - no dashboard deps at all
+
+    class ClientDisconnect(Exception):  # type: ignore[no-redef]
+        """Raised by ``request.stream()`` when the browser goes away.
+
+        Defined here too so the relay's ``except`` clause is importable on a
+        box without the dashboard deps — offline it is simply never raised.
+        """
+
+    class StreamingResponse:  # type: ignore[no-redef]
+        """The three attributes the route and offline tests touch."""
+
+        def __init__(self, content, media_type=None) -> None:
+            self.body_iterator = content
+            self.media_type = media_type
+            self.status_code = 200
+
+
 try:
     from fastapi import APIRouter, HTTPException, Request
-    from fastapi.responses import StreamingResponse
 except ImportError:  # pragma: no cover - offline tests run without the dashboard deps
 
     class APIRouter:  # type: ignore[no-redef]
@@ -91,13 +118,42 @@ except ImportError:  # pragma: no cover - offline tests run without the dashboar
     class Request:  # type: ignore[no-redef]
         """Annotation target only — never instantiated on this path."""
 
-    class StreamingResponse:  # type: ignore[no-redef]
-        """The two attributes the route and offline tests touch, in fastapi's shape."""
 
-        def __init__(self, content, media_type=None) -> None:
-            self.body_iterator = content
-            self.media_type = media_type
-            self.status_code = 200
+class RelayResponse(StreamingResponse):
+    """A streaming response that leaves the request body to the relay.
+
+    Starlette pairs the body stream with a disconnect listener that calls
+    ``receive()`` on the same channel. Below ASGI ``spec_version`` 2.4 it
+    races that listener against the body generator, and the listener wins
+    the first ``receive()`` — swallowing the browser's ``http.request``
+    messages. The relay's own ``request.stream()`` then only ever sees
+    ``http.disconnect``, so it waits forever for text that already arrived:
+    HTTP 200, zero bytes, then a ClientDisconnect in the log when the
+    browser gives up.
+
+    **Uvicorn advertises 2.3 for HTTP** — hardcoded in both
+    ``protocols/http/h11_impl.py`` and ``httptools_impl.py`` — so this is
+    the branch every Hermes dashboard actually takes, not an edge case.
+    Only uvicorn's websocket protocols say 2.4, which is why the websocket
+    lanes never showed this.
+
+    The relay reads the upload itself and ends on its own when the client
+    goes away, so the listener buys nothing here. This takes Starlette's OWN
+    ``>= 2.4`` path verbatim — including the ``OSError`` mapping and the
+    background callback — rather than a reduced version of it, so a server
+    that does advertise 2.4 and this class behave identically.
+    """
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope.get("type") != "http":  # websocket denial keeps base behavior
+            await super().__call__(scope, receive, send)
+            return
+        try:
+            await self.stream_response(send)
+        except OSError as exc:
+            raise ClientDisconnect() from exc
+        if self.background is not None:
+            await self.background()
 
 
 _log = logging.getLogger(__name__)
@@ -603,6 +659,12 @@ async def _cascade_pcm_stream(request, config: tuple[str, str, str]) -> AsyncIte
                     "dashboard cascade relay: unrecognized stream line — answer cancelled"
                 )
                 return
+        except ClientDisconnect:
+            # The browser vanished mid-upload (barge-in, tab closed, socket
+            # torn). That is an abort, not an error: same handling as a
+            # stream that ends without its `done` line — `completed` stays
+            # false, so the drain loop stops and aclose() silences the TTS.
+            return
         finally:
             audio_queue.put_nowait(_FEED_DONE)
 
@@ -642,7 +704,7 @@ async def cascade_tts(request: Request):
 
     require_dashboard_auth(request)
     config = _resolve_cascade_relay_config()
-    return StreamingResponse(
+    return RelayResponse(
         _cascade_pcm_stream(request, config),
         media_type=CASCADE_PCM_MEDIA_TYPE,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,13 @@ dependencies = ["httpx>=0.27", "aiohttp>=3.9"]
 
 [project.optional-dependencies]
 audio = ["sounddevice>=0.4.6", "numpy>=1.26"]
-dev = ["pytest>=8", "ruff==0.16.5"]
+# starlette is a TEST dependency, never a runtime one: the dashboard relay's
+# streaming response is a starlette response, and its ASGI behavior differs by
+# what the SERVER advertises (uvicorn says spec_version 2.3 for HTTP). Without
+# the real class in CI that branch is untestable, which is exactly how the
+# relay deadlock shipped. `dashboard/plugin_api.py` still runs against its own
+# stub when starlette is absent, so the plugin installs without it.
+dev = ["pytest>=8", "ruff==0.16.5", "starlette>=0.40"]
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/tests/test_dashboard_cascade.py
+++ b/tests/test_dashboard_cascade.py
@@ -478,3 +478,242 @@ def test_status_defaults_to_native(monkeypatch):
 
     body = _run(api.talk_status(JsonRequest()))
     assert body["voiceMode"] == "native"
+
+
+# -- the ASGI branch the relay actually runs on -------------------------------
+#
+# These drive the response object directly rather than through Starlette's
+# TestClient. That is deliberate and load-bearing: TestClient omits
+# `spec_version` from the scope entirely, so it takes the SAME broken branch
+# (`scope.get("asgi", {}).get("spec_version", "2.0")` -> below 2.4) and a test
+# written through it would HANG rather than fail. Every assertion here is
+# pinned to the scope VALUE, never to a version string, so a future uvicorn
+# that advertises 2.4 leaves these tests meaningful instead of vacuous.
+
+
+class _RecordingChannel:
+    """An ASGI ``send``/``receive`` pair that records who called what.
+
+    ``receive`` never returns: it is the disconnect listener's first await,
+    and a relay that touches it has taken the body message the relay's own
+    ``request.stream()`` was waiting for.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.receive_calls = 0
+
+    async def send(self, message: dict) -> None:
+        self.sent.append(message)
+
+    async def receive(self) -> dict:
+        self.receive_calls += 1
+        await asyncio.Event().wait()  # the deadlock, made explicit
+        raise AssertionError("unreachable")
+
+    def body(self) -> bytes:
+        return b"".join(
+            m.get("body", b"") for m in self.sent if m["type"] == "http.response.body"
+        )
+
+
+def _http_scope(spec_version: str) -> dict:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": spec_version},
+        "method": "POST",
+        "path": "/cascade-tts",
+        "headers": [],
+    }
+
+
+async def _one_chunk():
+    yield b"pcm-bytes"
+
+
+def test_relay_streams_on_a_server_advertising_asgi_below_2_4():
+    """The branch uvicorn actually selects: spec_version 2.3 over HTTP.
+
+    Starlette's own StreamingResponse races a disconnect listener against
+    the body generator here, and the listener calls receive() FIRST —
+    swallowing the browser's http.request messages, so the relay waits
+    forever for text that already arrived. RelayResponse owns the body
+    channel and must never touch receive().
+    """
+
+    channel = _RecordingChannel()
+    response = api.RelayResponse(_one_chunk(), media_type=api.CASCADE_PCM_MEDIA_TYPE)
+
+    _run(
+        asyncio.wait_for(
+            response(_http_scope("2.3"), channel.receive, channel.send), timeout=2.0
+        )
+    )
+
+    assert channel.receive_calls == 0, "the relay must own the request body channel"
+    assert channel.body() == b"pcm-bytes"
+    assert channel.sent[0]["type"] == "http.response.start"
+    assert channel.sent[0]["status"] == 200
+    assert channel.sent[-1] == {
+        "type": "http.response.body",
+        "body": b"",
+        "more_body": False,
+    }
+
+
+class _AsgiChannel:
+    """A real single-consumer ASGI channel: each message is delivered ONCE.
+
+    This is the whole bug in one object. The browser's upload arrives as
+    ``http.request`` messages on the same channel the disconnect listener
+    reads, and whichever coroutine calls ``receive()`` first takes them. A
+    fake that hands the body to everyone who asks cannot reproduce this.
+    """
+
+    def __init__(self, *bodies: bytes) -> None:
+        self.messages = [
+            {"type": "http.request", "body": body, "more_body": True}
+            for body in bodies
+        ]
+        self.messages.append({"type": "http.request", "body": b"", "more_body": False})
+        self.messages.append({"type": "http.disconnect"})
+        self.sent: list[dict] = []
+        self.receive_calls = 0
+
+    async def receive(self) -> dict:
+        self.receive_calls += 1
+        if self.messages:
+            return self.messages.pop(0)
+        await asyncio.Event().wait()  # drained: whoever waits here is stuck
+        raise AssertionError("unreachable")
+
+    async def send(self, message: dict) -> None:
+        self.sent.append(message)
+
+    def body(self) -> bytes:
+        return b"".join(
+            m.get("body", b"") for m in self.sent if m["type"] == "http.response.body"
+        )
+
+
+async def _drive_relay(response_cls, tts, pcm: bytes) -> bytes:
+    """Run the real relay body through ``response_cls`` over a real channel."""
+
+    starlette_requests = pytest.importorskip("starlette.requests")
+
+    upload = b"".join(
+        ndjson({"delta": "Hello there. "}, {"done": "Hello there."})
+    )
+    channel = _AsgiChannel(upload)
+    scope = _http_scope("2.3")
+    request = starlette_requests.Request(scope, channel.receive)
+
+    config = api._resolve_cascade_relay_config()
+    response = response_cls(
+        api._cascade_pcm_stream(request, config),
+        media_type=api.CASCADE_PCM_MEDIA_TYPE,
+    )
+
+    async def script_upstream():
+        await _wait_for(lambda: len(tts.sockets) == 1, timeout=1.0)
+        ws = tts.sockets[0]
+        await _wait_for(lambda: len(ws.sent) >= 3, timeout=1.0)
+        ws.feed_audio(pcm)
+        ws.feed_final()
+
+    upstream = asyncio.create_task(script_upstream())
+    try:
+        await asyncio.wait_for(response(scope, channel.receive, channel.send), 3.0)
+    finally:
+        upstream.cancel()
+        await asyncio.gather(upstream, return_exceptions=True)
+    return channel.body()
+
+
+def test_the_stock_streaming_response_loses_the_upload_on_the_same_scope(tts):
+    """Fail-without-the-fix, pinned to the scope VALUE, not a version string.
+
+    Starlette's disconnect listener calls receive() first and takes the
+    browser's `http.request` messages, so the relay's own request.stream()
+    only ever sees `http.disconnect` and the answer's text never reaches the
+    cascade. The reported symptom exactly: HTTP 200, zero bytes of PCM, and
+    a ClientDisconnect once the browser gives up.
+
+    If a future starlette stops racing here, THIS test fails and the
+    subclass can be reconsidered — the fixed one beside it stays green
+    either way, which is why the assertion is on the scope value rather
+    than on a starlette or uvicorn version.
+    """
+
+    starlette_responses = pytest.importorskip("starlette.responses")
+
+    body = _run(
+        _drive_relay(starlette_responses.StreamingResponse, tts, b"\x07\x08" * 480)
+    )
+
+    assert body == b"", "the stock response is expected to lose the upload"
+    assert not tts.sockets, "no text reached the cascade, so it never dialed"
+
+
+def test_the_relay_response_delivers_the_pcm_on_the_same_scope(tts):
+    """The same channel, the same scope, the same relay — with the fix."""
+
+    pcm = b"\x07\x08" * 480
+
+    body = _run(_drive_relay(api.RelayResponse, tts, pcm))
+
+    assert body == pcm
+    assert len(tts.sockets) == 1
+    assert [m.get("text") for m in tts.sockets[0].sent] == [" ", "Hello there.", ""]
+
+
+def test_relay_streams_identically_when_the_server_advertises_2_4():
+    """A server that advertises 2.4 gets byte-identical behavior."""
+
+    channel = _RecordingChannel()
+    response = api.RelayResponse(_one_chunk(), media_type=api.CASCADE_PCM_MEDIA_TYPE)
+
+    _run(
+        asyncio.wait_for(
+            response(_http_scope("2.4"), channel.receive, channel.send), timeout=2.0
+        )
+    )
+
+    assert channel.receive_calls == 0
+    assert channel.body() == b"pcm-bytes"
+
+
+def test_the_route_returns_a_relay_response_not_a_bare_streaming_response():
+    """The whole fix is which class the route hands back."""
+
+    response = _run(api.cascade_tts(StreamRequest([])))
+    assert isinstance(response, api.RelayResponse)
+    assert response.media_type == api.CASCADE_PCM_MEDIA_TYPE
+
+
+def test_a_client_that_vanishes_mid_upload_is_an_abort_not_an_error(tts, caplog):
+    """ClientDisconnect is handled like a stream that ends without `done`.
+
+    A browser that goes away mid-answer (barge-in, tab closed) must cancel
+    the TTS rather than raise out of the feeder — the operator hears silence,
+    the log stays clean, and no half-answer keeps speaking into a closed tab.
+    """
+
+    class _DisconnectingRequest(StreamRequest):
+        async def stream(self):
+            for chunk in self._chunks:
+                yield chunk
+            raise api.ClientDisconnect()
+
+    request = _DisconnectingRequest(ndjson({"delta": "Hello there. "}))
+
+    async def scenario():
+        response = await api.cascade_tts(request)
+        return await _collect(response)
+
+    with caplog.at_level("WARNING"):
+        out = _run(scenario())
+
+    assert out == b""  # aborted before any PCM was completed
+    assert "malformed" not in caplog.text
+    assert "unrecognized" not in caplog.text


### PR DESCRIPTION
The dashboard cascade relay deadlocks on the ASGI server Hermes actually ships with. `POST /api/plugins/hermes-talk/cascade-tts` returns **HTTP 200, zero bytes of PCM**, then a `ClientDisconnect` in the log when the browser gives up — so the dashboard's cloned voice degrades to text-only with no error on any surface.

## Root cause

Starlette's `StreamingResponse.__call__` only trusts `send()` for disconnect signalling when the server advertises ASGI `spec_version >= 2.4`. Below that it runs a task group racing `stream_response` against `listen_for_disconnect(receive)` — and that listener calls `receive()` **first**, taking the browser's `http.request` messages off the channel. The relay's own `request.stream()` then only ever sees `http.disconnect`, so it waits forever for text that already arrived.

**Uvicorn advertises `"2.3"` for HTTP.** That is the branch every Hermes dashboard takes — not an edge case.

The fix returns a `RelayResponse` that owns the request body channel, and handles a mid-upload `ClientDisconnect` in the feeder as an abort (same path as a stream that ends without its `done` line) rather than letting it escape as an error.

## What I verified independently

Everything below I checked against the **installed** source rather than taking the writeup's word for it:

- **Versions in the real Hermes venv** (`AppData\Local\hermes\hermes-agent\venv`): **starlette 1.3.1, uvicorn 0.41.0, fastapi 0.133.1**, Python 3.11.13. CI resolves starlette 1.6.0 — I read `StreamingResponse.__call__` in **both** and they are byte-identical in the branch that matters, so the fix is not pinned to one starlette.
- **The racing branch exists as described** — read verbatim from the installed `starlette/responses.py`: `spec_version = tuple(...scope.get("asgi", {}).get("spec_version", "2.0")...)`, `if spec_version >= (2, 4): ... else: <task group racing stream_response against listen_for_disconnect(receive)>`. And `listen_for_disconnect` is a bare `while True: message = await receive()`.
- **Uvicorn's advertised value** — `grep`'d the installed package: `"spec_version": "2.3"` in **both** `protocols/http/h11_impl.py:205` and `protocols/http/httptools_impl.py:227`. The contrast holds too: `websockets_impl.py:186` and `wsproto_impl.py:174` say `"2.4"`, which is exactly why the websocket lanes never showed this.
- **The default when the key is missing is `"2.0"`** — which is what makes the TestClient warning real, and why I did not test through it.
- **`git diff --stat` == `git diff --ignore-all-space --stat`.**

**One place the patch note was incomplete, and it mattered.** Its `RelayResponse` was:

```python
async def __call__(self, scope, receive, send) -> None:
    await self.stream_response(send)
```

That silently drops two things starlette's own `>= 2.4` path does: the `OSError` → `ClientDisconnect` mapping, and the `background` callback. Neither is used by this route today, but a subclass that quietly diverges from its base is a trap for whoever adds a background task later. This PR takes starlette's `>= 2.4` branch **verbatim** instead, so a server that genuinely advertises 2.4 and this class behave identically — and keeps `super().__call__` for the non-http (websocket denial) case.

## The test, and the mistake I made writing it

The instruction not to use `TestClient` is right — it omits `spec_version`, takes the same broken branch, and a test through it **hangs rather than fails**. But my first attempt at a fail-without-fix test was also wrong, and it is worth recording why:

I drove the stock `StreamingResponse` with a trivial body generator and expected a timeout. It passed cleanly. **A body generator that does not read the request body never deadlocks** — `stream_response` finishes first and the task group cancels the listener. The race only bites when two coroutines compete for the *same* messages.

So the test now drives **the real `_cascade_pcm_stream`**, over a real `starlette.requests.Request`, on a **single-consumer ASGI channel** where each message is delivered exactly once — which is the actual mechanism. The two halves are a differential on the same scope, the same channel, and the same relay body:

- `test_the_stock_streaming_response_loses_the_upload_on_the_same_scope` — stock response: body is `b""` and the cascade **never dials**, because no text reached it. The reported symptom exactly.
- `test_the_relay_response_delivers_the_pcm_on_the_same_scope` — `RelayResponse`: the PCM comes back and the socket saw `[" ", "Hello there.", ""]`.

Plus:

- `test_relay_streams_on_a_server_advertising_asgi_below_2_4` — asserts `receive_calls == 0` and a well-formed `http.response.start` → body → terminal empty-body sequence
- `test_relay_streams_identically_when_the_server_advertises_2_4` — the 2.4 scope behaves the same
- `test_the_route_returns_a_relay_response_not_a_bare_streaming_response`
- `test_a_client_that_vanishes_mid_upload_is_an_abort_not_an_error` — no PCM, and no "malformed"/"unrecognized" receipt in the log

**Every assertion is pinned to the scope VALUE, never a version string**, so a future uvicorn advertising 2.4 leaves these meaningful rather than vacuous.

**I confirmed the tests bite.** Neutering `RelayResponse.__call__` to fall through to the racing base fails exactly two — `AssertionError: the relay must own the request body channel` and `assert b'' == b'\x07\x08...'` — and passes the other 21.

## One judgement call: `starlette` as a dev dependency

The bug is starlette behavior, so testing it needs starlette. An `importorskip` would have skipped in CI — which is precisely how this shipped in the first place, so I did not do that.

Instead I split the import shim into two tiers. `StreamingResponse` and `ClientDisconnect` are **starlette's** — fastapi only re-exports them — so importing them from their real home lets the dev extra install `starlette` **alone**, without pulling a web framework into a plugin that has no web dependency. `APIRouter` / `HTTPException` / `Request` still come from fastapi or fall back to the existing stubs, so the rest of `test_dashboard_api.py` and `test_dashboard_cascade.py` behave exactly as before (verified: 52/52 still pass against the real starlette base). **Runtime dependencies are unchanged** — the module still falls back to its own stub when starlette is absent, and the plugin installs without it.

## Gates

`uv run --extra dev pytest -q` → **1657 passed, 40 skipped, 5 xfailed, 0 failed**. `ruff check .` clean on 0.16.5. As on #117, the 12 known-baseline failures (#93) did not reproduce in a fresh `uv` venv.

— SmokeDev
