### PR TITLE
chore(release): 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ named rather than smoothed.
 
 ## [Unreleased]
 
+## [0.17.1] — 2026-09-07
+
+Seven fixes and one knob. Spoken approvals in a Discord room now reach the
+host under the field name it actually reads, so they stop failing with HTTP
+400 (the first outside fix to a live production lane, by @danclaw93). The
+cascade voice stops forcing a generation per chunk and lets ElevenLabs buffer
+the turn, the dashboard relay no longer deadlocks on the servers Hermes
+actually runs, cloned-voice playback is gapless, and a browser that cannot
+stream says so instead of going mute. `TALK_CASCADE_SPEED` sets the delivery
+pace.
+
 ### Added
 - `TALK_CASCADE_SPEED` — delivery pace for the cascade voice, `0.7`–`1.2`
   (`1.0` is normal), resolved at call time so an operator's edit lands on
@@ -36,7 +47,9 @@ named rather than smoothed.
 - Room-scoped spoken approvals now return the approval event's exact
   `request_id` under the field name required by the Hermes run API. They no
   longer fail with HTTP 400 `approval_request_required` while a pending action
-  waits for an answer.
+  waits for an answer. Fixed by
+  [@danclaw93](https://github.com/danclaw93), the first outside fix to a
+  live production lane.
 - The dashboard cascade relay no longer deadlocks on the servers Hermes
   actually runs on. `POST /api/plugins/hermes-talk/cascade-tts` returned
   HTTP 200 and then zero bytes of PCM, followed by a `ClientDisconnect` in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,8 @@ uv run --extra dev pytest -q
 uv run --extra dev ruff check .
 ```
 
-Either way you get the pinned `ruff==0.16.5` from the dev extra — the pin is
-load-bearing, see below.
+Either way you get the ruff version pinned in the dev extra (see
+`pyproject.toml`). The pin is load-bearing, see below.
 
 **Why `--extra dev` on every `uv run`:** pytest and the pinned ruff live in
 the `dev` extra, not in the dependencies. `uv run` only guarantees the base

--- a/README.md
+++ b/README.md
@@ -894,7 +894,11 @@ it does not claim that hot lifecycle support already exists here.
 
 ### Contributors
 
-[@kvnloo](https://github.com/kvnloo) — PulseAudio WebRTC echo cancellation
+[@danclaw93](https://github.com/danclaw93): room-scoped spoken approvals send
+the `request_id` the Hermes run API reads, so they stop failing with HTTP 400
+(0.17.1).
+
+[@kvnloo](https://github.com/kvnloo): PulseAudio WebRTC echo cancellation
 on Linux, and the fix that stopped quiet words being clipped during
 playback ([#81](https://github.com/TheSmokeDev/hermes-talk/pull/81));
 semantic turn-detection controls across the three lanes

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Talk",
   "description": "Realtime speech-to-speech voice in the browser — duplex audio over WebRTC, live tool calls, background runs spoken when they land.",
   "icon": "MessageSquare",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "tab": { "path": "/talk", "position": "end" },
   "entry": "dist/index.js",
   "css": "dist/style.css",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-talk
-version: 0.17.0
+version: 0.17.1
 manifest_version: 1
 kind: standalone
 description: "OpenAI Realtime speech-to-speech voice for Hermes: duplex talk with live tool calling."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-talk"
-version = "0.17.0"
+version = "0.17.1"
 description = "Realtime speech-to-speech voice for Hermes Agent — OpenAI, xAI Grok, or Gemini Live — duplex talk with live tool calling."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts `[Unreleased]` to `[0.17.1]` and bumps the three version surfaces the hygiene test pins together.

Seven fixes and one knob: spoken approvals in a Discord room send the `request_id` the host reads (#121, first outside fix to a live lane, by @danclaw93), cascade relay deadlock (#118), gapless cloned-voice playback and an honest HTTP/1.1 failure (#119), no forced generation per chunk plus `enable_ssml_parsing` and `TALK_CASCADE_SPEED` (#117), ruff 0.16.6 (#124).

Also credits @danclaw93 in CHANGELOG + README Contributors, and makes CONTRIBUTING's ruff line version-agnostic.

Hygiene test 3/3, ruff clean, full suite 1680 passed / 0 failed, no line-ending flips.

Gemini #122 is not in this release; it ships as 0.17.2 once its patch passes review.

SmokeDev