### PR TITLE
fix(worker): remove the peer.json race and bound the wedged-peer CI hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
   test:
     # No secrets, no network: the suite runs against scripted Realtime
     # transcripts and a stub plugin context, and never opens an audio device.
+    #
+    # A healthy job finishes in ~3 minutes (Windows), so 15 is ~5x headroom.
+    # Without a ceiling a wedged test holds the runner for GitHub's 6-hour
+    # default, which reads as "still running" long after it has failed.
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/talk_codex_worker.py
+++ b/talk_codex_worker.py
@@ -73,6 +73,8 @@ class CodexWorkerConfig:
 
 class CodexWorker:
     CANCEL_TIMEOUT_S = 10.0
+    #: A live peer keeps streaming; this much silence means it is wedged.
+    PROGRESS_TIMEOUT_S = 300.0
 
     def __init__(
         self,
@@ -492,18 +494,22 @@ class CodexWorker:
                 )
                 self._turn(response.get("turn"))
             renewed = time.monotonic()
+            progress = time.monotonic()
             cancel_sent = False
             cancel_deadline = None
             while self.snapshot()["state"] not in TERMINAL:
                 message = self.wire.event()
                 if message is not None:
                     self._event(message)
+                    progress = time.monotonic()
                 if self.cancel_event.is_set() and not cancel_sent:
                     cancel_deadline = time.monotonic() + self.CANCEL_TIMEOUT_S
                     self.control("cancel-" + self.job_id, cancel=True)
                     cancel_sent = True
                 if cancel_deadline is not None and time.monotonic() >= cancel_deadline:
                     raise CodexWorkerError("cancellation_unconfirmed")
+                if time.monotonic() - progress >= self.PROGRESS_TIMEOUT_S:
+                    raise CodexWorkerError("outcome_unknown")
                 if time.monotonic() - renewed >= 5:
                     self._update()
                     renewed = time.monotonic()

--- a/tests/fixtures/codex_app_server.py
+++ b/tests/fixtures/codex_app_server.py
@@ -10,23 +10,33 @@ if "--version" in sys.argv:
     print("codex-cli " + os.environ.get("FAKE_CODEX_VERSION", "0.154.0"))
     raise SystemExit
 
-path = Path(sys.argv[1])
+base = Path(sys.argv[1])
 scenario = sys.argv[2]
-state = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {"requests": []}
+folder, prefix = base.parent, base.stem
+
+
+def snapshots():
+    return sorted(folder.glob(f"{prefix}-*.json"))
+
+
+def latest():
+    found = snapshots()
+    return found[-1] if found else None
+
+
+prior = latest()
+state = json.loads(prior.read_text(encoding="utf-8")) if prior else {"requests": []}
 state["processes"] = state.get("processes", 0) + 1
+sequence = (int(prior.stem.rsplit("-", 1)[1]) + 1) if prior else 1
 
 
 def save():
-    temporary = path.with_suffix(".tmp")
-    temporary.write_text(json.dumps(state), encoding="utf-8")
-    for attempt in range(30):
-        try:
-            temporary.replace(path)
-            return
-        except PermissionError:
-            if attempt == 29:
-                raise
-            time.sleep(0.005)
+    # Fresh name per write: replacing one shared file raced the reader on Windows.
+    global sequence
+    staging = folder / f"{prefix}-{sequence:08d}.tmp"
+    staging.write_text(json.dumps(state), encoding="utf-8")
+    os.replace(staging, folder / f"{prefix}-{sequence:08d}.json")
+    sequence += 1
 
 
 def send(message):

--- a/tests/test_codex_host_integration.py
+++ b/tests/test_codex_host_integration.py
@@ -335,7 +335,9 @@ async def test_dashboard_to_real_host_to_scripted_codex_preserves_ownership(
                 assert result["truncated"] is False
                 rows = db.get_messages("same-session")
                 assert sum(row["content"] == original for row in rows) == 1
-                state = json.loads((tmp_path / "peer.json").read_text(encoding="utf-8"))
+                state = json.loads(
+                    sorted(tmp_path.glob("peer-*.json"))[-1].read_text(encoding="utf-8")
+                )
                 methods = [row.get("method") for row in state["requests"]]
                 assert methods.count("thread/start") == methods.count("turn/start") == 1
                 if scenario.startswith("lease_"):

--- a/tests/test_codex_worker.py
+++ b/tests/test_codex_worker.py
@@ -44,7 +44,11 @@ def setup(tmp_path, scenario="complete", *, enabled=True, jobs=None, context="Re
 
 
 def peer(tmp_path):
-    return json.loads((tmp_path / "peer.json").read_text(encoding="utf-8"))
+    return json.loads(sorted(tmp_path.glob("peer-*.json"))[-1].read_text(encoding="utf-8"))
+
+
+def peer_wrote_nothing(tmp_path):
+    return not list(tmp_path.glob("peer-*.json"))
 
 
 def wait_for(check):
@@ -59,7 +63,7 @@ def wait_for(check):
 def test_disabled_worker_starts_no_process_or_job(tmp_path):
     with pytest.raises(CodexWorkerError, match="worker_disabled"):
         setup(tmp_path, enabled=False)
-    assert not (tmp_path / "peer.json").exists()
+    assert peer_wrote_nothing(tmp_path)
     jobs = CodexJobs(HistoryOutbox(tmp_path, profile="default"))
     with jobs.outbox._db() as db:
         assert db.execute("SELECT count(*) FROM codex_jobs").fetchone()[0] == 0
@@ -113,7 +117,7 @@ def test_version_mismatch_starts_no_app_server(tmp_path, monkeypatch):
     monkeypatch.setenv("FAKE_CODEX_VERSION", "0.999.0")
     worker = setup(tmp_path)
     assert worker.run()["error"] == "unsupported_version"
-    assert not (tmp_path / "peer.json").exists()
+    assert peer_wrote_nothing(tmp_path)
 
 
 def test_exact_steering_and_cancellation_keep_original_thread_and_turn(tmp_path):
@@ -172,7 +176,7 @@ def test_foreign_owner_and_changed_original_request_are_refused(tmp_path):
             {**worker.request, "goal": "different"},
             worker.config,
         )
-    assert not (tmp_path / "peer.json").exists()
+    assert peer_wrote_nothing(tmp_path)
 
 
 def test_stalled_stdin_cannot_hold_worker_shutdown_forever(tmp_path):

--- a/tests/test_codex_worker.py
+++ b/tests/test_codex_worker.py
@@ -2,10 +2,12 @@
 
 import json
 import sys
+import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -58,6 +60,52 @@ def wait_for(check):
             return
         time.sleep(0.01)
     raise AssertionError("Scripted worker did not reach the expected state")
+
+
+class _Run:
+    """A worker.run() in flight, joined with a deadline instead of forever."""
+
+    def __init__(self, worker):
+        self._done = threading.Event()
+        self._value: Any = None
+        self._error: BaseException | None = None
+        self.thread = threading.Thread(target=self._call, args=(worker,), daemon=True)
+        self.thread.start()
+
+    def _call(self, worker):
+        try:
+            self._value = worker.run()
+        except BaseException as exc:  # noqa: BLE001 - re-raised by result()
+            self._error = exc
+        finally:
+            self._done.set()
+
+    def result(self, timeout=None) -> Any:
+        if not self._done.wait(timeout):
+            raise AssertionError("worker.run() never returned; the worker is wedged")
+        if self._error is not None:
+            raise self._error
+        return self._value
+
+
+@contextmanager
+def run_worker(worker):
+    """Run the worker off-thread and bound the join.
+
+    A plain executor context manager calls ``shutdown(wait=True)`` on exit, so
+    one wedged worker thread hangs the whole process forever — which on a slow
+    Windows runner is indistinguishable from a very long test. The thread here
+    is a daemon and the join is bounded, so a stuck worker fails the test
+    loudly and cannot hold interpreter exit open.
+    """
+
+    running = _Run(worker)
+    try:
+        yield running
+    finally:
+        if worker.wire is not None:
+            worker.wire.close()
+        assert running._done.wait(10), "worker.run() never returned; the worker is wedged"
 
 
 def test_disabled_worker_starts_no_process_or_job(tmp_path):
@@ -122,20 +170,16 @@ def test_version_mismatch_starts_no_app_server(tmp_path, monkeypatch):
 
 def test_exact_steering_and_cancellation_keep_original_thread_and_turn(tmp_path):
     worker = setup(tmp_path, "hold")
-    with ThreadPoolExecutor(max_workers=1) as pool:
-        running = pool.submit(worker.run)
-        try:
-            wait_for(lambda: worker.snapshot()["state"] == "running")
-            original = "  Keep the prefix.\n  Add this correction exactly.  "
-            receipt = worker.control("steer-one", text=original)
-            assert receipt["state"] == "queued"
-            assert worker.control("steer-one", text=original) == receipt
-            with pytest.raises(CodexWorkerError, match="event_conflict"):
-                worker.control("steer-one", text="changed")
-            assert worker.control("cancel-one", cancel=True)["state"] == "cancel_requested"
-            assert running.result(timeout=5)["state"] == "interrupted"
-        finally:
-            worker.wire.close()
+    with run_worker(worker) as running:
+        wait_for(lambda: worker.snapshot()["state"] == "running")
+        original = "  Keep the prefix.\n  Add this correction exactly.  "
+        receipt = worker.control("steer-one", text=original)
+        assert receipt["state"] == "queued"
+        assert worker.control("steer-one", text=original) == receipt
+        with pytest.raises(CodexWorkerError, match="event_conflict"):
+            worker.control("steer-one", text="changed")
+        assert worker.control("cancel-one", cancel=True)["state"] == "cancel_requested"
+        assert running.result(timeout=5)["state"] == "interrupted"
     steering = [row for row in peer(tmp_path)["requests"] if row.get("method") == "turn/steer"]
     assert len(steering) == 1 and steering[0]["params"]["input"][0]["text"] == original
     assert steering[0]["params"]["expectedTurnId"] == "turn-owned"
@@ -144,22 +188,18 @@ def test_exact_steering_and_cancellation_keep_original_thread_and_turn(tmp_path)
 
 def test_current_approval_once_and_replay_cannot_authorize_a_new_request(tmp_path):
     worker = setup(tmp_path, "approval_replay")
-    with ThreadPoolExecutor(max_workers=1) as pool:
-        running = pool.submit(worker.run)
-        try:
-            wait_for(lambda: bool(worker.approvals()))
-            current = worker.approvals()[0]
-            with pytest.raises(CodexWorkerError, match="approval_unavailable"):
-                worker.approve("foreign", "once")
-            assert worker.approve(current["request_id"], "once")["evidence"] == "transport_handoff"
-            wait_for(lambda: peer(tmp_path).get("approval_replies") == 1)
-            with pytest.raises(CodexWorkerError, match="approval_unavailable"):
-                worker.approve(current["request_id"], "once")
-            assert worker.approvals() == []
-            worker.control("stop-approved-job", cancel=True)
-            assert running.result(timeout=5)["state"] == "interrupted"
-        finally:
-            worker.wire.close()
+    with run_worker(worker) as running:
+        wait_for(lambda: bool(worker.approvals()))
+        current = worker.approvals()[0]
+        with pytest.raises(CodexWorkerError, match="approval_unavailable"):
+            worker.approve("foreign", "once")
+        assert worker.approve(current["request_id"], "once")["evidence"] == "transport_handoff"
+        wait_for(lambda: peer(tmp_path).get("approval_replies") == 1)
+        with pytest.raises(CodexWorkerError, match="approval_unavailable"):
+            worker.approve(current["request_id"], "once")
+        assert worker.approvals() == []
+        worker.control("stop-approved-job", cancel=True)
+        assert running.result(timeout=5)["state"] == "interrupted"
     assert peer(tmp_path)["approval_replies"] == 1
 
 
@@ -216,8 +256,7 @@ def test_malformed_configuration_is_a_fixed_refusal(tmp_path, field, value):
 def test_unconfirmed_cancellation_exits_with_partial_result_and_no_replacement(tmp_path, scenario):
     worker = setup(tmp_path, scenario)
     worker.CANCEL_TIMEOUT_S = 0.25
-    with ThreadPoolExecutor(max_workers=1) as pool:
-        running = pool.submit(worker.run)
+    with run_worker(worker) as running:
         wait_for(lambda: worker.snapshot()["output"] == "Partial work before stop")
         worker.cancel_event.set()
         result = running.result(timeout=8)


### PR DESCRIPTION
Two independent Windows-only CI problems in the codex path. Both are fixed at the root — no retries, no timing windows, no test-only band-aids.

## 1. The `peer.json` race (`fix(tests)`)

`test_current_approval_once_and_replay_cannot_authorize_a_new_request` (and the other `peer()` consumers) intermittently failed on **windows-latest** only:

```
PermissionError: [Errno 13] Permission denied: ...\test_current_approval_once_and0\peer.json
```

**Root cause.** The fixture and the test shared *one mutable file*. `save()` wrote a `.tmp` and called `os.replace()` onto `peer.json` while the test's `peer()` had that same path open for read. On POSIX you may replace an open file; on Windows an open handle blocks the replace, so whichever side ran second raised `PermissionError`. Retrying cannot remove that race, only hide it.

**Fix, by construction.** `save()` now writes each snapshot to its own never-reused name (`peer-00000001.json`, `peer-00000002.json`, …). A reader only ever opens a fully written file, and a writer never collides with a read in flight. The fixture loads the newest snapshot at startup, preserving the cross-restart accumulation (`processes`, `requests`, `approval_replies`) the tests assert on. `peer()` reads the newest snapshot; the three "no process started" checks become `peer_wrote_nothing()`.

## 2. A wedged peer could hang a job forever (`fix(worker)`)

While diagnosing the flake above, a **second, worse** problem surfaced: `windows-latest, 3.12` sat in the **Test** step for **51+ minutes** while its Windows siblings finished in ~4, and an earlier run reached **3445 minutes**. That is not a slow test — it is a hang, and nothing stopped it.

**Root cause.** `CodexWorker.run()`'s event loop had a *cancel* deadline but **no overall deadline**, so a live-but-silent app-server peer left it spinning indefinitely. The tests ran the worker inside `ThreadPoolExecutor`, whose exit path calls `shutdown(wait=True)` with no timeout — so one wedged worker thread held the entire pytest process open forever. Reproduced on Linux:

```
inside with-block, exiting now...
exit=124 (TIMED OUT => hung forever)
```

**Fix.**
- **Worker:** added `PROGRESS_TIMEOUT_S = 300.0`. If no state-changing event arrives within that window the turn fails closed with `outcome_unknown` — the existing code that already maps to state `unknown`. A silent peer now terminates instead of spinning.
- **Tests:** the three `with ThreadPoolExecutor(...)` blocks now use a `run_worker()` helper — a daemon thread with a bounded join — so a stuck worker fails the test loudly instead of hanging the process.
- **CI:** `timeout-minutes: 15` on the `test` job (healthy jobs are ~3–4 min, so ~5x headroom). Without a ceiling a wedge occupies a runner until GitHub's 6-hour default.

## Verification

- **CI green on `3b9568a`** — all 6 matrix jobs pass; Windows max **4.3 min** (ubuntu ~1.4 min, windows 3.4–4.3 min).
- **Both guards proven with real output:**
  - bounded join: infinite hang → `AssertionError` in 10.2s
  - progress deadline: silent peer → `state='unknown', error='outcome_unknown'` in 1.2s
- **No regressions:** full suite **1945 passed, 57 skipped, 5 xfailed, 12 failed**; the same 12 fail with these changes stashed (all pre-existing environment failures in `test_capabilities` / `test_dashboard_cascade`, none in the codex path).
- `ruff check .` → clean.

## Caveat

The **specific** test that hangs on Windows is still unidentified — the hang does not reproduce on Linux (suite completes in ~104s) and the live job's logs returned `BlobNotFound`. This fixes the proven *mechanism*, not a line observed hanging. If a wedge recurs, `PROGRESS_TIMEOUT_S` and the bounded join will now name the test instead of hiding it.

## Commits

- `8a083b3` — `fix(tests): remove the peer.json race instead of retrying it`
- `3b9568a` — `fix(worker): bound the no-progress wait so a wedged peer cannot hang CI`
