### PR TITLE
feat: add task attachments and recoverable passive persistence

### DIFF
--- a/docs/passive-attachment-client.md
+++ b/docs/passive-attachment-client.md
@@ -57,6 +57,9 @@ callbacks and discards context before exact-generation detach, even if its respo
 is lost. Host restart, deletion and message retirement have no push notification in
 v1; refresh/reconcile is required to learn that state. Invalid attachments discard
 cached context; deletion/retirement scrub derived owner references and queued text.
+Receipt retirement scrubs only that event; unrelated pending dialogue survives.
+Only confirmed target deletion purges the owner's queue. Reconnect and error
+callbacks compare the expected generation inside the outbox writer transaction.
 
 The derived SQLite outbox lives at `state/talk-history-outbox.sqlite3` beneath the
 explicit profile home. Admission is transactional across processes and bounded to

--- a/docs/passive-attachment-client.md
+++ b/docs/passive-attachment-client.md
@@ -1,0 +1,73 @@
+# Shared passive attachment client
+
+`TalkAttachment` implements the passive-history v1 protocol for a configured
+Hermes host. It is a shared Python library; dashboard, terminal and Discord
+lifecycle wiring and execution-origin integration are separate work.
+
+Trusted host code supplies the exact selected session, resolved profile name and
+absolute profile home. Construct `HistoryTransport` with the configured host
+origin and credential; it captures these once and calls only fixed passive-history
+routes. `configured_gateway(profile=...)` uses existing Talk API-server config.
+Named gateway profiles require `named_profile=True`. Dashboard transport uses
+`surface="dashboard"` and the existing session token. OAuth wiring is not supplied
+by this client. URLs, credentials, profile homes and owner identity must never come
+from model tool arguments, transcript text or unverified client request fields.
+
+```python
+from talk_attachment import TalkAttachment
+from talk_outbox import HistoryOutbox
+from talk_passive import HistoryMessage, HistoryTransport
+
+# These values are already resolved by authenticated host integration code.
+transport = HistoryTransport.configured_gateway(profile=resolved_profile)
+outbox = HistoryOutbox(resolved_profile_home, profile=resolved_profile)
+attachment = TalkAttachment(transport, outbox, selected_session=selected_session)
+token = attachment.attach()
+# Keep the utterance's original identity across reconnect and retry.
+event = attachment.enqueue(
+    token, (HistoryMessage("user", finalized_text),), origin_turn_id=origin_turn_id,
+    finalized=True, disposition="dialogue",
+)
+result = attachment.flush(event, token)
+```
+
+Every method that performs I/O belongs in a worker, such as an `asyncio.to_thread`
+call. There is no retry loop, inference, tool dispatch or automatic chat fallback.
+The realtime manager and existing provider/surface behavior remain unchanged.
+
+The caller must wait until the **whole interaction** is known to be ordinary
+dialogue before enqueueing. A finalized user transcript alone does not prove that
+its realtime response will not dispatch work. Pass `disposition="dialogue"` only
+after that classification; incomplete fragments, tool/worker results and utterances
+that may enter execution or steering are refused. This client does not adopt
+execution-origin receipts even if a newer host advertises that additional operation.
+
+`attach()` negotiates version 1 and required operations/limits, reconciles pending
+events for the original owner, then obtains a fresh snapshot/attachment. The outer
+selected session remains the target even when the snapshot names a compression
+successor. `capture_token` fences callbacks; use the new token after reconnect.
+`flush()` returns pending, saved, conflicted or failed. A repeated attempt reconciles
+the original event and owner; unknown requires reattachment before committing.
+That may advance `capture_token` during flush, invalidating earlier callbacks.
+Keep the original event ID for every retry. A new task uses a new attachment;
+recovery must return to the original owner, never retarget pending speech.
+
+`refresh_snapshot()` detects host invalidation. `close(token)` fences local
+callbacks and discards context before exact-generation detach, even if its response
+is lost. Host restart, deletion and message retirement have no push notification in
+v1; refresh/reconcile is required to learn that state. Invalid attachments discard
+cached context; deletion/retirement scrub derived owner references and queued text.
+
+The derived SQLite outbox lives at `state/talk-history-outbox.sqlite3` beneath the
+explicit profile home. Admission is transactional across processes and bounded to
+128 entries, 1 MiB pending UTF-8 JSON and a 24-hour TTL (configurable downward).
+Successful or terminal delivery removes text. Expiration leaves content-free status
+for another TTL; terminal entries may be evicted for new dialogue. It is not a
+history archive or an execution/approval ledger. The resolved profile home must be
+operator-private; file permission tightening supplements that host responsibility.
+`diagnostics()` exposes counts and protocol/attachment state only. Errors expose a
+closed vocabulary, never raw transport bodies, credentials, transcripts or paths.
+
+The client targets an additive host contract that must actually be advertised.
+Missing support is explicit; local tests/builds do not establish installed or live
+host availability, and do not complete the broader Voice Manager feature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ py-modules = [
   "talk_diagnostics",
   "talk_wire",
   "talk_identity",
+  "talk_passive",
+  "talk_outbox",
+  "talk_attachment",
   "talk_host",
   "talk_tools",
   "talk_runs",
@@ -97,6 +100,7 @@ select = ["E", "F", "I", "UP", "B", "SIM", "RUF", "BLE"]
 [tool.ruff.lint.isort]
 known-first-party = [
   "talk_apiserver",
+  "talk_attachment",
   "talk_approvals",
   "talk_audio",
   "talk_auth",
@@ -113,6 +117,8 @@ known-first-party = [
   "talk_grok_realtime",
   "talk_host",
   "talk_identity",
+  "talk_outbox",
+  "talk_passive",
   "talk_lifecycle",
   "talk_operator_auth",
   "talk_openai_realtime",

--- a/talk_attachment.py
+++ b/talk_attachment.py
@@ -124,11 +124,22 @@ class TalkAttachment:
         self._authority = None
         self._snapshot = None
 
-    def _host_error(self, exc: HistoryError):
+    def _host_error(self, exc: HistoryError, token: CaptureToken, event_id: str | None = None):
+        self._check(token)
         if exc.code in {"target_missing", "target_unavailable", "retired"}:
+            # A retired receipt says only that this event's canonical rows are gone.
+            # Only confirmed target deletion invalidates the whole owner's queue.
+            if exc.code == "target_missing" or event_id is not None:
+                self._outbox.invalidate(
+                    self._owner,
+                    code=exc.code,
+                    connection_id=self._connection,
+                    generation=token.generation,
+                    event_id=None if exc.code == "target_missing" else event_id,
+                )
             self._forget_context()
-            self._outbox.invalidate(self._owner, code=exc.code)
-            self._token = None
+            if exc.code == "target_missing":
+                self._token = None
         elif exc.code in {"stale_attachment", "unauthorized", "malformed_response"}:
             self._forget_context()
 
@@ -145,39 +156,40 @@ class TalkAttachment:
             **change,
         )
 
-    def _reattach(self) -> CaptureToken:
+    def _advance(self, expected: CaptureToken | None = None) -> CaptureToken:
+        generation = self._outbox.begin(
+            self._owner,
+            self._connection,
+            expected_generation=expected.generation if expected else None,
+        )
         self._forget_context()
-        generation = self._outbox.begin(self._owner, self._connection)
         token = CaptureToken(self._owner, self._connection, generation)
         self._token = token
+        return token
+
+    def _reattach(self, token: CaptureToken) -> CaptureToken:
+        self._check(token)
+        data = self._transport.request(
+            "attach",
+            {"tab_id": self._connection, "session_id": self._owner.session_id},
+        )
+        self._check(token)
+        self._profile(data)
+        if (
+            data.get("tab_id") != self._connection
+            or data.get("session_id") != self._owner.session_id
+            or type(data.get("generation")) is not int
+            or data["generation"] < 1
+        ):
+            raise HistoryError("malformed_response")
         try:
-            data = self._transport.request(
-                "attach",
-                {
-                    "tab_id": self._connection,
-                    "session_id": self._owner.session_id,
-                },
-            )
-            self._check(token)
-            self._profile(data)
-            if (
-                data.get("tab_id") != self._connection
-                or data.get("session_id") != self._owner.session_id
-                or type(data.get("generation")) is not int
-                or data["generation"] < 1
-            ):
-                raise HistoryError("malformed_response")
-            try:
-                attachment_id = identifier(data.get("attachment_id"))
-            except HistoryError:
-                raise HistoryError("malformed_response") from None
-            snapshot = HistorySnapshot.parse(data.get("snapshot"))
-            self._authority = AttachmentAuthority(token, attachment_id, data["generation"])
-            self._snapshot = snapshot
-            return token
-        except HistoryError as exc:
-            self._host_error(exc)
-            raise
+            attachment_id = identifier(data.get("attachment_id"))
+        except HistoryError:
+            raise HistoryError("malformed_response") from None
+        snapshot = HistorySnapshot.parse(data.get("snapshot"))
+        self._authority = AttachmentAuthority(token, attachment_id, data["generation"])
+        self._snapshot = snapshot
+        return token
 
     def attach(self) -> CaptureToken:
         """Negotiate, reconcile this original owner's pending events, then attach.
@@ -188,21 +200,26 @@ class TalkAttachment:
         with self._lock:
             self._forget_context()
             self._caps = None
-            generation = self._outbox.begin(self._owner, self._connection)
-            token = CaptureToken(self._owner, self._connection, generation)
-            self._token = token
+            token = self._advance()
             try:
                 self._caps = HistoryCapabilities.parse(self._transport.request("capabilities"))
                 self._check(token)
                 for event_id in self._outbox.pending(self._owner):
                     event = self._outbox.get(self._owner, event_id)
-                    receipt = self._reconcile(event)
+                    try:
+                        receipt = self._reconcile(event)
+                    except HistoryError as exc:
+                        if exc.code != "retired":
+                            raise
+                        self._host_error(exc, token, event_id)
+                        continue
                     self._check(token)
                     if receipt is not None:
                         self._mark(event_id, token, state="saved")
-                return self._reattach()
+                token = self._advance(token)
+                return self._reattach(token)
             except HistoryError as exc:
-                self._host_error(exc)
+                self._host_error(exc, token)
                 raise
 
     def refresh_snapshot(self, token: CaptureToken) -> HistorySnapshot:
@@ -220,7 +237,7 @@ class TalkAttachment:
                 self._snapshot = snapshot
                 return snapshot
             except HistoryError as exc:
-                self._host_error(exc)
+                self._host_error(exc, token)
                 raise
 
     def enqueue(
@@ -324,7 +341,8 @@ class TalkAttachment:
                     if receipt is not None:
                         self._mark(event_id, token, state="saved")
                         return HistoryDelivery("saved", receipt=receipt)
-                    token = self._reattach()
+                    token = self._advance(token)
+                    self._reattach(token)
                 if self._authority is None:
                     raise HistoryError("not_attached")
                 if (
@@ -353,7 +371,7 @@ class TalkAttachment:
                 self._mark(event_id, token, state="saved")
                 return HistoryDelivery("saved", receipt=receipt)
             except HistoryError as exc:
-                self._host_error(exc)
+                self._host_error(exc, token, event_id)
                 if exc.code in {"target_missing", "target_unavailable", "retired"}:
                     return HistoryDelivery("failed", exc.code)
                 if exc.code in {"outbox_unavailable", "stale_generation"}:
@@ -381,13 +399,9 @@ class TalkAttachment:
             self._forget_context()
             if authority is None:
                 return
-            try:
-                data = self._transport.request("detach", authority.wire())
-                if data != {"status": "detached"}:
-                    raise HistoryError("malformed_response")
-            except HistoryError as exc:
-                self._host_error(exc)
-                raise
+            data = self._transport.request("detach", authority.wire())
+            if data != {"status": "detached"}:
+                raise HistoryError("malformed_response")
 
     def diagnostics(self) -> dict:
         with self._lock:

--- a/talk_attachment.py
+++ b/talk_attachment.py
@@ -1,0 +1,405 @@
+"""Shared canonical Talk attachment lifecycle, independent of voice providers.
+
+Use from a worker. Nothing here dispatches tools, starts inference or wires a
+voice surface. Trusted surface code classifies finalized ordinary dialogue;
+execution-origin input, tool results and fragments have different owners.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from dataclasses import dataclass
+
+try:
+    from .talk_outbox import HistoryOutbox, PendingHistory
+    from .talk_passive import (
+        HistoryCapabilities,
+        HistoryError,
+        HistoryMessage,
+        HistoryOwner,
+        HistoryReceipt,
+        HistorySnapshot,
+        HistoryTransport,
+        dialogue_messages,
+        identifier,
+    )
+except ImportError:  # pragma: no cover - flat Hermes plugin load
+    from talk_outbox import HistoryOutbox, PendingHistory
+    from talk_passive import (
+        HistoryCapabilities,
+        HistoryError,
+        HistoryMessage,
+        HistoryOwner,
+        HistoryReceipt,
+        HistorySnapshot,
+        HistoryTransport,
+        dialogue_messages,
+        identifier,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureToken:
+    owner: HistoryOwner
+    connection_id: str
+    generation: int
+
+
+@dataclass(frozen=True, slots=True)
+class AttachmentAuthority:
+    capture: CaptureToken
+    attachment_id: str
+    generation: int
+
+    def wire(self) -> dict:
+        return {
+            "tab_id": self.capture.connection_id,
+            "attachment_id": self.attachment_id,
+            "generation": self.generation,
+            "session_id": self.capture.owner.session_id,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryDelivery:
+    state: str
+    code: str = ""
+    receipt: HistoryReceipt | None = None
+
+
+class TalkAttachment:
+    """One immutable host/profile/principal/selected-task owner for its lifetime.
+
+    Reuse ``connection_id`` only to reconnect the same trusted surface/tab. A
+    different task requires a new instance; pending events never follow selection.
+    All methods are worker calls, serialized per instance; the durable generation
+    also fences separate instances/processes sharing this connection's identity.
+    """
+
+    def __init__(
+        self,
+        transport: HistoryTransport,
+        outbox: HistoryOutbox,
+        *,
+        selected_session: str,
+        connection_id: str | None = None,
+    ):
+        self._transport, self._outbox = transport, outbox
+        self._owner = transport.owner(selected_session)
+        self._connection = identifier(connection_id or uuid.uuid4().hex)
+        self._token: CaptureToken | None = None
+        self._authority: AttachmentAuthority | None = None
+        self._snapshot: HistorySnapshot | None = None
+        self._caps: HistoryCapabilities | None = None
+        self._lock = threading.RLock()
+
+    @property
+    def owner(self) -> HistoryOwner:
+        return self._owner
+
+    @property
+    def capture_token(self) -> CaptureToken | None:
+        return self._token
+
+    @property
+    def snapshot(self) -> HistorySnapshot | None:
+        with self._lock:
+            if self._token is not None:
+                try:
+                    self._check(self._token)
+                except HistoryError:
+                    self._snapshot = None
+                    self._authority = None
+                    raise
+            return self._snapshot
+
+    def _check(self, token: CaptureToken):
+        if token != self._token or token.owner != self._owner:
+            raise HistoryError("stale_generation")
+        self._outbox.check(self._owner, self._connection, token.generation)
+
+    def _forget_context(self):
+        self._authority = None
+        self._snapshot = None
+
+    def _host_error(self, exc: HistoryError):
+        if exc.code in {"target_missing", "target_unavailable", "retired"}:
+            self._forget_context()
+            self._outbox.invalidate(self._owner, code=exc.code)
+            self._token = None
+        elif exc.code in {"stale_attachment", "unauthorized", "malformed_response"}:
+            self._forget_context()
+
+    def _profile(self, data: dict):
+        if data.get("profile") != self._owner.profile:
+            raise HistoryError("malformed_response")
+
+    def _mark(self, event_id: str, token: CaptureToken, **change) -> str:
+        return self._outbox.mark(
+            self._owner,
+            event_id,
+            connection_id=self._connection,
+            generation=token.generation,
+            **change,
+        )
+
+    def _reattach(self) -> CaptureToken:
+        self._forget_context()
+        generation = self._outbox.begin(self._owner, self._connection)
+        token = CaptureToken(self._owner, self._connection, generation)
+        self._token = token
+        try:
+            data = self._transport.request(
+                "attach",
+                {
+                    "tab_id": self._connection,
+                    "session_id": self._owner.session_id,
+                },
+            )
+            self._check(token)
+            self._profile(data)
+            if (
+                data.get("tab_id") != self._connection
+                or data.get("session_id") != self._owner.session_id
+                or type(data.get("generation")) is not int
+                or data["generation"] < 1
+            ):
+                raise HistoryError("malformed_response")
+            try:
+                attachment_id = identifier(data.get("attachment_id"))
+            except HistoryError:
+                raise HistoryError("malformed_response") from None
+            snapshot = HistorySnapshot.parse(data.get("snapshot"))
+            self._authority = AttachmentAuthority(token, attachment_id, data["generation"])
+            self._snapshot = snapshot
+            return token
+        except HistoryError as exc:
+            self._host_error(exc)
+            raise
+
+    def attach(self) -> CaptureToken:
+        """Negotiate, reconcile this original owner's pending events, then attach.
+
+        Used for first attachment and reconnect. No commits happen here. Unknown
+        receipts remain pending for explicit ``flush``; a retry never changes owner.
+        """
+        with self._lock:
+            self._forget_context()
+            self._caps = None
+            generation = self._outbox.begin(self._owner, self._connection)
+            token = CaptureToken(self._owner, self._connection, generation)
+            self._token = token
+            try:
+                self._caps = HistoryCapabilities.parse(self._transport.request("capabilities"))
+                self._check(token)
+                for event_id in self._outbox.pending(self._owner):
+                    event = self._outbox.get(self._owner, event_id)
+                    receipt = self._reconcile(event)
+                    self._check(token)
+                    if receipt is not None:
+                        self._mark(event_id, token, state="saved")
+                return self._reattach()
+            except HistoryError as exc:
+                self._host_error(exc)
+                raise
+
+    def refresh_snapshot(self, token: CaptureToken) -> HistorySnapshot:
+        with self._lock:
+            self._check(token)
+            if self._authority is None:
+                raise HistoryError("not_attached")
+            try:
+                data = self._transport.request("snapshot", self._authority.wire())
+                self._check(token)
+                self._profile(data)
+                snapshot = HistorySnapshot.parse(data)
+                if self._snapshot and snapshot.conversation_id != self._snapshot.conversation_id:
+                    raise HistoryError("malformed_response")
+                self._snapshot = snapshot
+                return snapshot
+            except HistoryError as exc:
+                self._host_error(exc)
+                raise
+
+    def enqueue(
+        self,
+        token: CaptureToken,
+        messages: tuple[HistoryMessage, ...],
+        *,
+        origin_turn_id: str,
+        finalized: bool,
+        disposition: str,
+        event_id: str | None = None,
+    ) -> str:
+        """Explicit admission, with no NLP guessing and no default disposition.
+
+        Only finalized ``dialogue`` is admitted. Callers must withhold utterances
+        that may also enter execution/steering, even if origin adoption is advertised.
+        Wait until the whole realtime interaction can be classified: a finalized
+        user transcript alone does not prove that its response will not dispatch work.
+        Retain the returned event ID for retries; never mint a new event to retry.
+        """
+        if finalized is not True or disposition != "dialogue":
+            raise HistoryError("not_passive")
+        with self._lock:
+            self._check(token)
+            if self._authority is None or self._snapshot is None or self._caps is None:
+                raise HistoryError("not_attached")
+            rows = dialogue_messages(messages, max_bytes=self._caps.max_message_bytes)
+            if len(rows) > self._caps.max_messages:
+                raise HistoryError("invalid_input")
+            event_id = identifier(event_id or uuid.uuid4().hex)
+            origin_turn_id = identifier(origin_turn_id)
+            body = {
+                **self._authority.wire(),
+                "event_id": event_id,
+                "origin_turn_id": origin_turn_id,
+                "messages": [row.wire() for row in rows],
+            }
+            if (
+                len(json.dumps(body, ensure_ascii=False).encode("utf-8"))
+                > self._caps.max_request_bytes
+            ):
+                raise HistoryError("payload_too_large")
+            self._outbox.add(
+                PendingHistory(
+                    event_id,
+                    origin_turn_id,
+                    self._owner,
+                    self._snapshot.conversation_id,
+                    self._connection,
+                    token.generation,
+                    rows,
+                    "pending",
+                    0,
+                    "",
+                )
+            )
+            return event_id
+
+    def _reconcile(self, event: PendingHistory) -> HistoryReceipt | None:
+        data = self._transport.request(
+            "reconcile",
+            {
+                "session_id": event.owner.session_id,
+                "event_id": event.event_id,
+            },
+        )
+        self._profile(data)
+        if data.get("status") == "unknown" and data.get("receipt", "missing") is None:
+            return None
+        if data.get("status") != "saved":
+            raise HistoryError("malformed_response")
+        return self._receipt(data, event)
+
+    def _receipt(self, data: dict, event: PendingHistory) -> HistoryReceipt:
+        self._profile(data)
+        return HistoryReceipt.parse(
+            data.get("receipt"),
+            event_id=event.event_id,
+            origin_turn_id=event.origin_turn_id,
+            conversation_id=event.conversation_id,
+            message_count=len(event.messages),
+        )
+
+    def flush(self, event_id: str, token: CaptureToken) -> HistoryDelivery:
+        """One bounded delivery attempt. The caller owns scheduling/backoff.
+
+        Before every repeated/older-generation commit, reconcile the same owner and
+        event. Unknown requires a fresh attachment to that owner. Never auto-loop.
+        """
+        with self._lock:
+            self._check(token)
+            event = self._outbox.get(self._owner, identifier(event_id))
+            if event.state != "pending":
+                return HistoryDelivery(event.state, event.code)
+            if self._caps is None:
+                raise HistoryError("not_attached")
+            try:
+                if event.attempts or event.generation != token.generation:
+                    receipt = self._reconcile(event)
+                    self._check(token)
+                    if receipt is not None:
+                        self._mark(event_id, token, state="saved")
+                        return HistoryDelivery("saved", receipt=receipt)
+                    token = self._reattach()
+                if self._authority is None:
+                    raise HistoryError("not_attached")
+                if (
+                    self._snapshot is None
+                    or self._snapshot.conversation_id != event.conversation_id
+                ):
+                    raise HistoryError("event_conflict")
+                self._check(token)
+                # Durable attempt precedes HTTP so a crash/lost response always reconciles.
+                if self._mark(event_id, token, attempted=True) != "pending":
+                    current = self._outbox.get(self._owner, event_id)
+                    return HistoryDelivery(current.state, current.code)
+                data = self._transport.request(
+                    "commit",
+                    {
+                        **self._authority.wire(),
+                        "event_id": event.event_id,
+                        "origin_turn_id": event.origin_turn_id,
+                        "messages": [row.wire() for row in event.messages],
+                    },
+                )
+                self._check(token)
+                if data.get("status") not in {"saved", "already_saved"}:
+                    raise HistoryError("malformed_response")
+                receipt = self._receipt(data, event)
+                self._mark(event_id, token, state="saved")
+                return HistoryDelivery("saved", receipt=receipt)
+            except HistoryError as exc:
+                self._host_error(exc)
+                if exc.code in {"target_missing", "target_unavailable", "retired"}:
+                    return HistoryDelivery("failed", exc.code)
+                if exc.code in {"outbox_unavailable", "stale_generation"}:
+                    raise
+                if exc.code == "event_conflict":
+                    state = "conflicted"
+                elif exc.retryable or exc.code in {"malformed_response", "stale_attachment"}:
+                    state = "pending"
+                else:
+                    state = "failed"
+                state = self._mark(event_id, token, state=state, code=exc.code)
+                return HistoryDelivery(state, exc.code)
+
+    def close(self, token: CaptureToken):
+        """Fence local callbacks before requesting exact remote-generation detach.
+
+        Pending events remain bound to the original owner for later reconciliation.
+        A lost detach response never restores local authority or cached context.
+        """
+        with self._lock:
+            self._check(token)
+            authority = self._authority
+            self._outbox.end(self._owner, self._connection, token.generation)
+            self._token = None
+            self._forget_context()
+            if authority is None:
+                return
+            try:
+                data = self._transport.request("detach", authority.wire())
+                if data != {"status": "detached"}:
+                    raise HistoryError("malformed_response")
+            except HistoryError as exc:
+                self._host_error(exc)
+                raise
+
+    def diagnostics(self) -> dict:
+        with self._lock:
+            attached = False
+            if self._token is not None and self._authority is not None:
+                try:
+                    self._check(self._token)
+                    attached = True
+                except HistoryError:
+                    self._forget_context()
+            return {
+                "attached": attached,
+                "protocol": 1 if self._caps else None,
+                **self._outbox.diagnostics(),
+            }

--- a/talk_outbox.py
+++ b/talk_outbox.py
@@ -1,0 +1,325 @@
+"""Bounded, profile-resolved derived history queue. Never opens a host database."""
+
+from __future__ import annotations
+
+import json
+import math
+import sqlite3
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+try:
+    from .talk_passive import HistoryError, HistoryMessage, HistoryOwner, dialogue_messages, digest
+except ImportError:  # pragma: no cover - flat Hermes plugin load
+    from talk_passive import HistoryError, HistoryMessage, HistoryOwner, dialogue_messages, digest
+
+
+@dataclass(frozen=True, slots=True)
+class PendingHistory:
+    event_id: str
+    origin_turn_id: str
+    owner: HistoryOwner
+    conversation_id: str
+    connection_id: str
+    generation: int
+    messages: tuple[HistoryMessage, ...] = field(repr=False)
+    state: str
+    attempts: int
+    code: str
+
+
+class HistoryOutbox:
+    """Pass an absolute profile home resolved by trusted host code, never model text.
+
+    There is intentionally no root-home fallback or profile auto-detection. SQLite
+    writer transactions serialize capacity admission and generation changes across
+    processes. No transaction spans a network request. Content is scrubbed on save,
+    failure, expiration and retirement; this is not a second conversation archive.
+    """
+
+    def __init__(
+        self,
+        profile_home: Path,
+        *,
+        profile: str,
+        max_events: int = 128,
+        max_bytes: int = 1024 * 1024,
+        ttl_s: float = 86400,
+        clock: Callable[[], float] = time.time,
+    ):
+        if (
+            not profile_home.is_absolute()
+            or not profile
+            or type(max_events) is not int
+            or not 1 <= max_events <= 128
+            or type(max_bytes) is not int
+            or not 1 <= max_bytes <= 1024 * 1024
+            or not math.isfinite(ttl_s)
+            or not 0 < ttl_s <= 86400
+        ):
+            raise HistoryError("invalid_input")
+        self._profile = profile
+        self._max_events, self._max_bytes, self._ttl_s = max_events, max_bytes, ttl_s
+        self._clock = clock
+        self._path = profile_home / "state" / "talk-history-outbox.sqlite3"
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            self._path.touch(mode=0o600, exist_ok=True)
+            self._path.chmod(0o600)
+        except OSError:
+            raise HistoryError("outbox_unavailable") from None
+        with self._db(prune=False) as db:
+            db.execute(
+                "CREATE TABLE IF NOT EXISTS metadata "
+                "(profile TEXT NOT NULL, next_generation INTEGER NOT NULL)"
+            )
+            row = db.execute("SELECT profile FROM metadata").fetchone()
+            if row is None:
+                db.execute("INSERT INTO metadata VALUES (?,0)", (profile,))
+            elif row[0] != profile:
+                raise HistoryError("owner_mismatch")
+            db.execute("""CREATE TABLE IF NOT EXISTS connections (
+                scope TEXT PRIMARY KEY, owner TEXT NOT NULL, generation INTEGER NOT NULL,
+                touched REAL NOT NULL)""")
+            db.execute("""CREATE TABLE IF NOT EXISTS events (
+                event_id TEXT PRIMARY KEY, origin_turn_id TEXT NOT NULL, owner TEXT NOT NULL,
+                owner_json TEXT NOT NULL, conversation_id TEXT NOT NULL,
+                connection_id TEXT NOT NULL, generation INTEGER NOT NULL,
+                messages TEXT NOT NULL, payload_hash TEXT NOT NULL, bytes INTEGER NOT NULL,
+                created REAL NOT NULL, state TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0,
+                code TEXT NOT NULL DEFAULT '')""")
+
+    @contextmanager
+    def _db(self, *, prune: bool = True) -> Iterator[sqlite3.Connection]:
+        db = None
+        try:
+            db = sqlite3.connect(self._path, timeout=2)
+            db.row_factory = sqlite3.Row
+            db.execute("PRAGMA secure_delete=ON")
+            db.execute("BEGIN IMMEDIATE")
+            if prune:
+                # Retention cleanup must survive a subsequent admission/read refusal.
+                self._prune(db)
+                db.commit()
+                db.execute("BEGIN IMMEDIATE")
+            yield db
+            db.commit()
+        except (sqlite3.Error, OSError):
+            raise HistoryError("outbox_unavailable") from None
+        finally:
+            if db is not None:
+                db.close()
+
+    def _prune(self, db):
+        cutoff = self._clock() - self._ttl_s
+        # Preserve a content-free failed state for one TTL so expiration is observable.
+        db.execute("DELETE FROM events WHERE created < ?", (cutoff - self._ttl_s,))
+        db.execute(
+            """UPDATE events SET state='failed',code='expired',messages='',bytes=0,
+            owner='',owner_json='',conversation_id='',origin_turn_id='',connection_id=''
+            WHERE created < ?""",
+            (cutoff,),
+        )
+        db.execute("DELETE FROM connections WHERE touched < ?", (cutoff,))
+
+    def _scope(self, owner: HistoryOwner, connection_id: str) -> str:
+        if owner.profile != self._profile:
+            raise HistoryError("owner_mismatch")
+        return digest([owner.host, owner.profile, owner.principal, connection_id])
+
+    def _check(self, db, owner: HistoryOwner, connection_id: str, generation: int):
+        row = db.execute(
+            "SELECT owner,generation FROM connections WHERE scope=?",
+            (self._scope(owner, connection_id),),
+        ).fetchone()
+        if row is None or row["owner"] != owner.key or row["generation"] != generation:
+            raise HistoryError("stale_generation")
+
+    def begin(self, owner: HistoryOwner, connection_id: str) -> int:
+        scope = self._scope(owner, connection_id)
+        with self._db() as db:
+            row = db.execute(
+                "SELECT generation FROM connections WHERE scope=?", (scope,)
+            ).fetchone()
+            if row is None and db.execute("SELECT count(*) FROM connections").fetchone()[0] >= 128:
+                raise HistoryError("outbox_full")
+            generation = db.execute(
+                "UPDATE metadata SET next_generation=next_generation+1 RETURNING next_generation"
+            ).fetchone()[0]
+            db.execute(
+                "INSERT OR REPLACE INTO connections VALUES (?,?,?,?)",
+                (scope, owner.key, generation, self._clock()),
+            )
+            return generation
+
+    def check(self, owner: HistoryOwner, connection_id: str, generation: int):
+        with self._db() as db:
+            self._check(db, owner, connection_id, generation)
+
+    def end(self, owner: HistoryOwner, connection_id: str, generation: int):
+        with self._db() as db:
+            self._check(db, owner, connection_id, generation)
+            db.execute(
+                "UPDATE connections SET owner='',generation=generation+1 WHERE scope=?",
+                (self._scope(owner, connection_id),),
+            )
+
+    def add(self, event: PendingHistory):
+        encoded = json.dumps([row.wire() for row in event.messages], ensure_ascii=False)
+        size = len(encoded.encode("utf-8"))
+        fingerprint = digest([event.owner.key, event.origin_turn_id, encoded])
+        with self._db() as db:
+            self._check(db, event.owner, event.connection_id, event.generation)
+            prior = db.execute(
+                "SELECT payload_hash FROM events WHERE event_id=?", (event.event_id,)
+            ).fetchone()
+            if prior:
+                if prior[0] != fingerprint:
+                    raise HistoryError("event_conflict")
+                return
+            count, used = db.execute(
+                "SELECT count(*),coalesce(sum(bytes),0) FROM events"
+            ).fetchone()
+            if count >= self._max_events:
+                # Only terminal, content-free entries may give way to fresh dialogue.
+                oldest = db.execute(
+                    "SELECT event_id FROM events WHERE state!='pending' ORDER BY created LIMIT 1"
+                ).fetchone()
+                if oldest:
+                    db.execute("DELETE FROM events WHERE event_id=?", (oldest[0],))
+                    count -= 1
+            if count >= self._max_events or used + size > self._max_bytes:
+                raise HistoryError("outbox_full")
+            db.execute(
+                """INSERT INTO events
+                (event_id,origin_turn_id,owner,owner_json,conversation_id,connection_id,
+                 generation,messages,payload_hash,bytes,created,state)
+                 VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    event.event_id,
+                    event.origin_turn_id,
+                    event.owner.key,
+                    json.dumps(asdict(event.owner)),
+                    event.conversation_id,
+                    event.connection_id,
+                    event.generation,
+                    encoded,
+                    fingerprint,
+                    size,
+                    self._clock(),
+                    "pending",
+                ),
+            )
+
+    def get(self, owner: HistoryOwner, event_id: str) -> PendingHistory:
+        with self._db() as db:
+            row = db.execute("SELECT * FROM events WHERE event_id=?", (event_id,)).fetchone()
+            if row is None:
+                raise HistoryError("unknown_event")
+            if row["code"] in {"expired", "retired", "target_missing", "target_unavailable"}:
+                raise HistoryError(row["code"])
+            if row["owner"] != owner.key or owner.profile != self._profile:
+                raise HistoryError("owner_mismatch")
+            try:
+                rows = json.loads(row["messages"]) if row["messages"] else []
+                stored_owner = HistoryOwner(**json.loads(row["owner_json"]))
+                if stored_owner != owner:
+                    raise HistoryError("owner_mismatch")
+                messages = tuple(HistoryMessage(**message) for message in rows)
+                if row["state"] == "pending":
+                    dialogue_messages(messages)
+                    fingerprint = digest([owner.key, row["origin_turn_id"], row["messages"]])
+                    if fingerprint != row["payload_hash"]:
+                        raise HistoryError("outbox_unavailable")
+                return PendingHistory(
+                    row["event_id"],
+                    row["origin_turn_id"],
+                    stored_owner,
+                    row["conversation_id"],
+                    row["connection_id"],
+                    row["generation"],
+                    messages,
+                    row["state"],
+                    row["attempts"],
+                    row["code"],
+                )
+            except (ValueError, TypeError, KeyError):
+                raise HistoryError("outbox_unavailable") from None
+
+    def mark(
+        self,
+        owner: HistoryOwner,
+        event_id: str,
+        *,
+        connection_id: str,
+        generation: int,
+        state: str = "pending",
+        code: str = "",
+        attempted: bool = False,
+    ):
+        if state not in {"pending", "saved", "failed", "conflicted"}:
+            raise HistoryError("invalid_input")
+        safe_code = HistoryError(code).code if code else ""
+        with self._db() as db:
+            self._check(db, owner, connection_id, generation)
+            result = db.execute(
+                """UPDATE events SET state=?,code=?,attempts=attempts+?,
+                messages=CASE WHEN ?='pending' THEN messages ELSE '' END,
+                bytes=CASE WHEN ?='pending' THEN bytes ELSE 0 END
+                WHERE event_id=? AND owner=? AND state='pending'""",
+                (state, safe_code, int(attempted), state, state, event_id, owner.key),
+            )
+            if result.rowcount != 1:
+                prior = db.execute(
+                    "SELECT state FROM events WHERE event_id=? AND owner=?", (event_id, owner.key)
+                ).fetchone()
+                if prior is None:
+                    raise HistoryError("unknown_event")
+                return prior[0]
+            return state
+
+    def invalidate(self, owner: HistoryOwner, *, code: str):
+        if code not in {"retired", "target_missing", "target_unavailable"}:
+            raise HistoryError("invalid_input")
+        with self._db() as db:
+            db.execute(
+                """UPDATE events SET state='failed',code=?,messages='',bytes=0,
+                owner='',owner_json='',conversation_id='',origin_turn_id='',connection_id=''
+                WHERE owner=?""",
+                (code, owner.key),
+            )
+            db.execute(
+                "UPDATE connections SET owner='',generation=generation+1 WHERE owner=?",
+                (owner.key,),
+            )
+
+    def pending(self, owner: HistoryOwner) -> tuple[str, ...]:
+        if owner.profile != self._profile:
+            raise HistoryError("owner_mismatch")
+        with self._db() as db:
+            return tuple(
+                row[0]
+                for row in db.execute(
+                    "SELECT event_id FROM events WHERE owner=? AND state='pending' "
+                    "ORDER BY created,rowid",
+                    (owner.key,),
+                )
+            )
+
+    def diagnostics(self) -> dict:
+        """Counts and enumerated states only; no text, paths, credentials or owner IDs."""
+        with self._db() as db:
+            counts = {state: 0 for state in ("pending", "saved", "failed", "conflicted")}
+            for state, count in db.execute("SELECT state,count(*) FROM events GROUP BY state"):
+                if state in counts:
+                    counts[state] = count
+            return {
+                "states": counts,
+                "pending_bytes": db.execute("SELECT coalesce(sum(bytes),0) FROM events").fetchone()[
+                    0
+                ],
+            }

--- a/talk_outbox.py
+++ b/talk_outbox.py
@@ -138,9 +138,13 @@ class HistoryOutbox:
         if row is None or row["owner"] != owner.key or row["generation"] != generation:
             raise HistoryError("stale_generation")
 
-    def begin(self, owner: HistoryOwner, connection_id: str) -> int:
+    def begin(
+        self, owner: HistoryOwner, connection_id: str, *, expected_generation: int | None = None
+    ) -> int:
         scope = self._scope(owner, connection_id)
         with self._db() as db:
+            if expected_generation is not None:
+                self._check(db, owner, connection_id, expected_generation)
             row = db.execute(
                 "SELECT generation FROM connections WHERE scope=?", (scope,)
             ).fetchone()
@@ -282,20 +286,33 @@ class HistoryOutbox:
                 return prior[0]
             return state
 
-    def invalidate(self, owner: HistoryOwner, *, code: str):
+    def invalidate(
+        self,
+        owner: HistoryOwner,
+        *,
+        code: str,
+        connection_id: str,
+        generation: int,
+        event_id: str | None = None,
+    ):
         if code not in {"retired", "target_missing", "target_unavailable"}:
             raise HistoryError("invalid_input")
+        if event_id is None and code != "target_missing":
+            raise HistoryError("invalid_input")
         with self._db() as db:
+            self._check(db, owner, connection_id, generation)
             db.execute(
                 """UPDATE events SET state='failed',code=?,messages='',bytes=0,
                 owner='',owner_json='',conversation_id='',origin_turn_id='',connection_id=''
-                WHERE owner=?""",
-                (code, owner.key),
+                WHERE owner=?"""
+                + (" AND event_id=?" if event_id is not None else ""),
+                (code, owner.key, event_id) if event_id is not None else (code, owner.key),
             )
-            db.execute(
-                "UPDATE connections SET owner='',generation=generation+1 WHERE owner=?",
-                (owner.key,),
-            )
+            if event_id is None:
+                db.execute(
+                    "UPDATE connections SET owner='',generation=generation+1 WHERE owner=?",
+                    (owner.key,),
+                )
 
     def pending(self, owner: HistoryOwner) -> tuple[str, ...]:
         if owner.profile != self._profile:

--- a/talk_passive.py
+++ b/talk_passive.py
@@ -1,0 +1,347 @@
+"""Passive history v1 wire contract. Trusted host code configures this transport.
+
+Calls are synchronous and belong in a worker, never the realtime audio loop.
+There is deliberately no chat, execution, provider or database fallback here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass, field
+from urllib.parse import urlsplit
+
+import httpx
+
+OPERATIONS = frozenset({"attach", "snapshot", "commit", "reconcile", "detach"})
+MAX_RESPONSE_BYTES = 256 * 1024
+_ID = re.compile(r"[A-Za-z0-9._-]{1,128}\Z")
+_CODES = frozenset(
+    {
+        "unsupported",
+        "unavailable",
+        "unauthorized",
+        "invalid_input",
+        "malformed_response",
+        "busy",
+        "store_unavailable",
+        "stale_attachment",
+        "target_missing",
+        "target_unavailable",
+        "event_conflict",
+        "retired",
+        "invalid_request",
+        "payload_too_large",
+        "denied",
+        "stale_generation",
+        "not_attached",
+        "outbox_unavailable",
+        "outbox_full",
+        "expired",
+        "owner_mismatch",
+        "unknown_event",
+        "not_passive",
+    }
+)
+
+
+class HistoryError(Exception):
+    """Only a closed vocabulary crosses diagnostics, never server/transport text."""
+
+    def __init__(self, code: str, *, retryable: bool = False):
+        self.code = code if code in _CODES else "malformed_response"
+        self.retryable = retryable and self.code in {"busy", "store_unavailable", "unavailable"}
+        super().__init__(self.code)
+
+
+def identifier(value: object) -> str:
+    if not isinstance(value, str) or not _ID.fullmatch(value):
+        raise HistoryError("invalid_input")
+    return value
+
+
+def session_id(value: object) -> str:
+    if not isinstance(value, str) or not 1 <= len(value) <= 256:
+        raise HistoryError("invalid_input")
+    return value
+
+
+def digest(value: object) -> str:
+    return hashlib.sha256(json.dumps(value, ensure_ascii=True).encode()).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryOwner:
+    host: str
+    profile: str
+    principal: str
+    session_id: str
+
+    @property
+    def key(self) -> str:
+        return digest([self.host, self.profile, self.principal, self.session_id])
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryMessage:
+    role: str
+    content: str = field(repr=False)
+
+    def wire(self) -> dict:
+        return {"role": self.role, "content": self.content}
+
+
+def dialogue_messages(rows: object, *, max_bytes: int = 65536) -> tuple[HistoryMessage, ...]:
+    if not isinstance(rows, (tuple, list)) or not 1 <= len(rows) <= 2:
+        raise HistoryError("invalid_input")
+    result = []
+    for row in rows:
+        if not isinstance(row, HistoryMessage) or row.role not in {"user", "assistant"}:
+            raise HistoryError("not_passive")
+        try:
+            valid = isinstance(row.content, str) and row.content.strip()
+            valid = valid and len(row.content.encode("utf-8")) <= max_bytes
+        except UnicodeEncodeError:
+            valid = False
+        if not valid:
+            raise HistoryError("invalid_input")
+        result.append(row)
+    if len(result) == 2 and [row.role for row in result] != ["user", "assistant"]:
+        raise HistoryError("invalid_input")
+    return tuple(result)
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryCapabilities:
+    max_request_bytes: int
+    max_message_bytes: int
+    max_messages: int
+    max_snapshot_messages: int
+    max_snapshot_bytes: int
+
+    @classmethod
+    def parse(cls, data: object) -> HistoryCapabilities:
+        if not isinstance(data, dict):
+            raise HistoryError("unsupported")
+        operations = data.get("operations")
+        if (
+            type(data.get("version")) is not int
+            or data["version"] != 1
+            or data.get("passive_only") is not True
+            or type(data.get("origin_adoption")) is not bool
+            or data.get("restart_requires_reattach") is not True
+            or not isinstance(operations, list)
+            or any(not isinstance(op, str) for op in operations)
+            or not OPERATIONS.issubset(operations)
+        ):
+            raise HistoryError("unsupported")
+        limits = {
+            "max_request_bytes": 160 * 1024,
+            "max_message_bytes": 64 * 1024,
+            "max_messages": 2,
+            "max_snapshot_messages": 20,
+            "max_snapshot_bytes": 32 * 1024,
+        }
+        for key, bound in limits.items():
+            if type(data.get(key)) is not int or not 1 <= data[key] <= bound:
+                raise HistoryError("unsupported")
+        return cls(**{key: data[key] for key in limits})
+
+
+@dataclass(frozen=True, slots=True)
+class HistorySnapshot:
+    conversation_id: str
+    session_id: str
+    messages: tuple[HistoryMessage, ...] = field(repr=False)
+    truncated: bool
+
+    @classmethod
+    def parse(cls, data: object) -> HistorySnapshot:
+        try:
+            if not isinstance(data, dict) or type(data.get("truncated")) is not bool:
+                raise HistoryError("malformed_response")
+            caps = HistoryCapabilities.parse(data.get("capabilities"))
+            rows = data.get("messages")
+            if not isinstance(rows, list) or len(rows) > caps.max_snapshot_messages:
+                raise HistoryError("malformed_response")
+            messages = []
+            for row in rows:
+                if (
+                    not isinstance(row, dict)
+                    or set(row) != {"id", "role", "content"}
+                    or type(row["id"]) is not int
+                    or row["id"] <= 0
+                ):
+                    raise HistoryError("malformed_response")
+                messages.extend(dialogue_messages([HistoryMessage(row["role"], row["content"])]))
+            if sum(len(row.content.encode("utf-8")) for row in messages) > caps.max_snapshot_bytes:
+                raise HistoryError("malformed_response")
+            return cls(
+                session_id(data["conversation_id"]),
+                session_id(data["session_id"]),
+                tuple(messages),
+                data["truncated"],
+            )
+        except (KeyError, HistoryError):
+            raise HistoryError("malformed_response") from None
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryReceipt:
+    event_id: str
+    origin_turn_id: str
+    conversation_id: str
+    session_id: str
+    message_ids: tuple[int, ...]
+    revision: int
+
+    @classmethod
+    def parse(
+        cls,
+        data: object,
+        *,
+        event_id: str,
+        origin_turn_id: str,
+        conversation_id: str,
+        message_count: int,
+    ) -> HistoryReceipt:
+        if not isinstance(data, dict):
+            raise HistoryError("malformed_response")
+        ids = data.get("message_ids")
+        if (
+            data.get("producer") != "passive.ingress.v1"
+            or data.get("event_id") != event_id
+            or data.get("origin_turn_id") != origin_turn_id
+            or data.get("conversation_id") != conversation_id
+            or type(data.get("revision")) is not int
+            or data["revision"] <= 0
+            or type(data.get("replayed")) is not bool
+            or not isinstance(ids, list)
+            or len(ids) != message_count
+            or any(type(value) is not int or value <= 0 for value in ids)
+            or len(set(ids)) != len(ids)
+        ):
+            raise HistoryError("malformed_response")
+        try:
+            segment = session_id(data.get("session_id"))
+        except HistoryError:
+            raise HistoryError("malformed_response") from None
+        return cls(event_id, origin_turn_id, conversation_id, segment, tuple(ids), data["revision"])
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryTransport:
+    """Operator-configured HTTP connection, including its fixed authentication scope.
+
+    ``profile`` must already be resolved by the host. ``named_profile`` selects
+    the gateway's /p/{profile} route; dashboard always sends its profile selector.
+    Credentials are captured once, so a queued event cannot drift with env changes.
+    OAuth adapters and surface wiring are outside this module's current contract.
+    """
+
+    base_url: str = field(repr=False)
+    profile: str
+    credential: str = field(repr=False)
+    surface: str = "gateway"
+    named_profile: bool = False
+    timeout_s: float = 3.0
+    _http_transport: httpx.BaseTransport | None = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self):
+        parsed = urlsplit(self.base_url)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+            or parsed.path not in {"", "/"}
+            or self.surface not in {"gateway", "dashboard"}
+            or (self.surface == "dashboard" and self.named_profile)
+            or not isinstance(self.credential, str)
+            or not self.credential.strip()
+            or any(ord(char) < 32 or ord(char) == 127 for char in self.credential)
+            or not math.isfinite(self.timeout_s)
+            or not 0 < self.timeout_s <= 30
+        ):
+            raise HistoryError("invalid_input")
+        identifier(self.profile)
+
+    @classmethod
+    def configured_gateway(cls, *, profile: str, named_profile: bool = False) -> HistoryTransport:
+        try:
+            from . import talk_config
+        except ImportError:  # pragma: no cover - flat Hermes plugin load
+            import talk_config
+        return cls(
+            talk_config.api_server_url(),
+            profile,
+            talk_config.api_server_key() or "",
+            named_profile=named_profile,
+        )
+
+    @property
+    def prefix(self) -> str:
+        if self.surface == "dashboard":
+            return "/api/passive-history"
+        return (f"/p/{self.profile}" if self.named_profile else "") + "/v1/passive-history"
+
+    def owner(self, selected_session: str) -> HistoryOwner:
+        return HistoryOwner(
+            digest([self.base_url.rstrip("/"), self.prefix]),
+            self.profile,
+            digest([self.surface, self.credential]),
+            session_id(selected_session),
+        )
+
+    def request(self, operation: str, body: dict | None = None) -> dict:
+        if operation not in OPERATIONS | {"capabilities"}:
+            raise HistoryError("unsupported")
+        header = "Authorization" if self.surface == "gateway" else "X-Hermes-Session-Token"
+        value = f"Bearer {self.credential}" if self.surface == "gateway" else self.credential
+        params = {"profile": self.profile} if self.surface == "dashboard" else None
+        try:
+            content = None if body is None else json.dumps(body, ensure_ascii=False).encode("utf-8")
+            if content is not None and len(content) > 160 * 1024:
+                raise HistoryError("payload_too_large")
+            with (
+                httpx.Client(
+                    timeout=self.timeout_s,
+                    follow_redirects=False,
+                    trust_env=False,
+                    transport=self._http_transport,
+                ) as client,
+                client.stream(
+                    "GET" if operation == "capabilities" else "POST",
+                    self.base_url.rstrip("/") + self.prefix + "/" + operation,
+                    headers={header: value, "Content-Type": "application/json"},
+                    params=params,
+                    content=content,
+                ) as response,
+            ):
+                raw = bytearray()
+                for chunk in response.iter_bytes(chunk_size=4096):
+                    if len(raw) + len(chunk) > MAX_RESPONSE_BYTES:
+                        raise HistoryError("malformed_response")
+                    raw.extend(chunk)
+                status = response.status_code
+            if status in {401, 403}:
+                raise HistoryError("unauthorized")
+            if operation == "capabilities" and status in {404, 405}:
+                raise HistoryError("unsupported")
+            data = json.loads(raw)
+            if not isinstance(data, dict):
+                raise HistoryError("malformed_response")
+            if status != 200:
+                code = data.get("error")
+                if not isinstance(code, str) or type(data.get("retryable")) is not bool:
+                    raise HistoryError("malformed_response")
+                raise HistoryError(code, retryable=data["retryable"])
+            return data
+        except (httpx.HTTPError, OSError):
+            raise HistoryError("unavailable", retryable=True) from None
+        except (ValueError, TypeError, UnicodeError):
+            raise HistoryError("malformed_response") from None

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -1,0 +1,704 @@
+"""Real HTTP fixture for passive-history v1 (host contract 813d255).
+
+The fixture uses the public wire envelopes and independently checks exact request
+fields, attachment/principal scope, busy admission, event receipts and retirement.
+It has no execution route. No provider, microphone or installed host is contacted.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError, replace
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+
+from talk_attachment import TalkAttachment
+from talk_outbox import HistoryOutbox
+from talk_passive import HistoryError, HistoryMessage, HistoryTransport
+
+CAPS = {
+    "version": 1,
+    "passive_only": True,
+    "origin_adoption": False,
+    "operations": ["attach", "snapshot", "commit", "reconcile", "detach"],
+    "max_request_bytes": 163840,
+    "max_message_bytes": 65536,
+    "max_messages": 2,
+    "max_snapshot_messages": 20,
+    "max_snapshot_bytes": 32768,
+    "restart_requires_reattach": True,
+}
+ATTACHMENT_KEYS = {"tab_id", "attachment_id", "generation", "session_id"}
+BODY_KEYS = {
+    "attach": {"tab_id", "session_id"},
+    "snapshot": ATTACHMENT_KEYS,
+    "commit": ATTACHMENT_KEYS | {"event_id", "origin_turn_id", "messages"},
+    "reconcile": {"session_id", "event_id"},
+    "detach": ATTACHMENT_KEYS,
+}
+
+
+class FrozenHost:
+    def __init__(self):
+        self.caps = dict(CAPS)
+        self.calls = []
+        self.rows = [{"id": 1, "role": "user", "content": "Earlier typed message"}]
+        self.attachments = {}
+        self.receipts = {}
+        self.saved_bodies = {}
+        self.generation = 0
+        self.busy = False
+        self.deleted = False
+        self.retired = False
+        self.lose_commit = False
+        self.override = {}
+        self.before = None
+        self.url = ""
+
+    def error(self, code, status=409, retryable=False):
+        return status, {"error": code, "retryable": retryable}
+
+    def dispatch(self, operation, body, principal, profile):
+        self.calls.append((operation, body, profile))
+        if self.before:
+            self.before(operation)
+        if operation in self.override:
+            return self.override[operation]
+        if operation == "capabilities":
+            return 200, self.caps
+        assert set(body) == BODY_KEYS[operation]
+        if self.deleted:
+            return self.error("target_missing", 404)
+        if body["session_id"] not in {"selected", "other"}:
+            return self.error("target_missing", 404)
+        scope = (principal, profile, body.get("tab_id"))
+        if operation == "attach":
+            self.generation += 1
+            authority = {
+                "tab_id": body["tab_id"],
+                "session_id": body["session_id"],
+                "attachment_id": f"attachment-{self.generation}",
+                "generation": self.generation,
+            }
+            self.attachments[scope] = authority
+            return 200, {"profile": profile, **authority, "snapshot": self.snapshot()}
+        if operation == "reconcile":
+            event = body["event_id"]
+            if event in self.receipts and self.retired:
+                return self.error("retired", 410)
+            receipt = self.receipts.get(event)
+            if receipt and self.saved_bodies[event]["session_id"] != body["session_id"]:
+                return self.error("event_conflict")
+            return 200, {
+                "profile": profile,
+                "status": "saved" if receipt else "unknown",
+                "receipt": receipt,
+            }
+        if self.attachments.get(scope) != {key: body[key] for key in ATTACHMENT_KEYS}:
+            return self.error("stale_attachment")
+        if operation == "snapshot":
+            return 200, {"profile": profile, **self.snapshot()}
+        if operation == "detach":
+            del self.attachments[scope]
+            return 200, {"status": "detached"}
+        assert operation == "commit", "zero execution: no other route exists"
+        if self.busy:
+            return self.error("busy", retryable=True)
+        rows = body["messages"]
+        assert 1 <= len(rows) <= 2
+        assert all(set(row) == {"role", "content"} for row in rows)
+        assert all(row["role"] in {"user", "assistant"} and row["content"].strip() for row in rows)
+        event = body["event_id"]
+        if event in self.receipts:
+            prior = self.saved_bodies[event]
+            if any(prior[key] != body[key] for key in ("origin_turn_id", "messages", "session_id")):
+                return self.error("event_conflict")
+            receipt = {**self.receipts[event], "replayed": True}
+            return 200, {"profile": profile, "status": "already_saved", "receipt": receipt}
+        ids = []
+        for row in rows:
+            ids.append(len(self.rows) + 1)
+            self.rows.append({"id": ids[-1], **row})
+        receipt = {
+            "producer": "passive.ingress.v1",
+            "event_id": event,
+            "origin_turn_id": body["origin_turn_id"],
+            "conversation_id": "root",
+            "session_id": "compressed-tip",
+            "message_ids": ids,
+            "revision": len(self.receipts) + 1,
+            "replayed": False,
+        }
+        self.receipts[event], self.saved_bodies[event] = receipt, body
+        if self.lose_commit:
+            self.lose_commit = False
+            return None, None
+        return 200, {"profile": profile, "status": "saved", "receipt": receipt}
+
+    def snapshot(self):
+        return {
+            "conversation_id": "root",
+            "session_id": "compressed-tip",
+            "messages": list(self.rows),
+            "truncated": False,
+            "capabilities": self.caps,
+        }
+
+
+@pytest.fixture
+def host():
+    state = FrozenHost()
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def do_GET(self):
+            self.handle_call()
+
+        def do_POST(self):
+            self.handle_call()
+
+        def handle_call(self):
+            parsed = urlsplit(self.path)
+            operation = parsed.path.rsplit("/", 1)[-1]
+            assert operation in {*BODY_KEYS, "capabilities"}
+            assert parsed.path in {
+                f"/v1/passive-history/{operation}",
+                f"/p/work/v1/passive-history/{operation}",
+                f"/api/passive-history/{operation}",
+            }
+            principal = self.headers.get("Authorization") or self.headers.get(
+                "X-Hermes-Session-Token"
+            )
+            assert principal in {"Bearer secret-key", "Bearer second-key", "secret-key"}
+            profile = "work" if parsed.path.startswith("/p/work/") else "default"
+            profile = parse_qs(parsed.query).get("profile", [profile])[0]
+            body = None
+            if self.command == "POST":
+                size = int(self.headers["Content-Length"])
+                assert size <= CAPS["max_request_bytes"]
+                body = json.loads(self.rfile.read(size))
+            status, result = state.dispatch(operation, body, principal, profile)
+            if status is None:
+                self.connection.shutdown(socket.SHUT_RDWR)
+                self.connection.close()
+                return
+            raw = json.dumps(result).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    state.url = f"http://127.0.0.1:{server.server_port}"
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield state
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def client(host, tmp_path, *, selected="selected", tab="tab-one", **transport_options):
+    profile = transport_options.pop("profile", "default")
+    transport = HistoryTransport(host.url, profile, "secret-key", **transport_options)
+    box = HistoryOutbox(tmp_path, profile=profile)
+    return TalkAttachment(transport, box, selected_session=selected, connection_id=tab), box
+
+
+def queued(attachment, *, text="Final ordinary dialogue", event_id="event-one"):
+    token = attachment.capture_token
+    event = attachment.enqueue(
+        token,
+        (HistoryMessage("user", text),),
+        origin_turn_id="origin-one",
+        finalized=True,
+        disposition="dialogue",
+        event_id=event_id,
+    )
+    return event, token
+
+
+def test_snapshot_commit_readback_detach_and_no_execution(host, tmp_path):
+    attachment, box = client(host, tmp_path)
+    token = attachment.attach()
+    assert attachment.owner.session_id == "selected"
+    assert attachment.snapshot.session_id == "compressed-tip"
+    assert attachment.snapshot.messages[0].content == "Earlier typed message"
+    event, _ = queued(attachment)
+    result = attachment.flush(event, token)
+    assert result.state == "saved"
+    assert result.receipt.message_ids == (2,)
+    assert attachment.refresh_snapshot(token).messages[-1].content == "Final ordinary dialogue"
+    assert box.diagnostics()["pending_bytes"] == 0
+    attachment.close(token)
+    assert attachment.snapshot is None
+    with pytest.raises(HistoryError, match="stale_generation"):
+        attachment.enqueue(
+            token,
+            (HistoryMessage("user", "late"),),
+            origin_turn_id="late",
+            finalized=True,
+            disposition="dialogue",
+        )
+    assert {op for op, _, _ in host.calls} <= {*BODY_KEYS, "capabilities"}
+
+
+def test_response_loss_restart_reconcile_exactly_once(host, tmp_path):
+    attachment, box = client(host, tmp_path)
+    attachment.attach()
+    event, token = queued(attachment)
+    host.lose_commit = True
+    assert attachment.flush(event, token).state == "pending"
+    assert len(host.rows) == 2
+    # Both local process and host attachment epoch disappear; receipts survive.
+    host.attachments.clear()
+    restarted, _ = client(host, tmp_path)
+    new_token = restarted.attach()
+    assert restarted.flush(event, new_token).state == "saved"
+    assert len(host.rows) == 2
+    assert [op for op, _, _ in host.calls].count("commit") == 1
+    assert [op for op, _, _ in host.calls][-3:] == ["capabilities", "reconcile", "attach"]
+    assert box.get(restarted.owner, event).messages == ()
+
+
+def test_busy_retry_unknown_reattaches_original_identity(host, tmp_path):
+    attachment, box = client(host, tmp_path)
+    attachment.attach()
+    event, token = queued(attachment)
+    host.busy = True
+    assert attachment.flush(event, token).code == "busy"
+    first = next(body for op, body, _ in host.calls if op == "commit")
+    host.busy = False
+    assert attachment.flush(event, token).state == "saved"
+    ops = [op for op, _, _ in host.calls]
+    assert ops[-3:] == ["reconcile", "attach", "commit"]
+    last = host.saved_bodies[event]
+    for key in ("event_id", "origin_turn_id", "session_id", "messages", "tab_id"):
+        assert first[key] == last[key]
+    assert last["attachment_id"] != first["attachment_id"]
+    assert attachment.capture_token.generation > token.generation
+    assert box.get(attachment.owner, event).attempts == 2
+
+
+def test_new_selection_cannot_retarget_pending_event(host, tmp_path):
+    old, box = client(host, tmp_path)
+    token = old.attach()
+    event, _ = queued(old)
+    newer, _ = client(host, tmp_path, selected="other")
+    new_token = newer.attach()
+    before = len(host.calls)
+    with pytest.raises(HistoryError, match="owner_mismatch"):
+        newer.flush(event, new_token)
+    with pytest.raises(HistoryError, match="stale_generation"):
+        old.flush(event, token)
+    assert len(host.calls) == before
+    assert box.pending(old.owner) == (event,)
+    recovered_token = old.attach()
+    assert old.flush(event, recovered_token).state == "saved"
+    assert host.saved_bodies[event]["session_id"] == "selected"
+
+
+def test_late_attach_response_cannot_replace_newer_generation(host, tmp_path):
+    old, _ = client(host, tmp_path)
+    newer, _ = client(host, tmp_path)
+    entered, release = threading.Event(), threading.Event()
+    first = True
+
+    def delay(operation):
+        nonlocal first
+        if operation == "attach" and first:
+            first = False
+            entered.set()
+            assert release.wait(5)
+
+    host.before = delay
+    with ThreadPoolExecutor() as pool:
+        future = pool.submit(old.attach)
+        assert entered.wait(5)
+        token = newer.attach()
+        release.set()
+        with pytest.raises(HistoryError, match="stale_generation"):
+            future.result(timeout=5)
+    with pytest.raises(HistoryError, match="stale_generation"):
+        _ = old.snapshot
+    # A late host attach can invalidate the newer remote lease. It must refuse,
+    # never apply old context; reconnect explicitly obtains current authority.
+    with pytest.raises(HistoryError, match="stale_attachment"):
+        newer.refresh_snapshot(token)
+    assert newer.snapshot is None
+    assert newer.attach() != token
+
+
+@pytest.mark.parametrize(
+    "surface,profile,named",
+    [
+        ("gateway", "default", False),
+        ("gateway", "work", True),
+        ("dashboard", "work", False),
+    ],
+)
+def test_fixed_profile_transport_routes(host, tmp_path, surface, profile, named):
+    attachment, _ = client(host, tmp_path, surface=surface, profile=profile, named_profile=named)
+    attachment.attach()
+    event, token = queued(attachment)
+    assert attachment.flush(event, token).state == "saved"
+    assert {scope for _, _, scope in host.calls} == {profile}
+
+
+def test_credential_and_profile_ownership_are_immutable(host, tmp_path):
+    attachment, box = client(host, tmp_path)
+    attachment.attach()
+    event, _ = queued(attachment)
+    transport = HistoryTransport(host.url, "default", "second-key")
+    foreign = TalkAttachment(transport, box, selected_session="selected")
+    token = foreign.attach()
+    before = len(host.calls)
+    with pytest.raises(HistoryError, match="owner_mismatch"):
+        foreign.flush(event, token)
+    assert len(host.calls) == before
+    with pytest.raises(FrozenInstanceError):
+        transport.credential = "mutated"
+    with pytest.raises(FrozenInstanceError):
+        attachment.owner.session_id = "other"
+    with pytest.raises(HistoryError, match="owner_mismatch"):
+        HistoryOutbox(tmp_path, profile="other")
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"version": 2},
+        {"version": True},
+        {"passive_only": False},
+        {"operations": ["attach"]},
+        {"max_snapshot_bytes": 999999},
+        {"origin_adoption": None},
+    ],
+)
+def test_missing_or_incompatible_capability_never_attaches(host, tmp_path, mutation):
+    host.caps.update(mutation)
+    attachment, _ = client(host, tmp_path)
+    with pytest.raises(HistoryError, match="unsupported"):
+        attachment.attach()
+    assert [op for op, _, _ in host.calls] == ["capabilities"]
+
+
+def test_additive_host_capabilities_do_not_enable_execution(host, tmp_path):
+    host.caps = {
+        **CAPS,
+        "origin_adoption": True,
+        "origin_adoption_sources": ["api_runs"],
+        "operations": [*CAPS["operations"], "adopt"],
+    }
+    attachment, _ = client(host, tmp_path)
+    token = attachment.attach()
+    with pytest.raises(HistoryError, match="not_passive"):
+        attachment.enqueue(
+            token,
+            (HistoryMessage("user", "Do work"),),
+            origin_turn_id="work",
+            finalized=True,
+            disposition="execution",
+        )
+    assert [op for op, _, _ in host.calls] == ["capabilities", "attach"]
+
+
+@pytest.mark.parametrize(
+    "finalized,disposition,role",
+    [
+        (False, "dialogue", "user"),
+        (True, "fragment", "user"),
+        (True, "tool_result", "assistant"),
+        (True, "execution", "user"),
+        (True, "steering", "user"),
+        (True, "dialogue", "tool"),
+    ],
+)
+def test_nonpassive_input_never_enters_outbox_or_http(host, tmp_path, finalized, disposition, role):
+    attachment, box = client(host, tmp_path)
+    token = attachment.attach()
+    before = len(host.calls)
+    with pytest.raises(HistoryError, match="not_passive"):
+        attachment.enqueue(
+            token,
+            (HistoryMessage(role, "private text"),),
+            origin_turn_id="origin",
+            finalized=finalized,
+            disposition=disposition,
+        )
+    assert box.diagnostics()["states"]["pending"] == 0
+    assert len(host.calls) == before
+
+
+@pytest.mark.parametrize(
+    "code,status", [("target_missing", 404), ("retired", 410), ("target_unavailable", 409)]
+)
+def test_deletion_retirement_clear_derived_references(host, tmp_path, code, status):
+    attachment, box = client(host, tmp_path)
+    token = attachment.attach()
+    event, _ = queued(attachment, text="erased-utterance-123")
+    host.override["commit"] = host.error(code, status)
+    result = attachment.flush(event, token)
+    assert (result.state, result.code) == ("failed", code)
+    assert attachment.snapshot is None
+    assert box.diagnostics()["pending_bytes"] == 0
+    with pytest.raises(HistoryError, match=code):
+        box.get(attachment.owner, event)
+    raw = (tmp_path / "state" / "talk-history-outbox.sqlite3").read_bytes()
+    assert b"erased-utterance-123" not in raw
+    assert b'"session_id": "selected"' not in raw
+
+
+def test_message_retirement_after_lost_response_cannot_reinsert(host, tmp_path):
+    attachment, box = client(host, tmp_path)
+    token = attachment.attach()
+    event, _ = queued(attachment)
+    host.lose_commit = True
+    attachment.flush(event, token)
+    host.retired = True
+    assert attachment.flush(event, token).code == "retired"
+    assert len([op for op, _, _ in host.calls if op == "commit"]) == 1
+    assert box.diagnostics()["pending_bytes"] == 0
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"status": "saved", "profile": "default", "receipt": {}},
+        {"status": "saved", "profile": "other", "receipt": {}},
+        {"secret-key": "private text"},
+        [],
+    ],
+)
+def test_malformed_commit_response_stays_reconcilable_and_redacted(host, tmp_path, response):
+    attachment, box = client(host, tmp_path)
+    token = attachment.attach()
+    event, _ = queued(attachment, text="private text")
+    host.override["commit"] = (200, response)
+    result = attachment.flush(event, token)
+    assert (result.state, result.code) == ("pending", "malformed_response")
+    assert attachment.snapshot is None
+    assert box.pending(attachment.owner) == (event,)
+    diag = json.dumps(attachment.diagnostics()) + repr(result)
+    assert all(
+        secret not in diag for secret in ("secret-key", "private text", str(tmp_path), host.url)
+    )
+
+
+def test_malformed_snapshot_and_missing_host_fail_closed(host, tmp_path):
+    attachment, _ = client(host, tmp_path)
+    host.override["capabilities"] = (404, {"error": "missing secret-key"})
+    with pytest.raises(HistoryError, match="unsupported"):
+        attachment.attach()
+    host.override.clear()
+    token = attachment.attach()
+    malformed = {
+        **host.snapshot(),
+        "profile": "default",
+        "messages": [{"id": True, "role": "system", "content": "private text"}],
+    }
+    host.override["snapshot"] = (200, malformed)
+    with pytest.raises(HistoryError, match="malformed_response"):
+        attachment.refresh_snapshot(token)
+    assert attachment.snapshot is None
+
+
+def test_network_failure_and_untrusted_error_text_are_safe():
+    def fail(request):
+        raise httpx.ConnectError("credential=secret-key /private/path", request=request)
+
+    transport = HistoryTransport(
+        "http://127.0.0.1:1", "default", "secret-key", _http_transport=httpx.MockTransport(fail)
+    )
+    with pytest.raises(HistoryError, match=r"^unavailable$") as error:
+        transport.request("capabilities")
+    assert error.value.retryable
+    bad = replace(
+        transport,
+        _http_transport=httpx.MockTransport(
+            lambda _: httpx.Response(
+                409, json={"error": "credential=secret-key /private/path", "retryable": True}
+            )
+        ),
+    )
+    with pytest.raises(HistoryError, match=r"^malformed_response$"):
+        bad.request("commit", {})
+
+
+def test_outbox_count_bytes_ttl_and_generation_survive_reopen(host, tmp_path):
+    now = [1000.0]
+    transport = HistoryTransport(host.url, "default", "secret-key")
+    box = HistoryOutbox(
+        tmp_path, profile="default", max_events=1, max_bytes=100, ttl_s=10, clock=lambda: now[0]
+    )
+    attachment = TalkAttachment(transport, box, selected_session="selected")
+    token = attachment.attach()
+    event, _ = queued(attachment, text="short")
+    with pytest.raises(HistoryError, match="outbox_full"):
+        queued(attachment, event_id="second")
+    now[0] += 11
+    with pytest.raises(HistoryError, match="expired"):
+        box.get(attachment.owner, event)
+    assert b"short" not in (tmp_path / "state" / "talk-history-outbox.sqlite3").read_bytes()
+    assert box.diagnostics()["states"]["failed"] == 1
+    assert box.diagnostics()["pending_bytes"] == 0
+    with pytest.raises(HistoryError, match="expired"):
+        box.get(attachment.owner, event)
+    # Pruned connection rows cannot recycle a generation and revive an old callback.
+    fresh = attachment.attach()
+    assert fresh.generation > token.generation
+    with pytest.raises(HistoryError, match="stale_generation"):
+        attachment.flush(event, token)
+    with pytest.raises(HistoryError, match="outbox_full"):
+        queued(attachment, text="x" * 101, event_id="too-large")
+    queued(attachment, text="fits", event_id="new")
+    reopened = HistoryOutbox(tmp_path, profile="default", clock=lambda: now[0])
+    assert reopened.pending(attachment.owner) == ("new",)
+
+
+def test_event_identity_cannot_be_reused_with_new_payload(host, tmp_path):
+    attachment, box = client(host, tmp_path)
+    attachment.attach()
+    event, _ = queued(attachment)
+    assert queued(attachment)[0] == event
+    with pytest.raises(HistoryError, match="event_conflict"):
+        queued(attachment, text="changed")
+    assert box.diagnostics()["states"]["pending"] == 1
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user:secret@example.com",
+        "https://example.com/?credential=secret",
+        "https://example.com/#fragment",
+        "file:///private/path",
+        "https://example.com/chat",
+    ],
+)
+def test_arbitrary_endpoints_are_not_accepted(url):
+    with pytest.raises(HistoryError, match="invalid_input"):
+        HistoryTransport(url, "default", "secret-key")
+
+
+def test_no_arbitrary_operation_or_redirects():
+    calls = []
+
+    def respond(request):
+        calls.append(str(request.url))
+        return httpx.Response(302, headers={"Location": "https://external.invalid/steal"}, json={})
+
+    transport = HistoryTransport(
+        "https://configured.invalid",
+        "default",
+        "secret-key",
+        _http_transport=httpx.MockTransport(respond),
+    )
+    with pytest.raises(HistoryError, match="unsupported"):
+        transport.request("../../chat", {})
+    assert not calls
+    with pytest.raises(HistoryError, match="malformed_response"):
+        transport.request("capabilities")
+    assert calls == ["https://configured.invalid/v1/passive-history/capabilities"]
+
+
+def test_oversized_response_and_auth_failure_are_bounded():
+    for status, body, expected in [
+        (200, "x" * 300000, "malformed_response"),
+        (401, "secret-key private text", "unauthorized"),
+    ]:
+        transport = HistoryTransport(
+            "https://configured.invalid",
+            "default",
+            "secret-key",
+            _http_transport=httpx.MockTransport(
+                lambda request, status=status, body=body: httpx.Response(status, text=body)
+            ),
+        )
+        with pytest.raises(HistoryError, match=expected):
+            transport.request("capabilities")
+
+
+def test_late_commit_response_remains_pending_for_new_generation(host, tmp_path):
+    old, box = client(host, tmp_path)
+    token = old.attach()
+    event, _ = queued(old)
+    entered, release = threading.Event(), threading.Event()
+
+    def delay(operation):
+        if operation == "commit":
+            entered.set()
+            assert release.wait(5)
+
+    host.before = delay
+    with ThreadPoolExecutor() as pool:
+        future = pool.submit(old.flush, event, token)
+        assert entered.wait(5)
+        # Another process revokes this callback while the HTTP request is in flight.
+        box.begin(old.owner, token.connection_id)
+        release.set()
+        with pytest.raises(HistoryError, match="stale_generation"):
+            future.result(timeout=5)
+    assert box.pending(old.owner) == (event,)
+    fresh = old.attach()
+    assert old.flush(event, fresh).state == "saved"
+    assert len(host.rows) == 2
+
+
+def test_corrupt_outbox_never_submits_modified_payload(host, tmp_path):
+    attachment, _ = client(host, tmp_path)
+    token = attachment.attach()
+    event, _ = queued(attachment)
+    before = len(host.calls)
+    with sqlite3.connect(tmp_path / "state" / "talk-history-outbox.sqlite3") as db:
+        db.execute(
+            "UPDATE events SET messages=? WHERE event_id=?",
+            (json.dumps([{"role": "user", "content": "corrupted"}]), event),
+        )
+    with pytest.raises(HistoryError, match="outbox_unavailable"):
+        attachment.flush(event, token)
+    assert len(host.calls) == before
+    with pytest.raises(HistoryError, match="outbox_unavailable"):
+        HistoryOutbox(tmp_path / "state" / "talk-history-outbox.sqlite3", profile="default")
+
+
+def test_capacity_serializes_independent_connections(host, tmp_path):
+    transport = HistoryTransport(host.url, "default", "secret-key")
+    one = HistoryOutbox(tmp_path, profile="default", max_events=1)
+    two = HistoryOutbox(tmp_path, profile="default", max_events=1)
+    clients = [TalkAttachment(transport, box, selected_session="selected") for box in (one, two)]
+    for attachment in clients:
+        attachment.attach()
+
+    def admit(index):
+        try:
+            queued(clients[index], event_id=f"event-{index}")
+            return "pending"
+        except HistoryError as exc:
+            return exc.code
+
+    with ThreadPoolExecutor() as pool:
+        assert sorted(pool.map(admit, range(2))) == ["outbox_full", "pending"]
+    assert one.diagnostics()["states"]["pending"] == 1
+
+
+def test_host_conflict_is_terminal_and_scrubs_text(host, tmp_path):
+    attachment, box = client(host, tmp_path)
+    token = attachment.attach()
+    event, _ = queued(attachment)
+    host.override["commit"] = host.error("event_conflict")
+    result = attachment.flush(event, token)
+    assert (result.state, result.code) == ("conflicted", "event_conflict")
+    assert box.diagnostics()["pending_bytes"] == 0

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -702,3 +702,108 @@ def test_host_conflict_is_terminal_and_scrubs_text(host, tmp_path):
     result = attachment.flush(event, token)
     assert (result.state, result.code) == ("conflicted", "event_conflict")
     assert box.diagnostics()["pending_bytes"] == 0
+
+
+@pytest.mark.parametrize("during_reconnect", [False, True])
+def test_retired_event_preserves_unrelated_pending_dialogue(host, tmp_path, during_reconnect):
+    attachment, box = client(host, tmp_path)
+    token = attachment.attach()
+    event_a, _ = queued(attachment, event_id="event-a", text="retired A")
+    host.lose_commit = True
+    assert attachment.flush(event_a, token).state == "pending"
+    event_b, _ = queued(attachment, event_id="event-b", text="unsaved B")
+    host.retired = True
+    if during_reconnect:
+        token = attachment.attach()
+    else:
+        assert attachment.flush(event_a, token).code == "retired"
+        assert attachment.snapshot is None
+    assert box.pending(attachment.owner) == (event_b,)
+    assert box.get(attachment.owner, event_b).messages[0].content == "unsaved B"
+    assert attachment.flush(event_b, attachment.attach()).state == "saved"
+    assert [row["content"] for row in host.rows].count("unsaved B") == 1
+
+
+def test_retry_reattach_cas_cannot_reclaim_newer_connection(host, tmp_path, monkeypatch):
+    old, box = client(host, tmp_path)
+    token = old.attach()
+    event, _ = queued(old)
+    host.busy = True
+    assert old.flush(event, token).code == "busy"
+    host.busy = False
+    entered, release = threading.Event(), threading.Event()
+    begin = box.begin
+
+    def delayed_begin(*args, **kwargs):
+        entered.set()
+        assert release.wait(5)
+        return begin(*args, **kwargs)
+
+    monkeypatch.setattr(box, "begin", delayed_begin)
+    with ThreadPoolExecutor() as pool:
+        future = pool.submit(old.flush, event, token)
+        assert entered.wait(5)
+        newer, _ = client(host, tmp_path)
+        fresh = newer.attach()
+        calls_before_release = len(host.calls)
+        release.set()
+        with pytest.raises(HistoryError, match="stale_generation"):
+            future.result(timeout=5)
+    assert len(host.calls) == calls_before_release
+    assert newer.refresh_snapshot(fresh).conversation_id == "root"
+    assert newer.flush(event, fresh).state == "saved"
+
+
+def test_callback_invalidation_cas_rejects_late_writer(host, tmp_path, monkeypatch):
+    old, box = client(host, tmp_path)
+    token = old.attach()
+    event, _ = queued(old)
+    host.override["commit"] = host.error("target_missing", 404)
+    entered, release = threading.Event(), threading.Event()
+    invalidate = box.invalidate
+
+    def delayed_invalidate(*args, **kwargs):
+        entered.set()
+        assert release.wait(5)
+        return invalidate(*args, **kwargs)
+
+    monkeypatch.setattr(box, "invalidate", delayed_invalidate)
+    with ThreadPoolExecutor() as pool:
+        future = pool.submit(old.flush, event, token)
+        assert entered.wait(5)
+        newer, _ = client(host, tmp_path)
+        fresh = newer.attach()
+        release.set()
+        with pytest.raises(HistoryError, match="stale_generation"):
+            future.result(timeout=5)
+    assert box.pending(newer.owner) == (event,)
+    assert newer.refresh_snapshot(fresh).conversation_id == "root"
+    host.override.clear()
+    assert newer.flush(event, fresh).state == "saved"
+
+
+@pytest.mark.parametrize("code,status", [("retired", 410), ("target_missing", 404)])
+def test_stale_terminal_error_cannot_invalidate_new_generation(host, tmp_path, code, status):
+    old, box = client(host, tmp_path)
+    token = old.attach()
+    event_a, _ = queued(old)
+    entered, release = threading.Event(), threading.Event()
+
+    def delay(operation):
+        if operation == "commit":
+            entered.set()
+            assert release.wait(5)
+
+    host.before = delay
+    host.override["commit"] = host.error(code, status)
+    with ThreadPoolExecutor() as pool:
+        future = pool.submit(old.flush, event_a, token)
+        assert entered.wait(5)
+        newer, _ = client(host, tmp_path)
+        fresh = newer.attach()
+        event_b, _ = queued(newer, event_id="event-b", text="new generation B")
+        release.set()
+        with pytest.raises(HistoryError, match="stale_generation"):
+            future.result(timeout=5)
+    assert box.pending(newer.owner) == (event_a, event_b)
+    assert newer.refresh_snapshot(fresh).conversation_id == "root"


### PR DESCRIPTION
Add a shared Python client for attaching to existing Hermes conversations and recovering passive transcript writes after response loss. Fixed authenticated routes, immutable task ownership, generation checks and a bounded durable outbox keep retries tied to their original task. Unsupported hosts fail explicitly and the client never starts an agent turn.

This is the shared library foundation for [task-attached voice](https://github.com/TheSmokeDev/hermes-talk/issues/41), consuming the version-1 host contract in [the host draft](https://github.com/TheSmokeDev/hermes-agent/pull/5). Dashboard, terminal and Discord integration remain pending, as do OAuth transport and execution-origin/child dispatch. Callers must classify the complete interaction before enqueueing ordinary dialogue; final text alone is insufficient.

Validation: 91 focused tests (45 client/HTTP-fixture cases and 46 existing configuration cases), changed-file Ruff and diff checks. Wheel and sdist build successfully; all 38 declared modules are present and the three new modules import from the wheel. The HTTP fixture matches the pinned host schema; it is not a live installed-host acceptance receipt. No version bump, live-provider test or release.

After independent review, event retirement preserves unrelated pending dialogue and reconnect/error mutations use transactional generation checks. The affected lifecycle checks and six final correction cases pass, followed by a clean actual-host HTTP recheck with exactly one saved transcript row and zero execution. The same independent reviewer passed the correction delta.
