### PR TITLE
fix(gemini): keep diagnostics and setup on the Gemini path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ named rather than smoothed.
 
 ## [Unreleased]
 
+### Fixed
+- Gemini `doctor`, `check`, and `setup` now follow Gemini's own credential,
+  model, and voice settings. A Gemini-only install no longer fails an
+  unrelated OpenAI auth check or gets told to run `codex login`. Human
+  reports and redacted support bundles carry the Gemini receipt without
+  requiring Codex/xAI fields. Static diagnostics remain offline: configured
+  keys and models are not a claim that Google accepted a live connection.
+
 ## [0.17.1] — 2026-09-07
 
 Seven fixes and one knob. Spoken approvals in a Discord room now reach the

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -249,6 +249,23 @@ all of them. Canonical source: `talk_config.py` and `talk_auth.py`.
 | `TALK_GEMINI_VOICE` | `Puck` | **Fail-closed** against the Gemini Live voice list: `Puck`, `Charon`, `Kore`, `Fenrir`, `Aoede`. **Case-sensitive** — the knob never case-folds, because the wire does not. |
 | `TALK_GEMINI_API_KEY` / `GEMINI_API_KEY` | unset | Gemini key for the Gemini lane, Talk-scoped first (free-tier keys work). Set-but-blank is a hard refusal, same rule as the OpenAI keys. The key rides the WebSocket URL query on this lane, so the URL is treated as a secret: assembled at connect, never logged, scrubbed out of transport errors. The Live protocol has no client cancel/truncate command — barge-in degrades to local playback handling with a logged receipt. |
 
+### Gemini diagnostics and setup
+
+With `TALK_PROVIDER=gemini`, `hermes talk doctor` checks Gemini's key,
+`TALK_GEMINI_MODEL`, and `TALK_GEMINI_VOICE`. It does not require OpenAI
+credentials or a Codex login. Key precedence matches the session:
+`TALK_GEMINI_API_KEY` before `GEMINI_API_KEY`, with an explicitly blank
+override refusing rather than falling through. `hermes talk setup` repairs
+the Gemini settings and asks for confirmation before each write.
+
+Doctor and support bundles report configuration only; they do not connect
+to Google or verify that a key/model is accepted. Custom Gemini models
+produce a warning about unverified availability. Use
+`hermes talk check --provider gemini --no-run` for a bounded live provider
+turn without a delegated Hermes run. That command uses the real provider
+and may consume API quota. OpenAI/Grok auth behavior and Gemini's existing
+surface restrictions are unchanged.
+
 ### Custom voice (cascade lane)
 
 | Variable | Default | Effect / failure mode |

--- a/talk_diagnostics.py
+++ b/talk_diagnostics.py
@@ -94,6 +94,10 @@ _MAX_TEXT_CHARS = 300
 # A dict is a nested allowlist. Anything absent is dropped.
 
 _AUTH_DETAILS = {
+    "provider": "token",
+    "source": "token",
+    "keys": "token_map",
+    "validation_scope": "token",
     "configured": "bool",
     "winning_lane": "token",
     "preference": "token",
@@ -136,13 +140,14 @@ CHECK_DETAILS_ALLOWLIST: dict[str, dict[str, Any]] = {
     },
     "auth": _AUTH_DETAILS,
     "model": {
+        "provider": "token",
         "model": "token",
         "source": "token",
         "compatibility": "token",
         "policy_version": "token",
         "validation_scope": "token",
     },
-    "voice": {"voice": "token", "source": "token", "valid": "bool"},
+    "voice": {"provider": "token", "voice": "token", "source": "token", "valid": "bool"},
     "cascade": {
         "voice_mode": "token",
         "source": "token",

--- a/talk_doctor.py
+++ b/talk_doctor.py
@@ -400,11 +400,58 @@ def _grok_auth_check() -> dict[str, Any]:
     return _check("auth", "pass", summary, details)
 
 
-def _auth_check() -> dict[str, Any]:
+def _selected_provider() -> str | None:
     try:
-        provider = talk_config.talk_provider()
+        return talk_config.talk_provider()
     except talk_config.TalkConfigError:
-        provider = None
+        return None  # The provider check already reports this configuration error.
+
+
+def _gemini_auth_check() -> dict[str, Any]:
+    """Use session-time key precedence without network access or foreign auth stores."""
+
+    scoped = os.environ.get("TALK_GEMINI_API_KEY")
+    shared = os.environ.get("GEMINI_API_KEY")
+    source = (
+        "TALK_GEMINI_API_KEY" if scoped is not None
+        else "GEMINI_API_KEY" if shared is not None else None
+    )
+    details = {
+        "provider": "gemini",
+        "source": source,
+        "configured": False,
+        "winning_lane": None,
+        "keys": {"scoped": _key_presence(scoped), "shared": _key_presence(shared)},
+        "blocked_by": None,
+        "validation_scope": "presence-only",
+    }
+    try:
+        # Discard the value: only the resolver's success belongs in this receipt.
+        talk_config.resolve_gemini_key()
+    except talk_config.TalkConfigError:
+        if source is None:
+            details["blocked_by"] = "missing-key"
+            summary = "no Gemini API key is configured"
+        else:
+            details["blocked_by"] = "blank-talk-key" if scoped is not None else "blank-gemini-key"
+            summary = f"{source} is set but blank and blocks Gemini authentication"
+        return _check(
+            "auth", "fail", summary, details,
+            ("Set TALK_GEMINI_API_KEY or GEMINI_API_KEY; replace or unset a blank override.",),
+        )
+    details["configured"] = True
+    details["winning_lane"] = (
+        talk_auth.SOURCE_CONFIGURED if scoped is not None else talk_auth.SOURCE_ENV
+    )
+    return _check(
+        "auth", "pass", "Gemini API key is configured; live authentication was not checked", details
+    )
+
+
+def _auth_check() -> dict[str, Any]:
+    provider = _selected_provider()
+    if provider == "gemini":
+        return _gemini_auth_check()
     if provider == "grok":
         return _grok_auth_check()
     receipt = talk_auth.auth_diagnostic()
@@ -476,6 +523,24 @@ def _auth_check() -> dict[str, Any]:
 
 
 def _model_check() -> dict[str, Any]:
+    if _selected_provider() == "gemini":
+        model = talk_config.talk_gemini_model()
+        known_default = model == talk_config.DEFAULT_GEMINI_MODEL
+        return _check(
+            "model",
+            "pass" if known_default else "warn",
+            f"Gemini model {model} is configured; live availability was not checked",
+            {
+                "provider": "gemini",
+                "model": model,
+                "source": (
+                    "TALK_GEMINI_MODEL"
+                    if (os.environ.get("TALK_GEMINI_MODEL") or "").strip() else "default"
+                ),
+                "compatibility": "known-default" if known_default else "unknown",
+                "validation_scope": "configuration-only",
+            },
+        )
     model = talk_config.talk_model()
     source = "TALK_MODEL" if (os.environ.get("TALK_MODEL") or "").strip() else "default"
     compatibility = talk_config.realtime_model_compatibility(model)
@@ -515,6 +580,29 @@ def _model_check() -> dict[str, Any]:
 
 
 def _voice_check() -> dict[str, Any]:
+    if _selected_provider() == "gemini":
+        source = (
+            "TALK_GEMINI_VOICE"
+            if (os.environ.get("TALK_GEMINI_VOICE") or "").strip() else "default"
+        )
+        try:
+            voice = talk_config.talk_gemini_voice()
+        except talk_config.TalkConfigError:
+            return _check(
+                "voice", "fail", "configured Gemini voice is not a built-in Gemini Live voice",
+                {
+                    "provider": "gemini",
+                    "voice": (os.environ.get("TALK_GEMINI_VOICE") or "").strip() or None,
+                    "source": source,
+                    "valid": False,
+                },
+                (f"Choose TALK_GEMINI_VOICE from {', '.join(talk_config.GEMINI_LIVE_VOICES)} "
+                 "(case-sensitive).",),
+            )
+        return _check(
+            "voice", "pass", f"Gemini voice {voice} is valid",
+            {"provider": "gemini", "voice": voice, "source": source, "valid": True},
+        )
     source = "TALK_VOICE" if (os.environ.get("TALK_VOICE") or "").strip() else "default"
     try:
         voice = talk_config.talk_voice()
@@ -863,7 +951,13 @@ def render_human(report: dict[str, Any]) -> str:
     for check in report["checks"]:
         lines.append(f"[{check['status'].upper()}] {check['id']}: {check['summary']}")
         details = check["details"]
-        if check["id"] == "auth":
+        if check["id"] == "auth" and details.get("provider") == "gemini":
+            lines.append(
+                "  receipt: provider=gemini, "
+                f"winner={details.get('winning_lane') or 'none'}, "
+                f"source={details.get('source') or 'none'}, validation=presence-only"
+            )
+        elif check["id"] == "auth":
             if "xai_oauth" in details:
                 oauth = f"xai-oauth={details['xai_oauth']}"
                 # Name the store shape that answered, so a "missing" verdict

--- a/talk_setup.py
+++ b/talk_setup.py
@@ -1120,6 +1120,26 @@ def _grok_auth_changes(
     return []
 
 
+def _gemini_auth_changes(
+    check: dict, *, input_fn: InputFn, secret_input_fn: InputFn,
+) -> list[EnvChange]:
+    """Repair only the Gemini key selected by the offline diagnostic."""
+
+    if check.get("status") != "fail":
+        return []
+    blocked_by = check.get("details", {}).get("blocked_by")
+    key = "GEMINI_API_KEY" if blocked_by == "blank-gemini-key" else "TALK_GEMINI_API_KEY"
+    if blocked_by in {"blank-talk-key", "blank-gemini-key"}:
+        action = _ask_choice(
+            f"{key} is blank. Replace it or remove its dotenv entry?",
+            ("replace", "remove"), input_fn,
+        )
+        if action == "remove":
+            return [(key, None, True)]
+    secret = _ask_nonempty_secret(f"Enter {key} (input hidden): ", secret_input_fn)
+    return [(key, secret, True)]
+
+
 def _auth_changes(
     check: dict,
     *,
@@ -1128,6 +1148,8 @@ def _auth_changes(
     output_fn: OutputFn,
 ) -> list[tuple[str, str | None, bool]]:
     details = check.get("details", {})
+    if details.get("provider") == "gemini":
+        return _gemini_auth_changes(check, input_fn=input_fn, secret_input_fn=secret_input_fn)
     if "xai_oauth" in details:
         return _grok_auth_changes(
             check, input_fn=input_fn, secret_input_fn=secret_input_fn, output_fn=output_fn
@@ -1212,6 +1234,14 @@ def _model_changes(check: dict, input_fn: InputFn) -> list[tuple[str, str | None
     if check.get("status") == "pass":
         return []
     details = check.get("details", {})
+    if details.get("provider") == "gemini":
+        choice = _ask_choice(
+            "This Gemini model has not been checked live. Keep it or use the default?",
+            ("keep", "default"), input_fn,
+        )
+        return [] if choice == "keep" else [
+            ("TALK_GEMINI_MODEL", talk_config.DEFAULT_GEMINI_MODEL, False)
+        ]
     if check.get("status") == "warn" and details.get("compatibility") == "unknown":
         choice = _ask_choice(
             "The configured model has unknown duplex/tool compatibility. "
@@ -1232,6 +1262,13 @@ def _model_changes(check: dict, input_fn: InputFn) -> list[tuple[str, str | None
 def _voice_changes(check: dict, input_fn: InputFn) -> list[tuple[str, str | None, bool]]:
     if check.get("status") != "fail":
         return []
+    if check.get("details", {}).get("provider") == "gemini":
+        while True:
+            voice = input_fn(
+                f"Choose a Gemini voice [{talk_config.DEFAULT_GEMINI_VOICE}] (case-sensitive): "
+            ).strip() or talk_config.DEFAULT_GEMINI_VOICE
+            if voice in talk_config.GEMINI_LIVE_VOICES:
+                return [("TALK_GEMINI_VOICE", voice, False)]
     allowed = tuple(talk_config.OPENAI_REALTIME_VOICES)
     while True:
         voice = input_fn(

--- a/tests/test_gemini_diagnostics.py
+++ b/tests/test_gemini_diagnostics.py
@@ -1,0 +1,248 @@
+"""Gemini diagnostics must agree with the session lane, without inspecting other auth."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+import talk_auth
+import talk_check
+import talk_cli
+import talk_config
+import talk_diagnostics
+import talk_doctor
+import talk_host
+import talk_setup
+import talk_tools
+
+KEY = "AQ.offline-gemini-key-canary"
+
+
+@pytest.fixture(autouse=True)
+def isolated_gemini(monkeypatch, tmp_path):
+    for name in tuple(os.environ):
+        if name.startswith("TALK_") or name in {
+            "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "XAI_API_KEY",
+        }:
+            monkeypatch.delenv(name)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("TALK_PROVIDER", "gemini")
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)
+    monkeypatch.setitem(sys.modules, "agent", None)
+    monkeypatch.setitem(sys.modules, "plugins", None)
+    monkeypatch.setattr(talk_doctor.talk_audio, "audio_available", lambda: True)
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("Gemini diagnostics consulted foreign auth or the network")
+
+    monkeypatch.setattr(talk_auth, "auth_diagnostic", forbidden)
+    monkeypatch.setattr(talk_doctor.talk_grok_auth, "grok_auth_diagnostic", forbidden)
+    monkeypatch.setattr(talk_auth.httpx, "post", forbidden)
+    talk_host.bind_ctx(None)
+    talk_tools.REGISTRATION_RECEIPTS.clear()
+    talk_tools.REGISTRATION_FAILURES.clear()
+    yield
+    talk_host.bind_ctx(None)
+
+
+def checks(report):
+    return {row["id"]: row for row in report["checks"]}
+
+
+def test_gemini_diagnostics_do_not_write_or_open_a_provider_session(monkeypatch, tmp_path):
+    import aiohttp
+
+    monkeypatch.setenv("GEMINI_API_KEY", KEY)
+    before = dict(os.environ)
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("offline diagnostics tried to write or connect")
+
+    with monkeypatch.context() as guard:
+        guard.setattr(aiohttp, "ClientSession", forbidden)
+        guard.setattr(Path, "mkdir", forbidden)
+        guard.setattr(Path, "write_text", forbidden)
+        guard.setattr(Path, "write_bytes", forbidden)
+        report = talk_doctor.collect_report()
+        talk_doctor.render_human(report)
+        talk_diagnostics.collect_bundle(doctor_report=report)
+    assert os.environ == before
+    assert not (tmp_path / "hermes").exists()
+
+
+@pytest.mark.parametrize(
+    ("env", "status", "source"),
+    [
+        ({"GEMINI_API_KEY": KEY}, "pass", "GEMINI_API_KEY"),
+        ({"TALK_GEMINI_API_KEY": KEY}, "pass", "TALK_GEMINI_API_KEY"),
+        ({"TALK_GEMINI_API_KEY": KEY, "GEMINI_API_KEY": " "}, "pass", "TALK_GEMINI_API_KEY"),
+        ({}, "fail", None),
+        ({"GEMINI_API_KEY": " "}, "fail", "GEMINI_API_KEY"),
+        ({"TALK_GEMINI_API_KEY": " ", "GEMINI_API_KEY": KEY}, "fail", "TALK_GEMINI_API_KEY"),
+    ],
+)
+def test_full_report_uses_the_gemini_key_precedence(monkeypatch, env, status, source):
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    report = talk_doctor.collect_report()
+    auth = checks(report)["auth"]
+    assert auth["status"] == status
+    assert auth["details"]["source"] == source
+    assert auth["details"]["provider"] == "gemini"
+    assert auth["details"]["validation_scope"] == "presence-only"
+    assert report["ok"] is (status == "pass")
+    rendered = talk_doctor.render_human(report)
+    assert KEY not in rendered + json.dumps(report)
+    assert "codex login" not in rendered
+    assert "OpenAI" not in rendered
+
+
+def test_gemini_report_ignores_unrelated_openai_configuration(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", KEY)
+    monkeypatch.setenv("TALK_OPENAI_API_KEY", " ")
+    monkeypatch.setenv("TALK_PREFER_CODEX_OAUTH", "invalid")
+    monkeypatch.setenv("TALK_MODEL", "unrelated-invalid-model")
+    monkeypatch.setenv("TALK_VOICE", "unrelated-invalid-voice")
+    monkeypatch.setenv("TALK_GEMINI_VOICE", "Kore")
+    report = talk_doctor.collect_report()
+    rows = checks(report)
+    assert report["ok"]
+    assert rows["model"]["details"]["model"] == talk_config.DEFAULT_GEMINI_MODEL
+    assert rows["voice"]["details"]["voice"] == "Kore"
+    assert rows["voice"]["details"]["source"] == "TALK_GEMINI_VOICE"
+    assert rows["auth"]["details"]["winning_lane"] == talk_cli.resolve_provider_lane().auth.source
+
+
+def test_custom_gemini_model_is_reported_without_claiming_live_compatibility(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", KEY)
+    monkeypatch.setenv("TALK_GEMINI_MODEL", "gemini-custom-live-preview")
+    report = talk_doctor.collect_report()
+    model = checks(report)["model"]
+    assert report["ok"]
+    assert model["status"] == "warn"
+    assert model["details"]["model"] == "gemini-custom-live-preview"
+    assert model["details"]["source"] == "TALK_GEMINI_MODEL"
+    assert model["details"]["compatibility"] == "unknown"
+    assert model["details"]["validation_scope"] == "configuration-only"
+
+
+def test_gemini_voice_validation_preserves_case(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", KEY)
+    monkeypatch.setenv("TALK_GEMINI_VOICE", "puck")
+    report = talk_doctor.collect_report()
+    voice = checks(report)["voice"]
+    assert not report["ok"]
+    assert voice["status"] == "fail"
+    assert voice["details"]["voice"] == "puck"
+    assert "TALK_GEMINI_VOICE" in " ".join(voice["remediation"])
+
+
+def test_renderer_prefers_gemini_identity_even_with_legacy_receipt_fields(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", KEY)
+    report = talk_doctor.collect_report()
+    checks(report)["auth"]["details"].update(
+        codex_oauth="missing", xai_oauth="missing", preference="enabled"
+    )
+    rendered = talk_doctor.render_human(report)
+    assert "provider=gemini" in rendered
+    assert "codex=" not in rendered and "xai-oauth=" not in rendered
+
+
+def test_bundle_keeps_gemini_receipt_facts_without_key_values(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", KEY)
+    report = talk_doctor.collect_report()
+    checks(report)["auth"]["details"]["api_key"] = KEY
+    bundle = talk_diagnostics.collect_bundle(doctor_report=report)
+    rows = checks(bundle["doctor"])
+    assert rows["auth"]["details"]["provider"] == "gemini"
+    assert rows["auth"]["details"]["source"] == "GEMINI_API_KEY"
+    assert rows["auth"]["details"]["validation_scope"] == "presence-only"
+    assert rows["model"]["details"]["provider"] == "gemini"
+    assert rows["voice"]["details"]["provider"] == "gemini"
+    assert "GEMINI_API_KEY" in bundle["environment"]["names"]
+    assert KEY not in json.dumps(bundle)
+
+
+@pytest.mark.parametrize("has_key", [False, True])
+def test_real_doctor_controls_the_check_gate_without_a_live_call(monkeypatch, has_key):
+    if has_key:
+        monkeypatch.setenv("GEMINI_API_KEY", KEY)
+    monkeypatch.setattr(talk_check, "_live_enabled", lambda: True)
+    calls = []
+
+    def stop_at_transport(auth):
+        calls.append(auth.source)
+        raise RuntimeError("offline sentinel: provider factory reached")
+
+    report = talk_check.run_check(
+        no_run=True,
+        lane_resolver=talk_cli.resolve_provider_lane,
+        session_factory=stop_at_transport,
+    )
+    rows = {row["id"]: row for row in report["steps"]}
+    assert rows["static"]["status"] == ("pass" if has_key else "fail")
+    assert calls == (["env"] if has_key else [])
+    assert rows["provider_session"]["status"] == ("fail" if has_key else "skip")
+    assert not report["ok"]  # A fake transport must never become a live receipt.
+
+
+@pytest.mark.parametrize("confirm", ["yes", "no"])
+def test_setup_repairs_only_gemini_with_per_write_confirmation(monkeypatch, tmp_path, confirm):
+    monkeypatch.setenv("OPENAI_API_KEY", "unrelated-openai-placeholder")
+    monkeypatch.setenv("TALK_MODEL", "unrelated-model")
+    prompts, output = [], []
+
+    def answer(prompt):
+        prompts.append(prompt)
+        assert prompt.startswith("Write TALK_GEMINI_API_KEY=")
+        return confirm
+
+    def secret(prompt):
+        prompts.append(prompt)
+        assert "TALK_GEMINI_API_KEY" in prompt
+        return KEY
+
+    result = talk_setup.cli_entry(input_fn=answer, secret_input_fn=secret, output_fn=output.append)
+    env_path = tmp_path / "hermes" / ".env"
+    assert result == (0 if confirm == "yes" else 1)
+    assert env_path.exists() is (confirm == "yes")
+    if env_path.exists():
+        assert env_path.read_text(encoding="utf-8").strip() == f"TALK_GEMINI_API_KEY={KEY}"
+    assert os.environ["OPENAI_API_KEY"] == "unrelated-openai-placeholder"
+    assert os.environ["TALK_MODEL"] == "unrelated-model"
+    assert KEY not in "\n".join(prompts + output)
+    assert "codex login" not in "\n".join(prompts + output)
+
+
+@pytest.mark.parametrize(
+    ("key_name", "action"),
+    [("TALK_GEMINI_API_KEY", "remove"), ("GEMINI_API_KEY", "replace")],
+)
+def test_setup_targets_the_blank_gemini_key(monkeypatch, key_name, action):
+    monkeypatch.setenv(key_name, " ")
+    if key_name == "TALK_GEMINI_API_KEY":
+        monkeypatch.setenv("GEMINI_API_KEY", KEY)
+    auth = checks(talk_doctor.collect_report())["auth"]
+    proposed = talk_setup._auth_changes(
+        auth, input_fn=lambda _: action, secret_input_fn=lambda _: KEY, output_fn=lambda _: None
+    )
+    assert proposed == [(key_name, None if action == "remove" else KEY, True)]
+
+
+def test_setup_model_and_voice_repairs_use_gemini_settings(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", KEY)
+    monkeypatch.setenv("TALK_GEMINI_MODEL", "gemini-custom-live-preview")
+    monkeypatch.setenv("TALK_GEMINI_VOICE", "puck")
+    rows = checks(talk_doctor.collect_report())
+    assert talk_setup._model_changes(rows["model"], lambda _: "default") == [
+        ("TALK_GEMINI_MODEL", talk_config.DEFAULT_GEMINI_MODEL, False)
+    ]
+    assert talk_setup._model_changes(rows["model"], lambda _: "keep") == []
+    voices = iter(["puck", "Puck"])
+    assert talk_setup._voice_changes(rows["voice"], lambda _: next(voices)) == [
+        ("TALK_GEMINI_VOICE", "Puck", False)
+    ]


### PR DESCRIPTION
## What and why

With `TALK_PROVIDER=gemini` and only a Gemini API key configured, the provider check passes but the auth check falls through to OpenAI/Codex. That false failure blocks `hermes talk check`, and setup can tell a Gemini user to run `codex login`. Unrelated OpenAI model and voice settings can also fail the Gemini report.

Route Gemini diagnostics and setup through the existing Gemini key/model/voice functions. The auth receipt now says: "Gemini API key is configured; live authentication was not checked." Update the human renderer and support-bundle allowlist together, so Gemini receipts need no Codex/xAI fields.

- Preserve scoped-key precedence and rejection of explicitly blank overrides.
- Report the actual Gemini model and case-sensitive voice; custom models retain an honest configuration-only warning.
- Keep setup repair prompts on Gemini settings and preserve per-write confirmation.
- Preserve existing OpenAI and Grok behavior.
- Update the operating guide and Unreleased changelog for the next patch release.

Fixes #122

## How to test

The new whole-report regression failed on the original source at the attempted OpenAI auth diagnostic. The candidate adds 19 cases covering key precedence, unrelated OpenAI settings, offline/no-write behavior, mixed receipt rendering, bundle key exclusion, setup confirmation, and the real-doctor-to-check gate.

Run in a fresh project environment, without an importable Hermes installation:

```bash
uv sync --extra dev
uv run --extra dev pytest -q
uv run --extra dev ruff check .
uv build
git diff --check main...HEAD
```

Verified on this head after rebasing onto the 0.17.1 release:
- 1699 passed, 40 skipped, 5 xfailed.
- Ruff 0.16.6 passed.
- Source distribution and wheel built successfully.
- Diff whitespace check passed.

## Platforms

- [x] Windows — CPython 3.12.11, fresh project dev environment
- [ ] Linux — pending GitHub CI
- [ ] macOS — not tested locally

## Live receipt

Live Google verification remains pending. No live provider session was opened during implementation. The check-gate regression deliberately stops at an offline transport sentinel and reports failure; it proves the false static blocker is removed, not that Google accepted a credential.

The Gemini transport, session-time credential resolver, and delegation path are unchanged. Before release, obtain a bounded `hermes talk check --provider gemini --no-run --json` receipt on a configured host. The separate Gemini 3.1 text-trigger protocol question is outside this PR.

## Checklist

- [x] One logical change; regression tests included
- [x] Full local suite and pinned Ruff pass
- [x] Conventional Commit with Gemini scope
- [x] Diagnostics remain offline and read-only; no auth-store writes added
- [x] New receipts omit key values; test keys are synthetic
- [x] User-facing messages distinguish configuration from live authentication
- [x] Operating documentation updated
- [x] Changelog entry is under Unreleased, after the 0.17.1 release
- [ ] Independent review of this exact diff
- [ ] Live Gemini verification before release
