### PR TITLE
chore(release): 0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ named rather than smoothed.
 
 ## [Unreleased]
 
+## [0.17.3] — 2026-09-09
+
+One fix, for the dashboard tab. Ending a session could strand it: if any
+teardown step threw, the rest of `stop()` was skipped, the UI reset to
+idle, and the server kept listening, so the next session started with the
+previous one still live. Every teardown step now owns its own failure and a
+repeated `stop()` is a no-op. Found and fixed by
+[@JakeStevenson](https://github.com/JakeStevenson) while building a mobile
+surface on the dashboard transport, the second outside fix to a live lane.
+
+### Fixed
+- The dashboard transport's `stop()` is now idempotent and every teardown
+  step is guarded, so a throw in one can never skip the rest. Previously a
+  throw in `abortCascade()` (or any other step) left the channel and peer
+  open — the server kept listening even though the UI reset to idle, and a
+  second `stop()` could throw again. Each step now nulls its reference and
+  swallows its own failure, so teardown always completes and a repeated
+  call is a no-op. Regression test drives the real bundle through `node`
+  with a throwing `abortCascade()` and asserts every wire is closed. (#130)
+
 ## [0.17.2] — 2026-09-07
 
 One fix, for the Gemini lane. A Gemini-only install used to fail an OpenAI
@@ -68,14 +88,6 @@ pace.
   waits for an answer. Fixed by
   [@danclaw93](https://github.com/danclaw93), the first outside fix to a
   live production lane.
-- The dashboard transport's `stop()` is now idempotent and every teardown
-  step is guarded, so a throw in one can never skip the rest. Previously a
-  throw in `abortCascade()` (or any other step) left the channel and peer
-  open — the server kept listening even though the UI reset to idle, and a
-  second `stop()` could throw again. Each step now nulls its reference and
-  swallows its own failure, so teardown always completes and a repeated
-  call is a no-op. Regression test drives the real bundle through `node`
-  with a throwing `abortCascade()` and asserts every wire is closed.
 - The dashboard cascade relay no longer deadlocks on the servers Hermes
   actually runs on. `POST /api/plugins/hermes-talk/cascade-tts` returned
   HTTP 200 and then zero bytes of PCM, followed by a `ClientDisconnect` in

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Talk",
   "description": "Realtime speech-to-speech voice in the browser — duplex audio over WebRTC, live tool calls, background runs spoken when they land.",
   "icon": "MessageSquare",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "tab": { "path": "/talk", "position": "end" },
   "entry": "dist/index.js",
   "css": "dist/style.css",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-talk
-version: 0.17.2
+version: 0.17.3
 manifest_version: 1
 kind: standalone
 description: "OpenAI Realtime speech-to-speech voice for Hermes: duplex talk with live tool calling."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hermes-talk"
-version = "0.17.2"
+version = "0.17.3"
 description = "Realtime speech-to-speech voice for Hermes Agent — OpenAI, xAI Grok, or Gemini Live — duplex talk with live tool calling."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Cuts `[Unreleased]` to `[0.17.3]` and bumps the three version surfaces the hygiene test pins together.

One fix: the dashboard transport's `stop()` is idempotent and every teardown step is guarded, so a throw can no longer strand a session with the server still listening behind an idle UI (#130, found and fixed by @JakeStevenson). His changelog entry had landed inside the 0.17.1 section; it now lives under 0.17.3.

Hygiene + manifest tests 13/13, ruff clean, no line-ending flips.

SmokeDev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Vk4r4UyWRGw7P1vbiqeFB