### PR TITLE
fix(dashboard): gapless PCM playback and an honest failure when the browser cannot stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ named rather than smoothed.
 
 ## [Unreleased]
 
+### Changed
+- `starlette` is now a **dev/test** dependency. It is where
+  `StreamingResponse` and `ClientDisconnect` actually live (fastapi
+  re-exports them), and the relay deadlock fixed below is starlette
+  behavior — untestable in CI without the real class, which is exactly how the
+  deadlock shipped. `dashboard/plugin_api.py` still falls back to its own
+  stub when starlette is absent, so the plugin installs with no web
+  dependency of its own.
+
 ### Fixed
 - The dashboard cascade relay no longer deadlocks on the servers Hermes
   actually runs on. `POST /api/plugins/hermes-talk/cascade-tts` returned
@@ -45,14 +54,38 @@ named rather than smoothed.
   channel and asserts on the scope VALUE rather than on a version string,
   so a future uvicorn that advertises 2.4 leaves it meaningful.
 
-### Changed
-- `starlette` is now a **dev/test** dependency. It is where
-  `StreamingResponse` and `ClientDisconnect` actually live (fastapi
-  re-exports them), and the relay's behavior above is starlette behavior —
-  untestable in CI without the real class, which is exactly how the
-  deadlock shipped. `dashboard/plugin_api.py` still falls back to its own
-  stub when starlette is absent, so the plugin installs with no web
-  dependency of its own.
+- The dashboard's cloned voice no longer ticks at every chunk seam. The
+  page opened its AudioContext at the browser default (48kHz on Windows)
+  and then handed it 24kHz buffers, and Web Audio resamples each
+  `AudioBuffer` independently — two chunks resampled in isolation do not
+  line up where they meet, so every chunk boundary was a discontinuity
+  while the PCM leaving the server was provably clean. Measured on a 440 Hz
+  tone split into 40 uneven chunks: the per-chunk path jumped 0.105 between
+  adjacent output samples where a smooth signal steps 0.035, and a 3x step
+  at a seam is the tick you hear. The context is now requested at the PCM's
+  own 24kHz so nothing is resampled at all; browsers that refuse the rate
+  get a resampler that carries the previous chunk's last sample and its
+  fractional read position across chunks, which measures identical to
+  resampling the whole tone at once. Barge-in clears that carry-over along
+  with the generation bump, so an interrupted sentence cannot splice itself
+  onto the next answer.
+- The dashboard cascade no longer goes silently mute on HTTP/1.1. The relay
+  posted its request body as a `ReadableStream` with `duplex: "half"`, and
+  Chrome only sends a streaming request body over HTTP/2 or HTTP/3 — on a
+  plain HTTP/1.1 origin, which a local dashboard almost always is, the
+  fetch rejects outright. The `.catch(() => {})` swallowed it by design, so
+  the model's text captioned normally, no audio ever played, no error
+  appeared anywhere, and zero requests reached `/cascade-tts`. The page now
+  checks the protocol it actually negotiated
+  (`performance.getEntriesByType("navigation")[0].nextHopProtocol`) and
+  posts the whole answer once its text is done when it cannot stream. That
+  costs sentence pipelining — the first sentence no longer plays while the
+  model writes the second — but it produces audio instead of silence.
+- A cascade relay that fails for a real reason now says so once, through
+  the tab's own error surface and the console, instead of vanishing into
+  the same `.catch()`. "Silently" was half of the bug above: a mute voice
+  and a working one were indistinguishable. A deliberate abort (barge-in,
+  hang-up) stays quiet, because that is not a failure.
 
 ## [0.17.0] — 2026-09-03
 

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -91,6 +91,73 @@
     return relayEncoder.encode(JSON.stringify(line) + "\n");
   }
 
+  /** The cascade's PCM is 24kHz mono s16le; the context should agree. */
+  const PCM_RATE = 24000;
+
+  /**
+   * An AudioContext at the PCM's OWN rate, so no resampling happens at all.
+   *
+   * Web Audio resamples every AudioBuffer independently. At the browser
+   * default (48kHz on Windows) two chunks resampled in isolation do not line
+   * up where they meet, so every chunk seam is a discontinuity — an audible
+   * tick every couple of seconds while the PCM leaving the server is clean.
+   * Chrome and Edge honour the requested rate; the ones that refuse fall back
+   * to a resampler that carries state across chunks (see resampleToContext).
+   */
+  /** One mono AudioBuffer at `rate`, filled from `values` scaled by `scale`. */
+  function pcmBuffer(ctx, values, rate, scale) {
+    const buffer = ctx.createBuffer(1, values.length, rate);
+    const channel = buffer.getChannelData(0);
+    for (let i = 0; i < values.length; i++) channel[i] = values[i] / scale;
+    return buffer;
+  }
+
+  function makePcmContext() {
+    const Ctx = window.AudioContext || window.webkitAudioContext;
+    if (!Ctx) return null;
+    try {
+      return new Ctx({ sampleRate: PCM_RATE });
+    } catch (e) {
+      return new Ctx();
+    }
+  }
+
+  /**
+   * Whether this page may send a STREAMING request body.
+   *
+   * Chrome only streams an upload over HTTP/2 or HTTP/3. On a plain HTTP/1.1
+   * origin — which a local dashboard almost always is — `fetch` with
+   * `duplex: "half"` rejects outright, and the cascade's own `.catch()` used
+   * to swallow it: the model's text captioned fine, no audio ever played, and
+   * zero requests reached the relay. Gate on the protocol the page actually
+   * negotiated and buffer the answer when we cannot stream.
+   *
+   * Memoised, and computed on FIRST USE rather than at load: the navigation
+   * timing entry is not necessarily populated while this IIFE is still
+   * evaluating.
+   */
+  let canStreamUploadCache = null;
+  function canStreamUpload() {
+    if (canStreamUploadCache !== null) return canStreamUploadCache;
+    canStreamUploadCache = false;
+    try {
+      const nav = (typeof performance !== "undefined" && performance.getEntriesByType)
+        ? (performance.getEntriesByType("navigation")[0] || null)
+        : null;
+      const hop = String((nav && nav.nextHopProtocol) || "").toLowerCase();
+      if (!/^h[23]/.test(hop)) return canStreamUploadCache;
+      if (typeof Request === "undefined" || typeof ReadableStream === "undefined") {
+        return canStreamUploadCache;
+      }
+      // The browser must also ACCEPT a stream body — older engines throw here.
+      new Request("/", { method: "POST", body: new ReadableStream(), duplex: "half" });
+      canStreamUploadCache = true;
+    } catch (e) {
+      canStreamUploadCache = false;
+    }
+    return canStreamUploadCache;
+  }
+
   /** fetchJSON throws Error("<status>: <body>") — the gate's refusals look like this. */
   function isAuthError(err) {
     return /^(401|403)\b/.test(String((err && err.message) || ""));
@@ -149,6 +216,14 @@
       this.pcmNextTime = 0;
       this.pcmSources = [];
       this.pcmGeneration = 0;
+      // Resampler carry-over: the previous chunk's last sample and the
+      // fractional read position. Only used when the browser refused a
+      // 24kHz context; stale values would click on the next answer, so
+      // stopPcmPlayback() clears them alongside the generation bump.
+      this.pcmPrev = null;
+      this.pcmPos = 0;
+      // One receipt per session for a relay that failed for a real reason.
+      this.cascadeFailureLogged = false;
     }
 
     async start() {
@@ -337,50 +412,110 @@
      * writing the second, same as the terminal lane's sentence pipelining.
      */
     startCascadeStream() {
-      const req = { controller: new AbortController(), sink: null };
+      const req = { controller: new AbortController(), sink: null, buffered: null };
       this.cascadeReq = req;
       this.cascadeReqs.add(req);
+      if (!canStreamUpload()) {
+        // HTTP/1.1: this browser cannot send a streaming body at all. Collect
+        // the answer's lines and post them in one piece when its text is
+        // done (see finishCascadeStream). That costs sentence pipelining —
+        // the first sentence no longer plays while the model writes the
+        // second — but it produces audio instead of silence.
+        req.buffered = [];
+        return;
+      }
       const body = new ReadableStream({
         start: (controller) => {
           req.sink = controller;
         },
       });
+      this.sendCascadeRequest(req, body, true);
+    }
+
+    /** POST one relay request; `stream` picks the duplex upload path. */
+    sendCascadeRequest(req, body, stream) {
       const headers = { "content-type": "application/x-ndjson" };
       const token = readToken();
       if (token) headers["x-talk-token"] = token;
-      // Raw fetch, not apiCall: this is a bidirectional byte stream, not JSON.
-      fetch(API + "/cascade-tts", {
+      const init = {
         method: "POST",
         headers: headers,
         body: body,
-        duplex: "half",
         signal: req.controller.signal,
-      })
+      };
+      if (stream) init.duplex = "half";
+      // Raw fetch, not apiCall: this is a byte stream, not JSON.
+      fetch(API + "/cascade-tts", init)
         .then((res) => {
-          if (!res.ok || !res.body) return undefined;
+          if (!res.ok || !res.body) {
+            this.noteCascadeFailure("relay refused the answer (" +
+              ((res && res.status) || "no response") + ")");
+            return undefined;
+          }
           return this.playCascadePcm(req, res.body.getReader());
         })
-        .catch(() => {
-          // Aborts (barge-in, stop) and refusals alike land here: the answer
-          // degrades to text-only on screen, which is already true.
+        .catch((error) => {
+          // A barge-in or hang-up aborts on purpose and is not a failure.
+          // Anything else used to vanish here — which is how a browser that
+          // silently refused to stream the upload looked exactly like a
+          // working session with a mute voice.
+          if (!req.controller.signal.aborted) {
+            this.noteCascadeFailure(errorText(error));
+          }
         });
+    }
+
+    /** Say once, per session, that the custom voice is not being heard. */
+    noteCascadeFailure(detail) {
+      if (this.cascadeFailureLogged) return;
+      this.cascadeFailureLogged = true;
+      const message = "Custom voice unavailable — answers stay text-only. " + detail;
+      if (typeof console !== "undefined" && console.warn) console.warn(message);
+      if (this.cb && this.cb.onError) {
+        try { this.cb.onError(message); } catch (e) { /* UI must not kill audio */ }
+      }
     }
 
     cascadeSend(line) {
       // The previous response's relay may still be draining PCM — that is no
       // reason to drop THIS response's text; it opens its own stream.
-      if (!this.cascadeReq || !this.cascadeReq.sink) this.startCascadeStream();
-      const sink = this.cascadeReq && this.cascadeReq.sink;
+      const open = this.cascadeReq && (this.cascadeReq.sink || this.cascadeReq.buffered);
+      if (!open) this.startCascadeStream();
+      const req = this.cascadeReq;
+      if (!req) return;
       // An upload stream carries BYTES — a string chunk is a fetch-type error.
-      if (sink) sink.enqueue(encodeRelayLine(line));
+      if (req.sink) req.sink.enqueue(encodeRelayLine(line));
+      else if (req.buffered) req.buffered.push(encodeRelayLine(line));
     }
 
     /** The response's text is complete; the PCM answer keeps streaming. */
     finishCascadeStream() {
       const req = this.cascadeReq;
-      if (req && req.sink) {
+      if (!req) return;
+      if (req.sink) {
         try { req.sink.close(); } catch (e) { /* an errored stream is already closed */ }
         req.sink = null;
+        return;
+      }
+      if (req.buffered) {
+        // The whole answer at once — this is the point the buffered path was
+        // waiting for. A response with no text never posts at all.
+        const lines = req.buffered;
+        req.buffered = null;
+        if (!lines.length) {
+          this.cascadeReqs.delete(req);
+          if (this.cascadeReq === req) this.cascadeReq = null;
+          return;
+        }
+        let total = 0;
+        for (let i = 0; i < lines.length; i++) total += lines[i].length;
+        const body = new Uint8Array(total);
+        let offset = 0;
+        for (let i = 0; i < lines.length; i++) {
+          body.set(lines[i], offset);
+          offset += lines[i].length;
+        }
+        this.sendCascadeRequest(req, body, false);
       }
     }
 
@@ -393,6 +528,9 @@
         if (req.sink) {
           try { req.sink.close(); } catch (e) { /* already closed */ }
         }
+        // A buffered answer that never posted is dropped, not sent: the
+        // operator interrupted it, so there is nothing left to speak.
+        req.buffered = null;
         req.controller.abort();
       });
       this.stopPcmPlayback();
@@ -409,6 +547,11 @@
       this.pcmSources = [];
       this.pcmNextTime = 0;
       this.pcmGeneration += 1;
+      // Interpolation state belongs to the answer that was speaking. Left
+      // behind, it would splice the end of an interrupted sentence onto the
+      // start of the next one — the same seam click, one barge-in later.
+      this.pcmPrev = null;
+      this.pcmPos = 0;
     }
 
     /** PCM24k mono s16le off the wire onto the playback timeline. */
@@ -434,20 +577,52 @@
       if (this.cascadeReq === req) this.cascadeReq = null;
     }
 
+    /**
+     * PCM24k -> the context's rate, continuous ACROSS chunks.
+     *
+     * Carrying the previous chunk's last sample and the fractional read
+     * position is what makes the stream one unbroken signal. Interpolating
+     * each chunk in isolation is the original bug in a different costume.
+     */
+    resampleToContext(samples, rate) {
+      const ratio = PCM_RATE / rate;
+      const prev = this.pcmPrev === null ? samples[0] : this.pcmPrev;
+      const n = samples.length;
+      const at = (i) => (i === 0 ? prev : samples[i - 1]) / 32768;  // 0 = carried
+      const out = [];
+      let p = this.pcmPos;
+      while (p < n) {
+        const i = Math.floor(p);
+        const frac = p - i;
+        out.push(at(i) * (1 - frac) + at(i + 1) * frac);
+        p += ratio;
+      }
+      this.pcmPrev = samples[n - 1];
+      this.pcmPos = Math.max(0, p - n);
+      return out;
+    }
+
     /** Schedule one chunk after the last — gapless, in arrival order. */
     schedulePcm(bytes, generation) {
       if (generation !== this.pcmGeneration) return;  // decoded before a barge-in
-      const Ctx = window.AudioContext || window.webkitAudioContext;
-      if (!Ctx) return;  // no playback surface — the transcript still reads
       if (!this.pcmContext) {
-        this.pcmContext = new Ctx();
+        this.pcmContext = makePcmContext();
+        if (!this.pcmContext) return;  // no playback surface — transcript still reads
         this.pcmNextTime = 0;
       }
       const ctx = this.pcmContext;
       const samples = new Int16Array(bytes.buffer, bytes.byteOffset, bytes.length / 2);
-      const buffer = ctx.createBuffer(1, samples.length, 24000);
-      const channel = buffer.getChannelData(0);
-      for (let i = 0; i < samples.length; i++) channel[i] = samples[i] / 32768;
+      if (!samples.length) return;
+      let buffer;
+      if (ctx.sampleRate === PCM_RATE) {
+        // The common path: the context took the PCM's own rate, so the
+        // browser resamples nothing and no seam can drift.
+        buffer = pcmBuffer(ctx, samples, PCM_RATE, 32768);
+      } else {
+        const resampled = this.resampleToContext(samples, ctx.sampleRate);
+        if (!resampled.length) return;
+        buffer = pcmBuffer(ctx, resampled, ctx.sampleRate, 1);
+      }
       const source = ctx.createBufferSource();
       source.buffer = buffer;
       source.connect(ctx.destination);

--- a/tests/test_dashboard_js.py
+++ b/tests/test_dashboard_js.py
@@ -110,7 +110,13 @@ const scheduled = [];   // AudioBufferSourceNodes started on the fake context
 const stopped = [];     // sources stop()ed (barge-in / teardown)
 
 class FakeAudioContext {
-  constructor() { this.currentTime = 0; this.destination = {}; }
+  // Honours a requested sampleRate, like Chrome and Edge do. The transport
+  // asks for the PCM's own 24kHz so the browser resamples nothing.
+  constructor(options) {
+    this.sampleRate = (options && options.sampleRate) || 48000;
+    this.currentTime = 0;
+    this.destination = {};
+  }
   createBuffer(channels, length, sampleRate) {
     if (channels !== 1 || sampleRate !== 24000) throw new Error("wrong PCM shape");
     const data = new Float32Array(length);
@@ -163,10 +169,14 @@ const window = {
   clearTimeout,
   AudioContext: FakeAudioContext,
 };
+// An HTTP/2 page: the transport is allowed to stream its request body, which
+// is the path this test exercises. The HTTP/1.1 fallback has its own test.
 const context = {
   window, setTimeout, clearTimeout, AbortController, ReadableStream,
   TextDecoder, TextEncoder, Uint8Array, Int16Array, Float32Array, JSON, console,
-  fetch: fetchStub, Promise,
+  fetch: fetchStub, Promise, Math,
+  performance: { getEntriesByType: () => [{ nextHopProtocol: "h2" }] },
+  Request: class { constructor() {} },
 };
 vm.runInNewContext(source, context, { filename: "index.js" });
 const Transport = window.__HERMES_TALK_TEST__.TalkTransport;
@@ -253,6 +263,466 @@ const respond = (pcmChunks) => {
   if (fetches.length !== 2) throw new Error("native mode dialed the cascade relay");
   process.exit(0);
 })().catch((error) => { console.error(error); process.exit(1); });
+"""
+    completed = run(
+        ["node", "-e", script, str(DASHBOARD_JS)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=NODE_TIMEOUT_S,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_dashboard_buffers_the_answer_when_the_browser_cannot_stream_the_upload():
+    """HTTP/1.1: audio still arrives, and the failure is never silent.
+
+    Chrome only sends a streaming request body over HTTP/2 or HTTP/3. On a
+    plain HTTP/1.1 origin — which a local dashboard almost always is — the
+    `duplex: "half"` fetch rejects outright, and the relay's own `.catch()`
+    swallowed it: text captioned fine, no audio ever played, and zero
+    requests reached the server. The transport must notice it cannot stream
+    and post the whole answer at `done` instead.
+    """
+
+    script = r"""
+const fs = require("fs");
+const vm = require("vm");
+const source = fs.readFileSync(process.argv[1], "utf8");
+const fetches = [];
+const scheduled = [];
+const errors = [];
+
+class FakeAudioContext {
+  constructor(options) {
+    this.sampleRate = (options && options.sampleRate) || 48000;
+    this.currentTime = 0;
+    this.destination = {};
+  }
+  createBuffer(channels, length, sampleRate) {
+    const data = new Float32Array(length);
+    return { duration: length / sampleRate, getChannelData: (i) => data };
+  }
+  createBufferSource() {
+    return {
+      buffer: null, startedAt: -1, connect() {},
+      start(at) { this.startedAt = at; scheduled.push(this); },
+      stop() {},
+    };
+  }
+  close() { return Promise.resolve(); }
+}
+
+const pendingResponses = [];
+const fetchStub = (url, opts) => {
+  // A streaming body on HTTP/1.1 is exactly what the browser refuses. If the
+  // transport ever tries it here, that IS the bug — so fail the way Chrome
+  // does rather than quietly accepting it.
+  if (opts.duplex === "half") {
+    return Promise.reject(new TypeError("Failed to fetch"));
+  }
+  fetches.push({ url, opts, body: opts.body });
+  return new Promise((resolve) => pendingResponses.push(resolve));
+};
+
+const window = {
+  __HERMES_TALK_TEST_HOOK__: true,
+  __HERMES_PLUGINS__: { register() {} },
+  __HERMES_PLUGIN_SDK__: {
+    React: { createElement() {} },
+    hooks: { useState() {}, useEffect() {}, useRef() {}, useCallback() {} },
+    components: {},
+  },
+  sessionStorage: { getItem() { return ""; } },
+  setTimeout,
+  clearTimeout,
+  AudioContext: FakeAudioContext,
+};
+// An HTTP/1.1 page — the local-dashboard default.
+const context = {
+  window, setTimeout, clearTimeout, AbortController, ReadableStream,
+  TextDecoder, TextEncoder, Uint8Array, Int16Array, Float32Array, JSON, console,
+  fetch: fetchStub, Promise, Math,
+  performance: { getEntriesByType: () => [{ nextHopProtocol: "http/1.1" }] },
+  Request: class { constructor() {} },
+};
+vm.runInNewContext(source, context, { filename: "index.js" });
+const Transport = window.__HERMES_TALK_TEST__.TalkTransport;
+const waitFor = async (predicate, timeoutMs = 1000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("timed out waiting for cascade transport");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+};
+(async () => {
+  const transport = new Transport(
+    { voiceMode: "cascade" },
+    { onStatus() {}, onError: (m) => errors.push(m), onTranscript() {} },
+  );
+  transport.channel = { readyState: "open", send() {} };
+  const send = (event) => transport.handleEvent(JSON.stringify(event));
+
+  send({ type: "response.created", response: { id: "r1" } });
+  send({ type: "response.output_text.delta", delta: "Hello " });
+  send({ type: "response.output_text.delta", delta: "dashboard. " });
+  // Nothing posts while the text is still arriving: there is no stream to
+  // post it into, so the answer is held until it is complete.
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  if (fetches.length !== 0) throw new Error("posted before the answer was done");
+
+  send({ type: "response.output_text.done", text: "Hello dashboard." });
+  await waitFor(() => fetches.length === 1);
+  const post = fetches[0];
+  if (post.url !== "/api/plugins/hermes-talk/cascade-tts") {
+    throw new Error("wrong relay url: " + post.url);
+  }
+  if ("duplex" in post.opts) throw new Error("buffered post must not claim duplex");
+  const body = new TextDecoder().decode(post.body);
+  const lines = body.split("\n").filter((l) => l).map((l) => JSON.parse(l));
+  if (JSON.stringify(lines) !== JSON.stringify([
+    { delta: "Hello " }, { delta: "dashboard. " }, { done: "Hello dashboard." },
+  ])) throw new Error("wrong buffered NDJSON: " + body);
+
+  // And the PCM still plays.
+  const pcm = new Uint8Array(960);
+  const stream = new ReadableStream({
+    start(controller) { controller.enqueue(pcm); controller.close(); },
+  });
+  pendingResponses.shift()({ ok: true, body: stream });
+  await waitFor(() => scheduled.length === 1);
+
+  if (errors.length !== 0) {
+    throw new Error("a working buffered fallback must not report failure: " + errors);
+  }
+  process.exit(0);
+})().catch((error) => { console.error(error); process.exit(1); });
+"""
+    completed = run(
+        ["node", "-e", script, str(DASHBOARD_JS)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=NODE_TIMEOUT_S,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_dashboard_reports_a_relay_failure_instead_of_swallowing_it():
+    """"Silently" was half the bug: a dead relay must say so, once."""
+
+    script = r"""
+const fs = require("fs");
+const vm = require("vm");
+const source = fs.readFileSync(process.argv[1], "utf8");
+const errors = [];
+const warned = [];
+
+class FakeAudioContext {
+  constructor(options) {
+    this.sampleRate = (options && options.sampleRate) || 48000;
+    this.currentTime = 0;
+    this.destination = {};
+  }
+  createBuffer(c, length, rate) {
+    const data = new Float32Array(length);
+    return { duration: length / rate, getChannelData: () => data };
+  }
+  createBufferSource() {
+    return { buffer: null, connect() {}, start() {}, stop() {} };
+  }
+  close() { return Promise.resolve(); }
+}
+
+const window = {
+  __HERMES_TALK_TEST_HOOK__: true,
+  __HERMES_PLUGINS__: { register() {} },
+  __HERMES_PLUGIN_SDK__: {
+    React: { createElement() {} },
+    hooks: { useState() {}, useEffect() {}, useRef() {}, useCallback() {} },
+    components: {},
+  },
+  sessionStorage: { getItem() { return ""; } },
+  setTimeout, clearTimeout,
+  AudioContext: FakeAudioContext,
+};
+const context = {
+  window, setTimeout, clearTimeout, AbortController, ReadableStream,
+  TextDecoder, TextEncoder, Uint8Array, Int16Array, Float32Array, JSON,
+  console: { warn: (m) => warned.push(m), error: () => {}, log: () => {} },
+  fetch: () => Promise.reject(new TypeError("Failed to fetch")),
+  Promise, Math,
+  performance: { getEntriesByType: () => [{ nextHopProtocol: "h2" }] },
+  Request: class { constructor() {} },
+};
+vm.runInNewContext(source, context, { filename: "index.js" });
+const Transport = window.__HERMES_TALK_TEST__.TalkTransport;
+const waitFor = async (predicate, timeoutMs = 1000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+};
+(async () => {
+  const transport = new Transport(
+    { voiceMode: "cascade" },
+    { onStatus() {}, onError: (m) => errors.push(m), onTranscript() {} },
+  );
+  transport.channel = { readyState: "open", send() {} };
+  const send = (event) => transport.handleEvent(JSON.stringify(event));
+
+  send({ type: "response.created", response: { id: "r1" } });
+  send({ type: "response.output_text.delta", delta: "First answer. " });
+  send({ type: "response.output_text.done", text: "First answer." });
+  await waitFor(() => errors.length === 1);
+  if (!/text-only/.test(errors[0])) throw new Error("unhelpful receipt: " + errors[0]);
+  if (warned.length !== 1) throw new Error("expected exactly one console warning");
+
+  // A second failing answer must not spam: one receipt per session.
+  send({ type: "response.created", response: { id: "r2" } });
+  send({ type: "response.output_text.delta", delta: "Second answer. " });
+  send({ type: "response.output_text.done", text: "Second answer." });
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  if (errors.length !== 1) throw new Error("relay failure reported twice: " + errors.length);
+
+  // A deliberate barge-in abort is NOT a failure and must stay quiet.
+  const quiet = new Transport(
+    { voiceMode: "cascade" },
+    { onStatus() {}, onError: (m) => errors.push(m), onTranscript() {} },
+  );
+  quiet.channel = { readyState: "open", send() {} };
+  quiet.handleEvent(JSON.stringify({ type: "response.created", response: { id: "r3" } }));
+  quiet.handleEvent(JSON.stringify({
+    type: "response.output_text.delta", delta: "Interrupted answer. ",
+  }));
+  quiet.handleEvent(JSON.stringify({ type: "input_audio_buffer.speech_started" }));
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  if (errors.length !== 1) throw new Error("a barge-in was reported as a failure");
+  process.exit(0);
+})().catch((error) => { console.error(error); process.exit(1); });
+"""
+    completed = run(
+        ["node", "-e", script, str(DASHBOARD_JS)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=NODE_TIMEOUT_S,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_dashboard_pcm_context_asks_for_the_streams_own_sample_rate():
+    """No resampling means no seam to drift.
+
+    Web Audio resamples every AudioBuffer independently, so at the browser
+    default (48kHz on Windows) two chunks resampled in isolation do not line
+    up where they meet — an audible tick at every chunk boundary while the
+    PCM leaving the server is provably clean. Asking for the PCM's own rate
+    avoids the question entirely.
+    """
+
+    script = r"""
+const fs = require("fs");
+const vm = require("vm");
+const source = fs.readFileSync(process.argv[1], "utf8");
+const requested = [];
+const buffers = [];
+
+class FakeAudioContext {
+  constructor(options) {
+    requested.push(options ? options.sampleRate : undefined);
+    this.sampleRate = (options && options.sampleRate) || 48000;
+    this.currentTime = 0;
+    this.destination = {};
+  }
+  createBuffer(channels, length, sampleRate) {
+    const data = new Float32Array(length);
+    const buffer = {
+      duration: length / sampleRate, sampleRate, getChannelData: () => data,
+    };
+    buffers.push(buffer);
+    return buffer;
+  }
+  createBufferSource() {
+    return { buffer: null, connect() {}, start() {}, stop() {} };
+  }
+  close() { return Promise.resolve(); }
+}
+
+const window = {
+  __HERMES_TALK_TEST_HOOK__: true,
+  __HERMES_PLUGINS__: { register() {} },
+  __HERMES_PLUGIN_SDK__: {
+    React: { createElement() {} },
+    hooks: { useState() {}, useEffect() {}, useRef() {}, useCallback() {} },
+    components: {},
+  },
+  sessionStorage: { getItem() { return ""; } },
+  setTimeout, clearTimeout,
+  AudioContext: FakeAudioContext,
+};
+const context = {
+  window, setTimeout, clearTimeout, AbortController, ReadableStream,
+  TextDecoder, TextEncoder, Uint8Array, Int16Array, Float32Array, JSON, console,
+  fetch: () => new Promise(() => {}), Promise, Math,
+  performance: { getEntriesByType: () => [{ nextHopProtocol: "h2" }] },
+  Request: class { constructor() {} },
+};
+vm.runInNewContext(source, context, { filename: "index.js" });
+const Transport = window.__HERMES_TALK_TEST__.TalkTransport;
+const transport = new Transport(
+  { voiceMode: "cascade" },
+  { onStatus() {}, onError() {}, onTranscript() {} },
+);
+transport.schedulePcm(new Uint8Array(960), transport.pcmGeneration);
+
+if (requested[0] !== 24000) {
+  throw new Error("context was not asked for the PCM rate: " + requested[0]);
+}
+if (buffers.length !== 1 || buffers[0].sampleRate !== 24000) {
+  throw new Error("buffer was not created at the PCM rate");
+}
+if (transport.pcmContext.sampleRate !== 24000) {
+  throw new Error("context is not running at the PCM rate");
+}
+process.exit(0);
+"""
+    completed = run(
+        ["node", "-e", script, str(DASHBOARD_JS)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=NODE_TIMEOUT_S,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_dashboard_resampler_is_continuous_across_chunk_seams():
+    """The fallback for browsers that refuse a 24kHz context.
+
+    Measured on a 440 Hz tone split into 40 uneven chunks: the per-chunk
+    path jumped 0.105 between adjacent output samples where a smooth signal
+    steps 0.035. A 3x step at a seam is the tick. Carrying the previous
+    chunk's last sample and the fractional read position is what removes it
+    — interpolating each chunk in isolation is the original bug in a
+    different costume, so this drives BOTH paths and compares them.
+    """
+
+    script = r"""
+const fs = require("fs");
+const vm = require("vm");
+const source = fs.readFileSync(process.argv[1], "utf8");
+
+class FakeAudioContext {
+  constructor() {
+    // Refuse the requested rate, like the browsers this fallback exists for.
+    this.sampleRate = 48000;
+    this.currentTime = 0;
+    this.destination = {};
+  }
+  createBuffer(channels, length, sampleRate) {
+    const data = new Float32Array(length);
+    return { duration: length / sampleRate, sampleRate, getChannelData: () => data };
+  }
+  createBufferSource() {
+    return { buffer: null, connect() {}, start() {}, stop() {} };
+  }
+  close() { return Promise.resolve(); }
+}
+
+const window = {
+  __HERMES_TALK_TEST_HOOK__: true,
+  __HERMES_PLUGINS__: { register() {} },
+  __HERMES_PLUGIN_SDK__: {
+    React: { createElement() {} },
+    hooks: { useState() {}, useEffect() {}, useRef() {}, useCallback() {} },
+    components: {},
+  },
+  sessionStorage: { getItem() { return ""; } },
+  setTimeout, clearTimeout,
+  AudioContext: FakeAudioContext,
+};
+const context = {
+  window, setTimeout, clearTimeout, AbortController, ReadableStream,
+  TextDecoder, TextEncoder, Uint8Array, Int16Array, Float32Array, JSON, console,
+  fetch: () => new Promise(() => {}), Promise, Math,
+  performance: { getEntriesByType: () => [{ nextHopProtocol: "h2" }] },
+  Request: class { constructor() {} },
+};
+vm.runInNewContext(source, context, { filename: "index.js" });
+const Transport = window.__HERMES_TALK_TEST__.TalkTransport;
+const make = () => new Transport(
+  { voiceMode: "cascade" },
+  { onStatus() {}, onError() {}, onTranscript() {} },
+);
+
+// A continuous 440 Hz tone at 24kHz, split into 40 UNEVEN chunks.
+const TOTAL = 12000;
+const tone = new Int16Array(TOTAL);
+for (let i = 0; i < TOTAL; i++) {
+  tone[i] = Math.round(Math.sin((2 * Math.PI * 440 * i) / 24000) * 20000);
+}
+const chunks = [];
+let at = 0;
+for (let c = 0; c < 40 && at < TOTAL; c++) {
+  const size = 200 + ((c * 37) % 180);          // uneven on purpose
+  chunks.push(tone.subarray(at, Math.min(at + size, TOTAL)));
+  at += size;
+}
+
+const worstJump = (values) => {
+  let worst = 0;
+  for (let i = 1; i < values.length; i++) {
+    worst = Math.max(worst, Math.abs(values[i] - values[i - 1]));
+  }
+  return worst;
+};
+
+// The IDEAL: one resample of the whole tone, no seams at all.
+const ideal = make().resampleToContext(tone, 48000);
+
+// The FIX: state carried across every chunk.
+const fixed = make();
+let carried = [];
+chunks.forEach((chunk) => {
+  carried = carried.concat(fixed.resampleToContext(chunk, 48000));
+});
+
+// The BUG: each chunk resampled in isolation, state reset every time.
+const naive = make();
+let isolated = [];
+chunks.forEach((chunk) => {
+  naive.pcmPrev = null;
+  naive.pcmPos = 0;
+  isolated = isolated.concat(naive.resampleToContext(chunk, 48000));
+});
+
+const idealJump = worstJump(ideal);
+const fixedJump = worstJump(carried);
+const naiveJump = worstJump(isolated);
+
+// The fix must be indistinguishable from resampling the whole tone at once.
+if (fixedJump > idealJump * 1.05) {
+  throw new Error("state-carrying resampler has a seam: " + fixedJump + " vs " + idealJump);
+}
+// And the isolated path must be visibly worse, or this test proves nothing.
+if (naiveJump < fixedJump * 2) {
+  throw new Error(
+    "per-chunk resampling was expected to be much worse: " +
+    naiveJump + " vs " + fixedJump,
+  );
+}
+// stopPcmPlayback must clear the carry-over, or a barge-in clicks the next answer.
+fixed.stopPcmPlayback();
+if (fixed.pcmPrev !== null || fixed.pcmPos !== 0) {
+  throw new Error("barge-in left stale interpolation state behind");
+}
+process.exit(0);
 """
     completed = run(
         ["node", "-e", script, str(DASHBOARD_JS)],


### PR DESCRIPTION
Two defects in the dashboard cascade lane, both invisible from the server: the PCM leaving the relay is provably clean in each case.

## `dashboard/dist/index.js` is source, not a build artifact

Checked first, because it decides whether this PR is even editing the right file:

- **No build tooling exists in the repo.** `git ls-files` finds no `package.json`, no `tsconfig`, no rollup/vite/esbuild/webpack config, and no `.ts`/`.jsx`/`.mjs` anywhere. The only tracked JS/CSS are `dashboard/dist/index.js` and `dashboard/dist/style.css`.
- **Nothing builds it.** No bundle step in `pyproject.toml`, `MANIFEST.in`, or any CI workflow.
- **The file says so itself**, in its own header: *"Plain IIFE, no build step — same shape as the in-tree kanban and achievements plugins."*
- `dist/` is simply the path `dashboard/manifest.json` points `entry` at.

So `dist` **is** the checked-in source of truth, and this PR edits it directly. There is no source file to fix instead and nothing to rebuild.

## Defect 1 — a tick at every chunk seam

The page opened its `AudioContext` at the browser default (48kHz on Windows) and then handed it 24kHz buffers. Web Audio resamples each `AudioBuffer` **independently**, so two chunks resampled in isolation do not line up where they meet — every chunk boundary is a discontinuity.

The context is now requested at the PCM's own 24kHz, so nothing is resampled at all. Browsers that refuse the rate fall back to a resampler that carries the previous chunk's last sample and its fractional read position across chunks.

**Barge-in clears that carry-over** alongside the existing generation bump. Without it, an interrupted sentence's interpolation state splices onto the start of the next answer — the same seam click, one barge-in later.

## Defect 2 — a silent mute on HTTP/1.1

The relay posted its request body as a `ReadableStream` with `duplex: "half"`. Chrome only sends a streaming request body over HTTP/2 or HTTP/3; on a plain HTTP/1.1 origin — which a local dashboard almost always is — the fetch rejects outright. The `.catch(() => {})` swallowed it by design, so the model's text captioned normally, **no audio ever played, no error appeared anywhere, and zero requests reached `/cascade-tts`.**

The page now gates on `performance.getEntriesByType("navigation")[0].nextHopProtocol` and posts the whole answer once its text is done when it cannot stream. That costs sentence pipelining — the first sentence no longer plays while the model writes the second — but it produces audio instead of silence.

And since **"silently" was half the bug**, a relay that fails for a real reason now reports once, through the tab's own `onError` surface and the console. A deliberate abort (barge-in, hang-up) stays quiet, because that is not a failure. One receipt per session, so a broken relay does not spam every answer.

## What I verified independently

- **Both defect sites are exactly as described** — `duplex: "half"` at `:356`, `new Ctx()` at `:443`, `createBuffer(..., 24000)` at `:448`. Line numbers still line up with the writeup.
- **One small correction:** the patch note says to "replace both `new Ctx()` call sites." There is only **one** in this tree (`grep -c` → 1); the other `pcmContext` touch at `:227` is the teardown `close()`. The port it was written against must have had two.
- **The detection is computed on first use, not at load** — a change from the patch's module-scope constant. The navigation timing entry is not necessarily populated while the IIFE is still evaluating, so a load-time read can silently latch `false` and permanently disable streaming on a page that supports it.
- **`git diff --stat` == `git diff --ignore-all-space --stat`.** This initially failed: two lines had moved into the new sample-rate branch and so differed only in indentation. Rather than leave a whitespace-only diff, I pulled the shared buffer fill into one `pcmBuffer()` helper that both paths call — which removes the duplicated fill loop too. (A `cat`-append had also written the test file with LF endings; normalized back to CRLF to match the repo.)

## Tests — `tests/test_dashboard_js.py`, the existing `node -e` harness

- `test_dashboard_pcm_context_asks_for_the_streams_own_sample_rate` — the context is *asked* for 24000, the buffer is created at 24000, and the live context reports 24000
- `test_dashboard_resampler_is_continuous_across_chunk_seams` — a 440 Hz tone at 24kHz split into 40 uneven chunks, run through **three** paths and compared: resampling the whole tone at once (the ideal), the state-carrying resampler, and the per-chunk path with state reset each time. Asserts the fix is within 5% of the ideal's worst adjacent-sample jump **and** that the isolated path is at least 2x worse — so the test fails if the carry-over stops mattering, rather than passing vacuously. Also asserts `stopPcmPlayback()` clears `pcmPrev`/`pcmPos`
- `test_dashboard_buffers_the_answer_when_the_browser_cannot_stream_the_upload` — an HTTP/1.1 page whose `fetch` **rejects any `duplex: "half"` request**, the way Chrome does. Asserts nothing posts while text is still arriving, that the single post at `done` carries the full NDJSON and no `duplex` key, that the PCM still plays, and that a working fallback reports no error
- `test_dashboard_reports_a_relay_failure_instead_of_swallowing_it` — one receipt on the first failure, **not** a second on the next answer, and **silence** for a barge-in abort
- the existing cascade test now supplies an h2 navigation entry so it keeps exercising the streaming path, and its `FakeAudioContext` honours a requested `sampleRate` like Chrome does

**I confirmed all of these bite.** Reverting both fixes (`new Ctx()` and `if (false)`) fails exactly three — `timed out waiting for cascade transport`, `Custom voice unavailable — answers stay text-only`, and `context was not asked for the PCM rate: undefined` — and passes the rest.

## Gates

`uv run --extra dev pytest -q` → **1655 passed, 40 skipped, 5 xfailed, 0 failed**. `ruff check .` clean on 0.16.5. As on #117 and #118, the 12 known-baseline failures (#93) did not reproduce in a fresh `uv` venv.

— SmokeDev
