### PR TITLE
docs: make the README proof line and receipt example version-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ pip install "hermes-talk[audio]"   # mic + speaker support (sounddevice); skip i
 hermes talk
 ```
 
-Zero core edits — pure `register(ctx)` plugin surface, proven on a stock
-v0.17.0 install. 1,400+ offline tests across 46 files in [`tests/`](tests/),
-CI on ubuntu + windows × py3.11–3.13.
+Zero core edits: a pure `register(ctx)` plugin surface, proven on a stock
+Hermes install. 1,600+ offline tests across 50+ files in [`tests/`](tests/),
+CI on ubuntu and windows, Python 3.11 to 3.13.
 
 ## Quickstart — your first call on each surface
 

--- a/docs/PROVIDER-RECEIPT.md
+++ b/docs/PROVIDER-RECEIPT.md
@@ -69,7 +69,7 @@ a gap is fixable, a leaked key is not.
 | Model | the doctor's `model` check | `grok-voice-latest` |
 | Credential lane | the doctor's `auth` check — the lane, never the credential | `xAI OAuth` |
 | Surface | where you ran the call | `Discord voice channel` |
-| hermes-talk version | `hermes plugins list` | `0.16.0` |
+| hermes-talk version | `hermes plugins list` | `0.17.2` |
 | Hermes host version | `hermes --version` | `0.21.0` |
 | Python / OS | `python --version`, your OS | `3.12.6 / Windows 11` |
 | Events observed | the checklist above | `SessionReady, SpeechStarted, ResponseFinished` — no `FunctionCall` |


### PR DESCRIPTION
README pinned `v0.17.0 install` and `1,400+ tests across 46 files` (stale after two releases today; now 1,699 across 51). Made version-agnostic: `a stock Hermes install`, `1,600+ across 50+ files`. Provider receipt example row `0.16.0` to `0.17.2`. Two dashes in the README line replaced with plain punctuation. Docs only.

SmokeDev