### PR TITLE
chore(release): 0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ named rather than smoothed.
 
 ## [Unreleased]
 
+## [0.17.2] — 2026-09-07
+
+One fix, for the Gemini lane. A Gemini-only install used to fail an OpenAI
+auth check it never needed and get told to run `codex login`; doctor, check,
+and setup now follow Gemini's own credential, model, and voice settings, and
+the live check reaches Google instead of stopping at a false failure.
+Reported as #122 by @eabase, fixed by Codex, reviewed and live-verified
+before merge.
+
 ### Fixed
 - Gemini `doctor`, `check`, and `setup` now follow Gemini's own credential,
   model, and voice settings. A Gemini-only install no longer fails an
@@ -20,6 +29,7 @@ named rather than smoothed.
   reports and redacted support bundles carry the Gemini receipt without
   requiring Codex/xAI fields. Static diagnostics remain offline: configured
   keys and models are not a claim that Google accepted a live connection.
+  (#122)
 
 ## [0.17.1] — 2026-09-07
 

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Talk",
   "description": "Realtime speech-to-speech voice in the browser — duplex audio over WebRTC, live tool calls, background runs spoken when they land.",
   "icon": "MessageSquare",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "tab": { "path": "/talk", "position": "end" },
   "entry": "dist/index.js",
   "css": "dist/style.css",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-talk
-version: 0.17.1
+version: 0.17.2
 manifest_version: 1
 kind: standalone
 description: "OpenAI Realtime speech-to-speech voice for Hermes: duplex talk with live tool calling."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-talk"
-version = "0.17.1"
+version = "0.17.2"
 description = "Realtime speech-to-speech voice for Hermes Agent — OpenAI, xAI Grok, or Gemini Live — duplex talk with live tool calling."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts `[Unreleased]` to `[0.17.2]` and bumps the three version surfaces the hygiene test pins together.

One fix: Gemini `doctor`, `check`, and `setup` follow Gemini's own credential, model, and voice settings, so a Gemini-only install no longer fails an unrelated OpenAI auth check or gets told to run `codex login` (#122, reported by @eabase, fixed in #126, independently reviewed and live-verified against Google before merge).

Hygiene test 3/3, ruff clean, full suite 1699 passed / 0 failed, no line-ending flips.

SmokeDev