### PR TITLE
fix(bridge): send room approval request_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ named rather than smoothed.
   dependency of its own.
 
 ### Fixed
+- Room-scoped spoken approvals now return the approval event's exact
+  `request_id` under the field name required by the Hermes run API. They no
+  longer fail with HTTP 400 `approval_request_required` while a pending action
+  waits for an answer.
 - The dashboard cascade relay no longer deadlocks on the servers Hermes
   actually runs on. `POST /api/plugins/hermes-talk/cascade-tts` returned
   HTTP 200 and then zero bytes of PCM, followed by a `ClientDisconnect` in
@@ -574,8 +578,9 @@ regression tests:
   single-shot upstream (a reconnect 404s); when a run's watcher dies, the
   poll loop reconciles one conservative prompt (`once`/`deny`) instead of
   letting the approval sit silent until the host's 300s auto-deny. Resolves
-  also carry the request's own id (`approvalId`) for exact routing on hosts
-  that support it.
+  also carry the request's own id for exact routing; this release sent it as
+  `approvalId`, while current Hermes requires `request_id` (corrected under
+  [Unreleased](#unreleased)).
 - **Stale sidecars are quarantined by attach generation.** A delegated run
   outliving its session can no longer speak its approval into — or be
   resolved from — the next session.

--- a/talk_apiserver.py
+++ b/talk_apiserver.py
@@ -621,7 +621,7 @@ def respond_to_approval(
     :class:`TalkApiServerError` with speakable text on any other failure.
 
     ``approval_id`` is the request's own id from the ``approval.request``
-    event: a host that supports exact routing (the field is ``approvalId``
+    event: a host that supports exact routing (the field is ``request_id``
     on the wire) resolves THAT request instead of FIFO-popping the oldest;
     hosts that predate the field ignore it.
 
@@ -632,7 +632,7 @@ def respond_to_approval(
 
     body: dict = {"choice": choice}
     if approval_id:
-        body["approvalId"] = approval_id
+        body["request_id"] = approval_id
     try:
         response = httpx.post(
             f"{talk_config.api_server_url()}{RUNS_PATH}/{run_id}/approval",

--- a/talk_approvals.py
+++ b/talk_approvals.py
@@ -119,7 +119,7 @@ class _PendingApproval:
     request_text: str
     choices: tuple[str, ...]
     #: The host's approval request id (always present on real SSE events).
-    #: Sent back as ``approvalId`` so a host that supports exact routing
+    #: Sent back as ``request_id`` so a host that supports exact routing
     #: resolves THIS request instead of FIFO-popping the oldest; ``None``
     #: for reconciled prompts, where the id was lost with the stream.
     request_id: str | None = None

--- a/tests/test_approval_bridge.py
+++ b/tests/test_approval_bridge.py
@@ -484,7 +484,7 @@ def test_reconcile_stays_out_while_the_watcher_lives(monkeypatch):
 
 
 def test_resolve_routes_the_exact_request_when_the_event_carried_one(monkeypatch):
-    """Real SSE events always carry request_id; sending it back as approvalId
+    """Real SSE events always carry request_id; sending it back as request_id
     lets a host with exact routing resolve THIS request instead of
     FIFO-popping the oldest. Hosts that predate the field ignore it."""
 
@@ -822,7 +822,7 @@ def test_respond_to_approval_posts_the_choice(monkeypatch):
     assert seen["headers"] == {"Authorization": "Bearer k-123"}
 
 
-def test_respond_to_approval_carries_the_approval_id_when_given(monkeypatch):
+def test_respond_to_approval_carries_the_request_id_when_given(monkeypatch):
     seen = {}
 
     class Response:
@@ -841,7 +841,7 @@ def test_respond_to_approval_carries_the_approval_id_when_given(monkeypatch):
 
     talk_apiserver.respond_to_approval("run_9", "once", approval_id="req-77")
 
-    assert seen["json"] == {"choice": "once", "approvalId": "req-77"}
+    assert seen["json"] == {"choice": "once", "request_id": "req-77"}
 
 
 def test_respond_to_approval_409_is_the_gone_verdict(monkeypatch):


### PR DESCRIPTION
## What and why

Room-scoped approvals require the exact `request_id`, but `respond_to_approval()` sends that identifier as `approvalId`. Current Hermes therefore rejects spoken approval responses with HTTP 400 `approval_request_required`, leaving the pending action blocked.

Send the approval event identifier under the Hermes run API's `request_id` field and update the surrounding contract documentation and regression expectation.

Fixes #120

## How to test

The regression test was changed first and failed on `main` because the emitted payload still contained `approvalId`:

```text
AssertionError: {'choice': 'once', 'approvalId': 'req-77'} != {'choice': 'once', 'request_id': 'req-77'}
```

With this fix:

```bash
env -u TALK_PREFER_CODEX_OAUTH uv run --extra dev pytest -q tests/test_approval_bridge.py::test_respond_to_approval_carries_the_request_id_when_given
env -u TALK_PREFER_CODEX_OAUTH uv run --extra dev pytest -q
uv run --extra dev ruff check .
```

```text
1 passed
1671 passed, 49 skipped, 5 xfailed
All checks passed!
```

An integration check using the real Talk request builder and current Hermes approval handler also returned HTTP 200 with `resolved: 1` for the room-scoped request.

## Platforms

- [ ] Windows
- [x] Linux
- [ ] macOS

## Live receipt

Not required: this changes the local Hermes run-approval API payload, not a provider lane, credential-resolution path, or delegation implementation. The Talk-to-Hermes handler integration was exercised locally with an inert pending approval and temporary `HERMES_HOME`.

## Checklist

- [x] One logical change; tests ride with it, not behind it
- [x] `pytest -q` and `ruff check .` pass locally on the pinned ruff
- [x] Commits follow Conventional Commits with a hermes-talk scope
- [x] No auth-store writes outside the documented Codex refresh; tokens reach only the provider's own host
- [x] Nothing secret in logs, receipts, spoken sentences, or test fixtures
- [x] Every spoken sentence I added or changed claims only what an artifact proves
- [x] Docs updated where behaviour changed — code contract comments updated; user-facing operating and voice docs are N/A
- [x] `CHANGELOG.md` `[Unreleased]` entry added
