### PR TITLE
fix(dashboard): make transport stop() idempotent and failure-proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,14 @@ pace.
   waits for an answer. Fixed by
   [@danclaw93](https://github.com/danclaw93), the first outside fix to a
   live production lane.
+- The dashboard transport's `stop()` is now idempotent and every teardown
+  step is guarded, so a throw in one can never skip the rest. Previously a
+  throw in `abortCascade()` (or any other step) left the channel and peer
+  open — the server kept listening even though the UI reset to idle, and a
+  second `stop()` could throw again. Each step now nulls its reference and
+  swallows its own failure, so teardown always completes and a repeated
+  call is a no-op. Regression test drives the real bundle through `node`
+  with a throwing `abortCascade()` and asserts every wire is closed.
 - The dashboard cascade relay no longer deadlocks on the servers Hermes
   actually runs on. `POST /api/plugins/hermes-talk/cascade-tts` returned
   HTTP 200 and then zero bytes of PCM, followed by a `ClientDisconnect` in

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -296,22 +296,42 @@
 
     stop() {
       this.closed = true;
-      if (this.offerAbort) this.offerAbort.abort();
-      this.offerAbort = null;
-      this.abortCascade();
+      // Teardown is idempotent and each step is guarded so a throw in one can
+      // never skip the rest. (A throw in abortCascade() used to leave the
+      // channel/peer open, so the server kept listening even though the UI
+      // reset to idle.)
+      if (this.offerAbort) {
+        try { this.offerAbort.abort(); } catch (e) { /* already aborted */ }
+        this.offerAbort = null;
+      }
+      try { this.abortCascade(); } catch (e) { /* already torn down */ }
       if (this.pcmContext) {
         const ctx = this.pcmContext;
         this.pcmContext = null;
         if (ctx.close) Promise.resolve(ctx.close()).catch(() => {});
       }
-      if (this.channel) this.channel.close();
-      this.channel = null;
-      if (this.peer) this.peer.close();
-      this.peer = null;
-      if (this.media) this.media.getTracks().forEach((track) => track.stop());
-      this.media = null;
-      if (this.audio) this.audio.remove();
-      this.audio = null;
+      if (this.channel) {
+        try {
+          if (this.channel.readyState === "open" || this.channel.readyState === "connecting") {
+            this.channel.close();
+          }
+        } catch (e) { /* already closed */ }
+        this.channel = null;
+      }
+      if (this.peer) {
+        try {
+          if (this.peer.connectionState !== "closed") this.peer.close();
+        } catch (e) { /* already closed */ }
+        this.peer = null;
+      }
+      if (this.media) {
+        try { this.media.getTracks().forEach((track) => track.stop()); } catch (e) { /* already stopped */ }
+        this.media = null;
+      }
+      if (this.audio) {
+        try { this.audio.remove(); } catch (e) { /* already removed */ }
+        this.audio = null;
+      }
     }
 
     send(payload) {

--- a/tests/test_dashboard_js.py
+++ b/tests/test_dashboard_js.py
@@ -97,7 +97,74 @@ const waitFor = async (predicate, timeoutMs = 1000) => {
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
-def test_dashboard_cascade_relays_text_and_plays_pcm_until_barge_in():
+def test_dashboard_stop_is_idempotent_when_teardown_throws():
+    """stop() must fully tear down even if a sub-step throws.
+
+    A throw in abortCascade() (or any other teardown step) used to skip the
+    rest of stop(), leaving the channel/peer open so the server kept
+    listening even though the UI reset to idle. Every step is now guarded so
+    a single failure can never strand the session.
+    """
+
+    script = r"""
+const fs = require("fs");
+const vm = require("vm");
+const source = fs.readFileSync(process.argv[1], "utf8");
+const window = {
+  __HERMES_TALK_TEST_HOOK__: true,
+  __HERMES_PLUGINS__: { register() {} },
+  __HERMES_PLUGIN_SDK__: {
+    React: { createElement() {} },
+    hooks: { useState() {}, useEffect() {}, useRef() {}, useCallback() {} },
+    components: {},
+  },
+  sessionStorage: { getItem() { return ""; } },
+  setTimeout,
+  clearTimeout,
+};
+const context = { window, setTimeout, clearTimeout, AbortController, console };
+vm.runInNewContext(source, context, { filename: "index.js" });
+const Transport = window.__HERMES_TALK_TEST__.TalkTransport;
+const transport = new Transport({}, { onStatus() {}, onError() {} });
+
+// Every teardown target is present and live.
+const channel = { readyState: "open", close() { this.closed = true; } };
+const peer = { connectionState: "connected", close() { this.closed = true; } };
+const track = { stop() { this.stopped = true; } };
+const media = { getTracks() { return [track]; } };
+const audio = { remove() { this.removed = true; } };
+transport.channel = channel;
+transport.peer = peer;
+transport.media = media;
+transport.audio = audio;
+
+// The failure that used to strand the session: abortCascade() throws.
+transport.abortCascade = () => { throw new Error("boom"); };
+
+// stop() must still close everything and null every reference.
+transport.stop();
+if (transport.channel !== null) throw new Error("channel not nulled");
+if (transport.peer !== null) throw new Error("peer not nulled");
+if (transport.media !== null) throw new Error("media not nulled");
+if (transport.audio !== null) throw new Error("audio not nulled");
+if (!channel.closed) throw new Error("channel not closed");
+if (!peer.closed) throw new Error("peer not closed");
+if (!track.stopped) throw new Error("mic track not stopped");
+if (!audio.removed) throw new Error("audio element not removed");
+
+// And a second call must be a no-op, not a throw.
+transport.stop();
+process.exit(0);
+""".lstrip()
+    completed = run(
+        ["node", "-e", script, str(DASHBOARD_JS)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=NODE_TIMEOUT_S,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
     """The cascade transport: NDJSON out, PCM onto the AudioContext, abort kills both."""
 
     script = r"""

--- a/tests/test_dashboard_js.py
+++ b/tests/test_dashboard_js.py
@@ -165,6 +165,9 @@ process.exit(0);
         check=False,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_dashboard_cascade_relays_text_and_plays_pcm_until_barge_in():
     """The cascade transport: NDJSON out, PCM onto the AudioContext, abort kills both."""
 
     script = r"""


### PR DESCRIPTION
## What

The dashboard transport's `stop()` is now idempotent and every teardown step is guarded, so a throw in one can never skip the rest.

Previously a throw in `abortCascade()` (or any other teardown step) left the channel and peer open — the server kept listening even though the UI reset to idle, and a second `stop()` could throw again. Each step now nulls its own reference and swallows its own failure, so teardown always completes and a repeated call is a no-op.

## Why

Found while building a standalone mobile surface that reuses the dashboard transport (`dashboard/plugin_api.py` + the lifted `TalkTransport`). Hitting End/New Session could strand the session: the UI reset to idle but the server kept listening, so the next session started with the previous one still live.

## Test

New regression test in `tests/test_dashboard_js.py` drives the real bundle through `node` with a throwing `abortCascade()` and asserts every wire (channel, peer, mic track, audio element) is closed and nulled. Verified it fails on `main` and passes with the fix.

```
pytest tests/test_dashboard_js.py -q   # 6 passed
```

## Changelog

Entry added under `[Unreleased] → Fixed`.